### PR TITLE
Add comprehensive AirPlay 1 (RAOP) documentation

### DIFF
--- a/docs/24-airplay1-overview.md
+++ b/docs/24-airplay1-overview.md
@@ -1,0 +1,303 @@
+# AirPlay 1 Support - Overview
+
+## Introduction
+
+This document provides an overview of adding AirPlay 1 (also known as AirTunes or RAOP - Remote Audio Output Protocol) support to the `airplay2-rs` library. AirPlay 1 is the original audio streaming protocol introduced by Apple, predating AirPlay 2's enhanced features.
+
+## Protocol Comparison
+
+### AirPlay 1 (RAOP) vs AirPlay 2
+
+| Feature | AirPlay 1 (RAOP) | AirPlay 2 |
+|---------|------------------|-----------|
+| Service Discovery | `_raop._tcp` | `_airplay._tcp` |
+| Primary Port | 49152 (varies) | 7000 |
+| Authentication | RSA challenge-response | HomeKit pairing (SRP-6a, Ed25519, X25519) |
+| Key Exchange | RSA-OAEP (1024-bit) | X25519 + HKDF |
+| Session Encryption | AES-128 (CTR mode) | ChaCha20-Poly1305 / AES-GCM |
+| Control Protocol | RTSP with SDP | RTSP with binary plist |
+| Audio Transport | RTP over UDP | RTP over UDP |
+| Multi-room | Not supported | Supported |
+| Buffered Audio | Not supported | Supported |
+| Time Sync | NTP-style timing | PTP / NTP |
+
+### Shared Components
+
+Both protocols share significant architectural similarities that can be leveraged:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Unified Public API                           │
+│                 AirPlayClient (extended)                        │
+└─────────────────────────────────┬───────────────────────────────┘
+                                  │
+         ┌────────────────────────┴────────────────────────┐
+         │                                                 │
+┌────────▼────────┐                               ┌────────▼────────┐
+│   AirPlay 2     │                               │   AirPlay 1     │
+│   Connection    │                               │   Connection    │
+│   (HomeKit)     │                               │   (RSA Auth)    │
+└────────┬────────┘                               └────────┬────────┘
+         │                                                 │
+         └────────────────────────┬────────────────────────┘
+                                  │
+┌─────────────────────────────────▼───────────────────────────────┐
+│                    Shared Protocol Layer                         │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌────────────────┐ │
+│  │  RTSP Protocol   │  │  RTP Protocol    │  │  Audio Codecs  │ │
+│  │  (Sans-IO)       │  │  (Sans-IO)       │  │  (ALAC, AAC)   │ │
+│  └──────────────────┘  └──────────────────┘  └────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## AirPlay 1 Protocol Stack
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Application Layer                            │
+│         Remote Control (DACP) │ Metadata (DAAP/DMAP)            │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+┌─────────────────────────────────────────────────────────────────┐
+│                      Session Layer                               │
+│                    RTSP over TCP                                 │
+│  OPTIONS → ANNOUNCE → SETUP → RECORD → SET_PARAMETER → TEARDOWN │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+┌─────────────────────────────────────────────────────────────────┐
+│                     Transport Layer                              │
+│  ┌────────────────┐  ┌───────────────┐  ┌───────────────────┐   │
+│  │  Audio Stream  │  │    Control    │  │     Timing        │   │
+│  │  (RTP/UDP)     │  │   (RTP/UDP)   │  │   (NTP/UDP)       │   │
+│  └────────────────┘  └───────────────┘  └───────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+┌─────────────────────────────────────────────────────────────────┐
+│                     Security Layer                               │
+│         RSA-OAEP Key Exchange │ AES-128-CTR Encryption          │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+┌─────────────────────────────────────────────────────────────────┐
+│                    Discovery Layer                               │
+│              mDNS/DNS-SD (_raop._tcp)                           │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Implementation Strategy
+
+### Phase 1: Core Protocol Extensions
+
+1. **RSA Authentication Module** (Section 02)
+   - RSA-1024/2048 key handling
+   - Challenge-response protocol
+   - OAEP encryption for key exchange
+
+2. **RAOP Service Discovery** (Section 01)
+   - Parse `_raop._tcp` TXT records
+   - Detect AirPlay 1 vs AirPlay 2 devices
+   - Extract audio capabilities (codecs, encryption types)
+
+3. **RTSP Extensions for RAOP** (Section 03)
+   - SDP body parsing/generation
+   - AirPlay 1-specific headers (`Apple-Challenge`, `Apple-Response`)
+   - Legacy session management
+
+### Phase 2: Audio Streaming
+
+4. **RTP Enhancements** (Section 04)
+   - Sync packet handling
+   - Timing protocol (NTP-style)
+   - Retransmission support
+
+5. **Audio Encryption** (Section 05)
+   - AES-128-CTR for audio payload
+   - RSA-OAEP key encapsulation
+   - IV management
+
+### Phase 3: Extended Features
+
+6. **Remote Control (DACP)** (Section 06)
+   - Playback commands
+   - Service advertisement
+
+7. **Metadata (DAAP/DMAP)** (Section 07)
+   - Track information
+   - Artwork delivery
+   - Progress updates
+
+### Phase 4: Integration
+
+8. **Unified Client API** (Section 08)
+   - Protocol auto-detection
+   - Shared abstractions
+   - Graceful fallback
+
+9. **Testing Infrastructure** (Section 09)
+   - Mock RAOP server
+   - Protocol compliance tests
+   - Real device testing
+
+## Section Dependencies
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                  Existing AirPlay 2 Foundation                   │
+│  Core Types │ Crypto │ RTSP │ RTP │ mDNS │ Audio │ Connection   │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+         ┌────────────────────┼────────────────────┐
+         │                    │                    │
+┌────────▼───────┐   ┌────────▼───────┐   ┌───────▼────────┐
+│ 01: RAOP       │   │ 02: RSA        │   │ 03: RTSP       │
+│ Discovery      │   │ Authentication │   │ Extensions     │
+└────────┬───────┘   └────────┬───────┘   └───────┬────────┘
+         │                    │                    │
+         └────────────────────┼────────────────────┘
+                              │
+         ┌────────────────────┼────────────────────┐
+         │                    │                    │
+┌────────▼───────┐   ┌────────▼───────┐   ┌───────▼────────┐
+│ 04: RTP        │   │ 05: Audio      │   │ 06: Remote     │
+│ Enhancements   │   │ Encryption     │   │ Control        │
+└────────┬───────┘   └────────┬───────┘   └───────┬────────┘
+         │                    │                    │
+         └────────────────────┼────────────────────┘
+                              │
+                     ┌────────▼───────┐
+                     │ 07: Metadata   │
+                     │ (DAAP/DMAP)    │
+                     └────────┬───────┘
+                              │
+         ┌────────────────────┼────────────────────┐
+         │                    │                    │
+┌────────▼───────┐                       ┌────────▼───────┐
+│ 08: Integration│                       │ 09: Testing    │
+│ Guide          │                       │ Strategy       │
+└────────────────┘                       └────────────────┘
+```
+
+## Code Reuse Analysis
+
+### Components to Extend
+
+| Existing Component | AirPlay 1 Extension Required |
+|--------------------|------------------------------|
+| `src/protocol/rtsp/` | Add SDP parsing, Apple headers |
+| `src/protocol/rtp/` | Add sync packets, timing protocol |
+| `src/protocol/crypto/` | Add RSA-OAEP module |
+| `src/discovery/` | Parse RAOP TXT records |
+| `src/audio/` | Shared (ALAC, AAC codecs) |
+| `src/connection/` | Add RAOP connection state machine |
+
+### New Components
+
+| New Component | Purpose |
+|---------------|---------|
+| `src/protocol/raop/` | RAOP-specific protocol logic |
+| `src/protocol/sdp/` | SDP parsing/generation |
+| `src/protocol/dacp/` | Remote control protocol |
+| `src/protocol/daap/` | Metadata protocol |
+
+## Design Principles
+
+### 1. Protocol Detection
+
+The library should automatically detect device capabilities:
+
+```rust
+pub enum DeviceProtocol {
+    /// AirPlay 2 with HomeKit pairing
+    AirPlay2,
+    /// AirPlay 1 with RSA authentication
+    AirPlay1,
+    /// Device supports both protocols
+    Both { prefer: PreferredProtocol },
+}
+
+pub struct AirPlayDevice {
+    // ... existing fields ...
+    pub protocol: DeviceProtocol,
+    pub raop_capabilities: Option<RaopCapabilities>,
+}
+```
+
+### 2. Unified Connection API
+
+```rust
+impl AirPlayClient {
+    /// Connect to device using appropriate protocol
+    pub async fn connect(&self, device: &AirPlayDevice) -> Result<(), AirPlayError> {
+        match device.protocol {
+            DeviceProtocol::AirPlay2 => self.connect_airplay2(device).await,
+            DeviceProtocol::AirPlay1 => self.connect_raop(device).await,
+            DeviceProtocol::Both { prefer } => {
+                match prefer {
+                    PreferredProtocol::AirPlay2 => self.connect_airplay2(device).await,
+                    PreferredProtocol::AirPlay1 => self.connect_raop(device).await,
+                }
+            }
+        }
+    }
+}
+```
+
+### 3. Shared Audio Pipeline
+
+Both protocols share the same audio encoding and buffering:
+
+```rust
+pub trait AudioSink {
+    /// Send encoded audio data
+    fn send_audio(&mut self, data: &AudioPacket) -> Result<(), Error>;
+
+    /// Get current buffer status
+    fn buffer_status(&self) -> BufferStatus;
+}
+
+// Both AirPlay 1 and 2 implement this trait
+impl AudioSink for RaopSession { /* ... */ }
+impl AudioSink for AirPlay2Session { /* ... */ }
+```
+
+## Testing Strategy Overview
+
+### Unit Testing
+
+- Sans-IO protocol testing for all new components
+- Property-based testing for codec roundtrips
+- Known test vectors for RSA/AES operations
+
+### Integration Testing
+
+- Extended mock server supporting RAOP protocol
+- Full session simulation tests
+- Interoperability tests between AirPlay 1 and 2 modes
+
+### Real Device Testing
+
+- AirPort Express (1st/2nd generation)
+- Older Apple TV (2nd/3rd generation)
+- Third-party RAOP receivers (e.g., Shairport-sync)
+
+## References
+
+- [Unofficial AirPlay Protocol Specification](https://nto.github.io/AirPlay.html)
+- [OpenAirPlay Specification](https://openairplay.github.io/airplay-spec/)
+- [Shairport-sync](https://github.com/mikebrady/shairport-sync) - Reference RAOP implementation
+- [go-airplay](https://github.com/joelgibson/go-airplay) - Go implementation
+- [RAOP Wikipedia](https://en.wikipedia.org/wiki/RAOP)
+
+## Document Index
+
+| Section | Title | Description |
+|---------|-------|-------------|
+| 00 | Overview (this document) | Architecture and strategy |
+| 01 | Service Discovery | RAOP mDNS/DNS-SD |
+| 02 | RSA Authentication | Challenge-response protocol |
+| 03 | RTSP Session | AirPlay 1 RTSP flow |
+| 04 | RTP Audio Streaming | Audio transport details |
+| 05 | Audio Encryption | AES encryption with RSA key exchange |
+| 06 | Remote Control | DACP protocol |
+| 07 | Metadata | DAAP/DMAP protocols |
+| 08 | Integration Guide | Unified API design |
+| 09 | Testing Strategy | Test infrastructure |

--- a/docs/25-raop-discovery.md
+++ b/docs/25-raop-discovery.md
@@ -1,0 +1,758 @@
+# Section 25: RAOP Service Discovery
+
+## Dependencies
+- **Section 08**: mDNS Discovery (must be complete)
+- **Section 02**: Core Types, Errors & Configuration (must be complete)
+- **Section 24**: AirPlay 1 Overview (should be reviewed)
+
+## Overview
+
+AirPlay 1 devices (AirPort Express, older Apple TVs, third-party receivers) advertise themselves via the `_raop._tcp` mDNS service type, distinct from AirPlay 2's `_airplay._tcp`. This section extends the existing mDNS discovery infrastructure to detect and parse RAOP service advertisements.
+
+## Objectives
+
+- Extend service browser to discover `_raop._tcp` services
+- Parse RAOP-specific TXT records
+- Detect device capabilities (codecs, encryption types)
+- Distinguish between AirPlay 1-only and dual-protocol devices
+- Integrate with existing `AirPlayDevice` type
+
+---
+
+## Tasks
+
+### 25.1 RAOP Service Types
+
+- [ ] **25.1.1** Define RAOP service constants and types
+
+**File:** `src/discovery/raop.rs`
+
+```rust
+//! RAOP (AirPlay 1) service discovery
+
+/// RAOP service type for mDNS discovery
+pub const RAOP_SERVICE_TYPE: &str = "_raop._tcp.local.";
+
+/// RAOP TXT record keys
+pub mod txt_keys {
+    /// TXT record version (usually "1")
+    pub const TXTVERS: &str = "txtvers";
+    /// Number of audio channels (e.g., "2" for stereo)
+    pub const CHANNELS: &str = "ch";
+    /// Supported codecs (e.g., "0,1,2,3")
+    pub const CODECS: &str = "cn";
+    /// Metadata support flag
+    pub const METADATA: &str = "da";
+    /// Supported encryption types (e.g., "0,1,3,5")
+    pub const ENCRYPTION: &str = "et";
+    /// Supported metadata types (e.g., "0,1,2")
+    pub const METADATA_TYPES: &str = "md";
+    /// Password required flag
+    pub const PASSWORD: &str = "pw";
+    /// Sample rate in Hz (e.g., "44100")
+    pub const SAMPLE_RATE: &str = "sr";
+    /// Sample size in bits (e.g., "16")
+    pub const SAMPLE_SIZE: &str = "ss";
+    /// Transport protocol (e.g., "UDP")
+    pub const TRANSPORT: &str = "tp";
+    /// Server version (e.g., "130.14")
+    pub const VERSION: &str = "vs";
+    /// Version number (e.g., "65537")
+    pub const VERSION_NUM: &str = "vn";
+    /// Device model (e.g., "AppleTV2,1")
+    pub const MODEL: &str = "am";
+    /// Status flags
+    pub const FLAGS: &str = "sf";
+}
+
+/// Supported audio codecs for RAOP
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum RaopCodec {
+    /// Uncompressed PCM
+    Pcm = 0,
+    /// Apple Lossless Audio Codec
+    Alac = 1,
+    /// Advanced Audio Coding
+    Aac = 2,
+    /// AAC Enhanced Low Delay (for screen mirroring)
+    AacEld = 3,
+}
+
+impl RaopCodec {
+    /// Parse from numeric value
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(Self::Pcm),
+            1 => Some(Self::Alac),
+            2 => Some(Self::Aac),
+            3 => Some(Self::AacEld),
+            _ => None,
+        }
+    }
+
+    /// Get human-readable name
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Pcm => "PCM",
+            Self::Alac => "Apple Lossless",
+            Self::Aac => "AAC",
+            Self::AacEld => "AAC-ELD",
+        }
+    }
+}
+
+/// Supported encryption types for RAOP
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum RaopEncryption {
+    /// No encryption
+    None = 0,
+    /// RSA (AirPort Express original)
+    Rsa = 1,
+    /// FairPlay (iTunes DRM)
+    FairPlay = 3,
+    /// MFi-SAP (third-party devices)
+    MfiSap = 4,
+    /// FairPlay SAPv2.5 (iOS/macOS mirroring)
+    FairPlaySap25 = 5,
+}
+
+impl RaopEncryption {
+    /// Parse from numeric value
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(Self::None),
+            1 => Some(Self::Rsa),
+            3 => Some(Self::FairPlay),
+            4 => Some(Self::MfiSap),
+            5 => Some(Self::FairPlaySap25),
+            _ => None,
+        }
+    }
+
+    /// Check if this encryption type is supported by the library
+    pub fn is_supported(&self) -> bool {
+        matches!(self, Self::None | Self::Rsa)
+    }
+}
+
+/// Metadata types supported by RAOP devices
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum RaopMetadataType {
+    /// Text metadata (track, artist, album)
+    Text = 0,
+    /// Artwork images
+    Artwork = 1,
+    /// Playback progress
+    Progress = 2,
+}
+
+impl RaopMetadataType {
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(Self::Text),
+            1 => Some(Self::Artwork),
+            2 => Some(Self::Progress),
+            _ => None,
+        }
+    }
+}
+```
+
+---
+
+### 25.2 RAOP Capabilities Parsing
+
+- [ ] **25.2.1** Implement RAOP TXT record parser
+
+**File:** `src/discovery/raop.rs` (continued)
+
+```rust
+/// RAOP device capabilities parsed from TXT records
+#[derive(Debug, Clone, Default)]
+pub struct RaopCapabilities {
+    /// TXT record version
+    pub txt_version: u8,
+    /// Number of audio channels
+    pub channels: u8,
+    /// Supported codecs
+    pub codecs: Vec<RaopCodec>,
+    /// Supported encryption types
+    pub encryption_types: Vec<RaopEncryption>,
+    /// Supports metadata
+    pub metadata_support: bool,
+    /// Supported metadata types
+    pub metadata_types: Vec<RaopMetadataType>,
+    /// Password required
+    pub password_required: bool,
+    /// Sample rate (Hz)
+    pub sample_rate: u32,
+    /// Sample size (bits)
+    pub sample_size: u8,
+    /// Transport protocol
+    pub transport: String,
+    /// Server version string
+    pub server_version: Option<String>,
+    /// Device model
+    pub model: Option<String>,
+    /// Status flags
+    pub status_flags: u32,
+}
+
+impl RaopCapabilities {
+    /// Parse from TXT record map
+    pub fn from_txt_records(records: &std::collections::HashMap<String, String>) -> Self {
+        let mut caps = Self::default();
+
+        // Parse txtvers
+        if let Some(v) = records.get(txt_keys::TXTVERS) {
+            caps.txt_version = v.parse().unwrap_or(1);
+        }
+
+        // Parse channels
+        if let Some(v) = records.get(txt_keys::CHANNELS) {
+            caps.channels = v.parse().unwrap_or(2);
+        } else {
+            caps.channels = 2; // Default stereo
+        }
+
+        // Parse codecs (comma-separated list)
+        if let Some(v) = records.get(txt_keys::CODECS) {
+            caps.codecs = Self::parse_codec_list(v);
+        }
+
+        // Parse encryption types
+        if let Some(v) = records.get(txt_keys::ENCRYPTION) {
+            caps.encryption_types = Self::parse_encryption_list(v);
+        }
+
+        // Parse metadata support
+        if let Some(v) = records.get(txt_keys::METADATA) {
+            caps.metadata_support = v == "true" || v == "1";
+        }
+
+        // Parse metadata types
+        if let Some(v) = records.get(txt_keys::METADATA_TYPES) {
+            caps.metadata_types = Self::parse_metadata_types(v);
+        }
+
+        // Parse password requirement
+        if let Some(v) = records.get(txt_keys::PASSWORD) {
+            caps.password_required = v == "true" || v == "1";
+        }
+
+        // Parse sample rate
+        if let Some(v) = records.get(txt_keys::SAMPLE_RATE) {
+            caps.sample_rate = v.parse().unwrap_or(44100);
+        } else {
+            caps.sample_rate = 44100;
+        }
+
+        // Parse sample size
+        if let Some(v) = records.get(txt_keys::SAMPLE_SIZE) {
+            caps.sample_size = v.parse().unwrap_or(16);
+        } else {
+            caps.sample_size = 16;
+        }
+
+        // Parse transport
+        if let Some(v) = records.get(txt_keys::TRANSPORT) {
+            caps.transport = v.clone();
+        } else {
+            caps.transport = "UDP".to_string();
+        }
+
+        // Optional fields
+        caps.server_version = records.get(txt_keys::VERSION).cloned();
+        caps.model = records.get(txt_keys::MODEL).cloned();
+
+        if let Some(v) = records.get(txt_keys::FLAGS) {
+            caps.status_flags = u32::from_str_radix(v.trim_start_matches("0x"), 16)
+                .unwrap_or(0);
+        }
+
+        caps
+    }
+
+    fn parse_codec_list(s: &str) -> Vec<RaopCodec> {
+        s.split(',')
+            .filter_map(|v| v.trim().parse::<u8>().ok())
+            .filter_map(RaopCodec::from_u8)
+            .collect()
+    }
+
+    fn parse_encryption_list(s: &str) -> Vec<RaopEncryption> {
+        s.split(',')
+            .filter_map(|v| v.trim().parse::<u8>().ok())
+            .filter_map(RaopEncryption::from_u8)
+            .collect()
+    }
+
+    fn parse_metadata_types(s: &str) -> Vec<RaopMetadataType> {
+        s.split(',')
+            .filter_map(|v| v.trim().parse::<u8>().ok())
+            .filter_map(RaopMetadataType::from_u8)
+            .collect()
+    }
+
+    /// Check if device supports a specific codec
+    pub fn supports_codec(&self, codec: RaopCodec) -> bool {
+        self.codecs.contains(&codec)
+    }
+
+    /// Check if device supports RSA encryption
+    pub fn supports_rsa(&self) -> bool {
+        self.encryption_types.contains(&RaopEncryption::Rsa)
+    }
+
+    /// Check if device supports unencrypted streaming
+    pub fn supports_unencrypted(&self) -> bool {
+        self.encryption_types.contains(&RaopEncryption::None)
+    }
+
+    /// Get preferred codec (ALAC > AAC > PCM)
+    pub fn preferred_codec(&self) -> Option<RaopCodec> {
+        if self.codecs.contains(&RaopCodec::Alac) {
+            Some(RaopCodec::Alac)
+        } else if self.codecs.contains(&RaopCodec::Aac) {
+            Some(RaopCodec::Aac)
+        } else if self.codecs.contains(&RaopCodec::Pcm) {
+            Some(RaopCodec::Pcm)
+        } else {
+            self.codecs.first().copied()
+        }
+    }
+
+    /// Get preferred encryption (RSA if available, else None)
+    pub fn preferred_encryption(&self) -> Option<RaopEncryption> {
+        if self.supports_rsa() {
+            Some(RaopEncryption::Rsa)
+        } else if self.supports_unencrypted() {
+            Some(RaopEncryption::None)
+        } else {
+            None
+        }
+    }
+}
+```
+
+---
+
+### 25.3 RAOP Service Browser
+
+- [ ] **25.3.1** Extend discovery browser for RAOP services
+
+**File:** `src/discovery/browser.rs` (extensions)
+
+```rust
+use super::raop::{RaopCapabilities, RAOP_SERVICE_TYPE};
+
+/// Extended discovery options for both AirPlay 1 and 2
+#[derive(Debug, Clone)]
+pub struct DiscoveryOptions {
+    /// Discover AirPlay 2 devices (_airplay._tcp)
+    pub discover_airplay2: bool,
+    /// Discover AirPlay 1/RAOP devices (_raop._tcp)
+    pub discover_raop: bool,
+    /// Timeout for discovery scan
+    pub timeout: Duration,
+    /// Filter by device capabilities
+    pub filter: Option<DeviceFilter>,
+}
+
+impl Default for DiscoveryOptions {
+    fn default() -> Self {
+        Self {
+            discover_airplay2: true,
+            discover_raop: true,
+            timeout: Duration::from_secs(5),
+            filter: None,
+        }
+    }
+}
+
+/// Device filter criteria
+#[derive(Debug, Clone, Default)]
+pub struct DeviceFilter {
+    /// Require audio support
+    pub audio_only: bool,
+    /// Require specific codec support
+    pub required_codec: Option<RaopCodec>,
+    /// Exclude password-protected devices
+    pub exclude_password_protected: bool,
+}
+
+/// Extended device information with RAOP capabilities
+#[derive(Debug, Clone)]
+pub struct DiscoveredDevice {
+    /// Device identifier
+    pub id: String,
+    /// Display name
+    pub name: String,
+    /// IP addresses
+    pub addresses: Vec<std::net::IpAddr>,
+    /// AirPlay 2 service port (if available)
+    pub airplay_port: Option<u16>,
+    /// RAOP service port (if available)
+    pub raop_port: Option<u16>,
+    /// AirPlay 2 capabilities (if available)
+    pub airplay_capabilities: Option<crate::types::DeviceCapabilities>,
+    /// RAOP capabilities (if available)
+    pub raop_capabilities: Option<RaopCapabilities>,
+    /// Detected protocol support
+    pub protocol: DeviceProtocol,
+}
+
+/// Protocol support detected for a device
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeviceProtocol {
+    /// Only AirPlay 2 supported
+    AirPlay2Only,
+    /// Only AirPlay 1 (RAOP) supported
+    RaopOnly,
+    /// Both protocols supported
+    Both,
+}
+
+impl DiscoveredDevice {
+    /// Check if device supports AirPlay 2
+    pub fn supports_airplay2(&self) -> bool {
+        matches!(self.protocol, DeviceProtocol::AirPlay2Only | DeviceProtocol::Both)
+    }
+
+    /// Check if device supports RAOP (AirPlay 1)
+    pub fn supports_raop(&self) -> bool {
+        matches!(self.protocol, DeviceProtocol::RaopOnly | DeviceProtocol::Both)
+    }
+
+    /// Get the preferred connection port
+    pub fn preferred_port(&self) -> Option<u16> {
+        // Prefer AirPlay 2 if available
+        self.airplay_port.or(self.raop_port)
+    }
+
+    /// Convert to AirPlayDevice for use with client
+    pub fn to_airplay_device(&self) -> crate::types::AirPlayDevice {
+        crate::types::AirPlayDevice {
+            id: self.id.clone(),
+            name: self.name.clone(),
+            addresses: self.addresses.clone(),
+            port: self.preferred_port().unwrap_or(7000),
+            capabilities: self.airplay_capabilities.clone()
+                .unwrap_or_default(),
+            // Extended fields for RAOP support
+            raop_port: self.raop_port,
+            raop_capabilities: self.raop_capabilities.clone(),
+        }
+    }
+}
+```
+
+---
+
+### 25.4 RAOP Service Name Parsing
+
+- [ ] **25.4.1** Parse RAOP service instance names
+
+**File:** `src/discovery/raop.rs` (continued)
+
+```rust
+/// Parse RAOP service instance name
+///
+/// RAOP service names follow the format: `{MAC_ADDRESS}@{DEVICE_NAME}`
+/// Example: "0050C212A23F@Living Room"
+pub fn parse_raop_service_name(name: &str) -> Option<(String, String)> {
+    let parts: Vec<&str> = name.splitn(2, '@').collect();
+    if parts.len() == 2 {
+        let mac = parts[0].to_uppercase();
+        let device_name = parts[1].to_string();
+
+        // Validate MAC address format (12 hex characters)
+        if mac.len() == 12 && mac.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Some((mac, device_name));
+        }
+    }
+    None
+}
+
+/// Format MAC address with colons
+pub fn format_mac_address(mac: &str) -> String {
+    mac.chars()
+        .collect::<Vec<_>>()
+        .chunks(2)
+        .map(|chunk| chunk.iter().collect::<String>())
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_raop_service_name() {
+        let (mac, name) = parse_raop_service_name("0050C212A23F@Living Room").unwrap();
+        assert_eq!(mac, "0050C212A23F");
+        assert_eq!(name, "Living Room");
+    }
+
+    #[test]
+    fn test_parse_raop_service_name_with_special_chars() {
+        let (mac, name) = parse_raop_service_name("AABBCCDDEEFF@Speaker's Room").unwrap();
+        assert_eq!(mac, "AABBCCDDEEFF");
+        assert_eq!(name, "Speaker's Room");
+    }
+
+    #[test]
+    fn test_format_mac_address() {
+        assert_eq!(format_mac_address("0050C212A23F"), "00:50:C2:12:A2:3F");
+    }
+}
+```
+
+---
+
+### 25.5 Unified Discovery API
+
+- [ ] **25.5.1** Implement unified discovery stream
+
+**File:** `src/discovery/mod.rs` (extensions)
+
+```rust
+/// Discovery event types
+#[derive(Debug, Clone)]
+pub enum DiscoveryEvent {
+    /// New device discovered
+    DeviceFound(DiscoveredDevice),
+    /// Device went offline
+    DeviceLost { id: String },
+    /// Device information updated
+    DeviceUpdated(DiscoveredDevice),
+    /// Discovery error (non-fatal)
+    Error(String),
+}
+
+/// Start continuous discovery for both AirPlay 1 and 2 devices
+pub async fn discover_all(options: DiscoveryOptions) -> impl Stream<Item = DiscoveryEvent> {
+    // Implementation combines both service browsers
+    // and correlates devices that advertise both services
+    todo!()
+}
+
+/// One-shot scan for all compatible devices
+pub async fn scan_all(options: DiscoveryOptions) -> Result<Vec<DiscoveredDevice>, AirPlayError> {
+    let events = discover_all(options.clone());
+    tokio::pin!(events);
+
+    let mut devices: HashMap<String, DiscoveredDevice> = HashMap::new();
+    let deadline = tokio::time::Instant::now() + options.timeout;
+
+    while tokio::time::Instant::now() < deadline {
+        match tokio::time::timeout_at(deadline, events.next()).await {
+            Ok(Some(DiscoveryEvent::DeviceFound(device))) => {
+                devices.insert(device.id.clone(), device);
+            }
+            Ok(Some(DiscoveryEvent::DeviceUpdated(device))) => {
+                devices.insert(device.id.clone(), device);
+            }
+            Ok(Some(DiscoveryEvent::DeviceLost { id })) => {
+                devices.remove(&id);
+            }
+            Ok(Some(DiscoveryEvent::Error(_))) => continue,
+            Ok(None) | Err(_) => break,
+        }
+    }
+
+    Ok(devices.into_values().collect())
+}
+```
+
+---
+
+## Unit Tests
+
+### Test File: `src/discovery/raop.rs`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_parse_capabilities_basic() {
+        let mut records = HashMap::new();
+        records.insert("ch".to_string(), "2".to_string());
+        records.insert("cn".to_string(), "0,1,2".to_string());
+        records.insert("et".to_string(), "0,1".to_string());
+        records.insert("sr".to_string(), "44100".to_string());
+        records.insert("ss".to_string(), "16".to_string());
+
+        let caps = RaopCapabilities::from_txt_records(&records);
+
+        assert_eq!(caps.channels, 2);
+        assert_eq!(caps.sample_rate, 44100);
+        assert_eq!(caps.sample_size, 16);
+        assert!(caps.supports_codec(RaopCodec::Pcm));
+        assert!(caps.supports_codec(RaopCodec::Alac));
+        assert!(caps.supports_codec(RaopCodec::Aac));
+        assert!(caps.supports_rsa());
+        assert!(caps.supports_unencrypted());
+    }
+
+    #[test]
+    fn test_parse_capabilities_airport_express() {
+        // Typical AirPort Express TXT records
+        let mut records = HashMap::new();
+        records.insert("txtvers".to_string(), "1".to_string());
+        records.insert("ch".to_string(), "2".to_string());
+        records.insert("cn".to_string(), "0,1,2,3".to_string());
+        records.insert("da".to_string(), "true".to_string());
+        records.insert("et".to_string(), "0,3,5".to_string());
+        records.insert("md".to_string(), "0,1,2".to_string());
+        records.insert("pw".to_string(), "false".to_string());
+        records.insert("sr".to_string(), "44100".to_string());
+        records.insert("ss".to_string(), "16".to_string());
+        records.insert("tp".to_string(), "UDP".to_string());
+        records.insert("vs".to_string(), "130.14".to_string());
+        records.insert("am".to_string(), "AirPort10,115".to_string());
+
+        let caps = RaopCapabilities::from_txt_records(&records);
+
+        assert!(caps.metadata_support);
+        assert!(!caps.password_required);
+        assert_eq!(caps.model, Some("AirPort10,115".to_string()));
+        assert_eq!(caps.preferred_codec(), Some(RaopCodec::Alac));
+    }
+
+    #[test]
+    fn test_preferred_encryption_rsa() {
+        let mut records = HashMap::new();
+        records.insert("et".to_string(), "0,1".to_string());
+
+        let caps = RaopCapabilities::from_txt_records(&records);
+
+        assert_eq!(caps.preferred_encryption(), Some(RaopEncryption::Rsa));
+    }
+
+    #[test]
+    fn test_preferred_encryption_none_only() {
+        let mut records = HashMap::new();
+        records.insert("et".to_string(), "0".to_string());
+
+        let caps = RaopCapabilities::from_txt_records(&records);
+
+        assert_eq!(caps.preferred_encryption(), Some(RaopEncryption::None));
+    }
+
+    #[test]
+    fn test_preferred_encryption_fairplay_unsupported() {
+        let mut records = HashMap::new();
+        records.insert("et".to_string(), "3".to_string()); // FairPlay only
+
+        let caps = RaopCapabilities::from_txt_records(&records);
+
+        assert_eq!(caps.preferred_encryption(), None);
+    }
+
+    #[test]
+    fn test_codec_preference() {
+        let mut records = HashMap::new();
+        records.insert("cn".to_string(), "0,2".to_string()); // PCM and AAC
+
+        let caps = RaopCapabilities::from_txt_records(&records);
+
+        // Should prefer AAC over PCM
+        assert_eq!(caps.preferred_codec(), Some(RaopCodec::Aac));
+    }
+
+    #[test]
+    fn test_empty_records() {
+        let records = HashMap::new();
+        let caps = RaopCapabilities::from_txt_records(&records);
+
+        // Should use sensible defaults
+        assert_eq!(caps.channels, 2);
+        assert_eq!(caps.sample_rate, 44100);
+        assert_eq!(caps.sample_size, 16);
+        assert_eq!(caps.transport, "UDP");
+    }
+}
+```
+
+---
+
+## Integration Tests
+
+### Test: Discovery of RAOP devices
+
+```rust
+// tests/discovery_raop_integration.rs
+
+use airplay2_rs::discovery::{discover_all, DiscoveryOptions, DiscoveryEvent, DeviceProtocol};
+use std::time::Duration;
+use futures::StreamExt;
+
+#[tokio::test]
+async fn test_raop_discovery_simulation() {
+    // Use mock mDNS responses
+    let options = DiscoveryOptions {
+        discover_airplay2: false,
+        discover_raop: true,
+        timeout: Duration::from_secs(2),
+        filter: None,
+    };
+
+    let events = discover_all(options);
+    tokio::pin!(events);
+
+    // In a real test environment with mock services:
+    // - Verify RAOP services are discovered
+    // - Verify TXT records are parsed correctly
+    // - Verify device protocol is detected as RaopOnly
+}
+
+#[tokio::test]
+async fn test_dual_protocol_device() {
+    // Test device advertising both _raop._tcp and _airplay._tcp
+    let options = DiscoveryOptions {
+        discover_airplay2: true,
+        discover_raop: true,
+        timeout: Duration::from_secs(3),
+        filter: None,
+    };
+
+    // In a real test:
+    // - Verify both services are correlated to same device
+    // - Verify protocol is DeviceProtocol::Both
+    // - Verify both capability sets are populated
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] RAOP service type is correctly browsed via mDNS
+- [ ] All TXT record fields are parsed correctly
+- [ ] Codec list parsing handles all valid formats
+- [ ] Encryption type detection is accurate
+- [ ] Service name parsing extracts MAC and device name
+- [ ] Device protocol detection distinguishes AirPlay 1/2/Both
+- [ ] Unified discovery API returns correlated devices
+- [ ] Password-protected devices are detected
+- [ ] Missing TXT fields use sensible defaults
+- [ ] All unit tests pass
+- [ ] Integration tests with mock services pass
+
+---
+
+## Notes
+
+- Some older devices may have non-standard TXT record formats
+- MAC address in service name may not match actual network interface
+- Consider caching discovered devices for quick reconnection
+- Network changes should trigger re-discovery
+- Some devices advertise both services with different capabilities

--- a/docs/26-rsa-authentication.md
+++ b/docs/26-rsa-authentication.md
@@ -1,0 +1,876 @@
+# Section 26: RSA Authentication
+
+## Dependencies
+- **Section 04**: Cryptographic Primitives (must be complete)
+- **Section 24**: AirPlay 1 Overview (should be reviewed)
+- **Section 25**: RAOP Discovery (recommended)
+
+## Overview
+
+AirPlay 1 devices use RSA-based authentication to verify that clients are authorized Apple software and to establish encryption keys for the audio stream. This is fundamentally different from AirPlay 2's HomeKit-based pairing.
+
+The RSA authentication serves two purposes:
+1. **Challenge-Response**: Device proves it has the legitimate RSA private key
+2. **Key Exchange**: Client sends AES encryption key wrapped with RSA public key
+
+## Historical Context
+
+The RSA key pair was originally kept secret by Apple:
+- The **public key** (in iTunes) was extracted by Jon Lech Johansen in 2004
+- The **private key** (in AirPort Express) was extracted by James Laird in 2011
+
+This enabled third-party implementations like Shairport and Shairport-sync.
+
+## Objectives
+
+- Implement RSA-OAEP encryption for AES key exchange
+- Implement RSA-PKCS#1 v1.5 signature verification for challenge-response
+- Handle Apple-Challenge and Apple-Response headers
+- Support both authentication and encryption use cases
+
+---
+
+## Tasks
+
+### 26.1 RSA Module Structure
+
+- [ ] **26.1.1** Define RSA types and constants
+
+**File:** `src/protocol/crypto/rsa.rs`
+
+```rust
+//! RSA cryptography for AirPlay 1 (RAOP) authentication
+
+use super::CryptoError;
+
+/// RSA key sizes used in RAOP
+pub mod sizes {
+    /// RSA modulus size (1024 bits)
+    pub const MODULUS_BITS: usize = 1024;
+    /// RSA modulus size in bytes
+    pub const MODULUS_BYTES: usize = 128;
+    /// Maximum plaintext size for OAEP (with SHA-1)
+    pub const OAEP_MAX_PLAINTEXT: usize = 86; // 128 - 2*20 - 2
+    /// PKCS#1 signature size
+    pub const SIGNATURE_BYTES: usize = 128;
+}
+
+/// Apple's RSA public key used for RAOP authentication
+///
+/// This is the well-known public key extracted from iTunes.
+/// Modulus: 1024 bits, Exponent: 65537
+pub struct AppleRsaPublicKey {
+    inner: rsa::RsaPublicKey,
+}
+
+impl AppleRsaPublicKey {
+    /// The known Apple RSA public key modulus (hex)
+    const MODULUS_HEX: &'static str = concat!(
+        "e7d7447851a2c8f3d70a3c9d18e63b5b",
+        "5f23e8c0f2e6c6b2a7f8e0c7a8b9d1e2",
+        "f3a4b5c6d7e8f90a1b2c3d4e5f60718",
+        "293a4b5c6d7e8f90a1b2c3d4e5f6071",
+        "8293a4b5c6d7e8f90a1b2c3d4e5f607",
+        "18293a4b5c6d7e8f90a1b2c3d4e5f60",
+        "718293a4b5c6d7e8f90a1b2c3d4e5f6",
+        "0718293a4b5c6d7e8f90a1b2c3d4e5f"
+    );
+
+    /// Standard RSA exponent
+    const EXPONENT: u32 = 65537;
+
+    /// Load the Apple public key
+    pub fn load() -> Result<Self, CryptoError> {
+        use rsa::BigUint;
+
+        // In real implementation, use the actual Apple public key
+        // These are placeholder values - actual key from iTunes needed
+        let n = BigUint::parse_bytes(Self::MODULUS_HEX.as_bytes(), 16)
+            .ok_or_else(|| CryptoError::InvalidPublicKey)?;
+        let e = BigUint::from(Self::EXPONENT);
+
+        let inner = rsa::RsaPublicKey::new(n, e)
+            .map_err(|e| CryptoError::InvalidPublicKey)?;
+
+        Ok(Self { inner })
+    }
+
+    /// Encrypt data using RSA-OAEP with SHA-1
+    ///
+    /// Used to encrypt the AES key for the device
+    pub fn encrypt_oaep(&self, plaintext: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        use rsa::Oaep;
+        use sha1::Sha1;
+        use rand::rngs::OsRng;
+
+        if plaintext.len() > sizes::OAEP_MAX_PLAINTEXT {
+            return Err(CryptoError::EncryptionFailed(
+                format!("plaintext too long: {} > {}", plaintext.len(), sizes::OAEP_MAX_PLAINTEXT)
+            ));
+        }
+
+        let padding = Oaep::new::<Sha1>();
+        self.inner
+            .encrypt(&mut OsRng, padding, plaintext)
+            .map_err(|e| CryptoError::EncryptionFailed(e.to_string()))
+    }
+
+    /// Verify a PKCS#1 v1.5 signature
+    ///
+    /// Used to verify the Apple-Response header
+    pub fn verify_pkcs1(&self, message: &[u8], signature: &[u8]) -> Result<(), CryptoError> {
+        use rsa::pkcs1v15::{Signature, VerifyingKey};
+        use rsa::signature::Verifier;
+        use sha1::Sha1;
+
+        let verifying_key = VerifyingKey::<Sha1>::new(self.inner.clone());
+        let sig = Signature::try_from(signature)
+            .map_err(|_| CryptoError::InvalidSignature)?;
+
+        verifying_key
+            .verify(message, &sig)
+            .map_err(|_| CryptoError::VerificationFailed)
+    }
+}
+
+/// RSA private key for RAOP server emulation (testing)
+///
+/// This represents the private key held by AirPlay receivers.
+pub struct RaopRsaPrivateKey {
+    inner: rsa::RsaPrivateKey,
+}
+
+impl RaopRsaPrivateKey {
+    /// Generate a new RSA key pair for testing
+    pub fn generate() -> Result<Self, CryptoError> {
+        use rand::rngs::OsRng;
+
+        let inner = rsa::RsaPrivateKey::new(&mut OsRng, sizes::MODULUS_BITS)
+            .map_err(|e| CryptoError::RngError)?;
+
+        Ok(Self { inner })
+    }
+
+    /// Load from PEM-encoded private key
+    pub fn from_pem(pem: &str) -> Result<Self, CryptoError> {
+        use rsa::pkcs8::DecodePrivateKey;
+
+        let inner = rsa::RsaPrivateKey::from_pkcs8_pem(pem)
+            .map_err(|e| CryptoError::InvalidKeyLength {
+                expected: sizes::MODULUS_BYTES,
+                actual: 0,
+            })?;
+
+        Ok(Self { inner })
+    }
+
+    /// Decrypt RSA-OAEP encrypted data
+    ///
+    /// Used by receivers to decrypt the AES key
+    pub fn decrypt_oaep(&self, ciphertext: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        use rsa::Oaep;
+        use sha1::Sha1;
+
+        let padding = Oaep::new::<Sha1>();
+        self.inner
+            .decrypt(padding, ciphertext)
+            .map_err(|e| CryptoError::DecryptionFailed(e.to_string()))
+    }
+
+    /// Sign data with PKCS#1 v1.5
+    ///
+    /// Used by receivers to sign the Apple-Response
+    pub fn sign_pkcs1(&self, message: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        use rsa::pkcs1v15::SigningKey;
+        use rsa::signature::Signer;
+        use sha1::Sha1;
+
+        let signing_key = SigningKey::<Sha1>::new(self.inner.clone());
+        let signature = signing_key.sign(message);
+
+        Ok(signature.to_vec())
+    }
+
+    /// Get the corresponding public key
+    pub fn public_key(&self) -> rsa::RsaPublicKey {
+        self.inner.to_public_key()
+    }
+}
+```
+
+---
+
+### 26.2 Challenge-Response Protocol
+
+- [ ] **26.2.1** Implement Apple-Challenge generation and verification
+
+**File:** `src/protocol/raop/auth.rs`
+
+```rust
+//! RAOP challenge-response authentication
+
+use super::super::crypto::rsa::{AppleRsaPublicKey, RaopRsaPrivateKey};
+use super::super::crypto::CryptoError;
+use base64::{Engine as _, engine::general_purpose::STANDARD_NO_PAD as BASE64};
+
+/// Challenge size in bytes (128 bits)
+pub const CHALLENGE_SIZE: usize = 16;
+
+/// Generate a random Apple-Challenge
+pub fn generate_challenge() -> [u8; CHALLENGE_SIZE] {
+    use rand::RngCore;
+
+    let mut challenge = [0u8; CHALLENGE_SIZE];
+    rand::thread_rng().fill_bytes(&mut challenge);
+    challenge
+}
+
+/// Encode challenge as Base64 for Apple-Challenge header
+pub fn encode_challenge(challenge: &[u8]) -> String {
+    BASE64.encode(challenge)
+}
+
+/// Decode challenge from Apple-Challenge header
+pub fn decode_challenge(header: &str) -> Result<Vec<u8>, CryptoError> {
+    BASE64.decode(header.trim())
+        .map_err(|e| CryptoError::DecryptionFailed(format!("invalid base64: {}", e)))
+}
+
+/// Build the message to sign for Apple-Response
+///
+/// The response is: RSA_Sign(challenge || ip_address || mac_address)
+pub fn build_response_message(
+    challenge: &[u8],
+    ip_address: &std::net::IpAddr,
+    mac_address: &[u8; 6],
+) -> Vec<u8> {
+    let mut message = Vec::with_capacity(CHALLENGE_SIZE + 16 + 6);
+
+    // Add challenge
+    message.extend_from_slice(challenge);
+
+    // Add IP address (4 bytes for IPv4, 16 for IPv6)
+    match ip_address {
+        std::net::IpAddr::V4(addr) => {
+            message.extend_from_slice(&addr.octets());
+        }
+        std::net::IpAddr::V6(addr) => {
+            message.extend_from_slice(&addr.octets());
+        }
+    }
+
+    // Add MAC address
+    message.extend_from_slice(mac_address);
+
+    // Pad to 32 bytes if needed (some implementations require this)
+    while message.len() < 32 {
+        message.push(0);
+    }
+
+    message
+}
+
+/// Generate Apple-Response for a given challenge (server-side)
+pub fn generate_response(
+    private_key: &RaopRsaPrivateKey,
+    challenge: &[u8],
+    ip_address: &std::net::IpAddr,
+    mac_address: &[u8; 6],
+) -> Result<String, CryptoError> {
+    let message = build_response_message(challenge, ip_address, mac_address);
+    let signature = private_key.sign_pkcs1(&message)?;
+    Ok(BASE64.encode(&signature))
+}
+
+/// Verify Apple-Response header (client-side)
+pub fn verify_response(
+    public_key: &AppleRsaPublicKey,
+    response_header: &str,
+    challenge: &[u8],
+    server_ip: &std::net::IpAddr,
+    server_mac: &[u8; 6],
+) -> Result<(), CryptoError> {
+    let signature = BASE64.decode(response_header.trim())
+        .map_err(|e| CryptoError::VerificationFailed)?;
+
+    let message = build_response_message(challenge, server_ip, server_mac);
+    public_key.verify_pkcs1(&message, &signature)
+}
+
+/// RAOP authentication state machine
+pub struct RaopAuthenticator {
+    /// Generated challenge
+    challenge: [u8; CHALLENGE_SIZE],
+    /// State of authentication
+    state: AuthState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthState {
+    /// Initial state, challenge not sent
+    Initial,
+    /// Challenge sent, waiting for response
+    ChallengeSent,
+    /// Response verified successfully
+    Authenticated,
+    /// Authentication failed
+    Failed,
+}
+
+impl RaopAuthenticator {
+    /// Create new authenticator
+    pub fn new() -> Self {
+        Self {
+            challenge: generate_challenge(),
+            state: AuthState::Initial,
+        }
+    }
+
+    /// Get current state
+    pub fn state(&self) -> AuthState {
+        self.state
+    }
+
+    /// Get the Apple-Challenge header value
+    pub fn challenge_header(&self) -> String {
+        encode_challenge(&self.challenge)
+    }
+
+    /// Mark challenge as sent
+    pub fn mark_sent(&mut self) {
+        self.state = AuthState::ChallengeSent;
+    }
+
+    /// Verify the Apple-Response header
+    pub fn verify(
+        &mut self,
+        response_header: &str,
+        server_ip: &std::net::IpAddr,
+        server_mac: &[u8; 6],
+    ) -> Result<(), CryptoError> {
+        if self.state != AuthState::ChallengeSent {
+            return Err(CryptoError::VerificationFailed);
+        }
+
+        let public_key = AppleRsaPublicKey::load()?;
+        let result = verify_response(
+            &public_key,
+            response_header,
+            &self.challenge,
+            server_ip,
+            server_mac,
+        );
+
+        self.state = if result.is_ok() {
+            AuthState::Authenticated
+        } else {
+            AuthState::Failed
+        };
+
+        result
+    }
+
+    /// Check if authentication is complete
+    pub fn is_authenticated(&self) -> bool {
+        self.state == AuthState::Authenticated
+    }
+}
+```
+
+---
+
+### 26.3 AES Key Exchange
+
+- [ ] **26.3.1** Implement AES key generation and RSA wrapping
+
+**File:** `src/protocol/raop/key_exchange.rs`
+
+```rust
+//! AES key exchange for RAOP audio encryption
+
+use super::super::crypto::rsa::AppleRsaPublicKey;
+use super::super::crypto::CryptoError;
+use base64::{Engine as _, engine::general_purpose::STANDARD_NO_PAD as BASE64};
+
+/// AES key size (128 bits)
+pub const AES_KEY_SIZE: usize = 16;
+/// AES IV size (128 bits)
+pub const AES_IV_SIZE: usize = 16;
+
+/// Session keys for RAOP audio encryption
+#[derive(Clone)]
+pub struct RaopSessionKeys {
+    /// AES encryption key
+    aes_key: [u8; AES_KEY_SIZE],
+    /// AES initialization vector
+    aes_iv: [u8; AES_IV_SIZE],
+    /// RSA-encrypted AES key (for SDP)
+    encrypted_key: Vec<u8>,
+}
+
+impl RaopSessionKeys {
+    /// Generate new random session keys
+    pub fn generate() -> Result<Self, CryptoError> {
+        use rand::RngCore;
+
+        let mut aes_key = [0u8; AES_KEY_SIZE];
+        let mut aes_iv = [0u8; AES_IV_SIZE];
+
+        let mut rng = rand::thread_rng();
+        rng.fill_bytes(&mut aes_key);
+        rng.fill_bytes(&mut aes_iv);
+
+        // Encrypt AES key with Apple's RSA public key
+        let public_key = AppleRsaPublicKey::load()?;
+        let encrypted_key = public_key.encrypt_oaep(&aes_key)?;
+
+        Ok(Self {
+            aes_key,
+            aes_iv,
+            encrypted_key,
+        })
+    }
+
+    /// Get the AES key
+    pub fn aes_key(&self) -> &[u8; AES_KEY_SIZE] {
+        &self.aes_key
+    }
+
+    /// Get the AES IV
+    pub fn aes_iv(&self) -> &[u8; AES_IV_SIZE] {
+        &self.aes_iv
+    }
+
+    /// Get RSA-encrypted AES key as Base64 for `rsaaeskey` SDP attribute
+    pub fn rsaaeskey(&self) -> String {
+        BASE64.encode(&self.encrypted_key)
+    }
+
+    /// Get AES IV as Base64 for `aesiv` SDP attribute
+    pub fn aesiv(&self) -> String {
+        BASE64.encode(&self.aes_iv)
+    }
+}
+
+impl Drop for RaopSessionKeys {
+    fn drop(&mut self) {
+        // Zeroize sensitive data
+        self.aes_key.iter_mut().for_each(|b| *b = 0);
+        self.aes_iv.iter_mut().for_each(|b| *b = 0);
+    }
+}
+
+/// Parse `rsaaeskey` and `aesiv` from SDP (server-side)
+pub fn parse_session_keys(
+    rsaaeskey_b64: &str,
+    aesiv_b64: &str,
+    private_key: &super::super::crypto::rsa::RaopRsaPrivateKey,
+) -> Result<([u8; AES_KEY_SIZE], [u8; AES_IV_SIZE]), CryptoError> {
+    // Decode and decrypt AES key
+    let encrypted_key = BASE64.decode(rsaaeskey_b64.trim())
+        .map_err(|e| CryptoError::DecryptionFailed(format!("invalid base64: {}", e)))?;
+
+    let aes_key_vec = private_key.decrypt_oaep(&encrypted_key)?;
+
+    if aes_key_vec.len() != AES_KEY_SIZE {
+        return Err(CryptoError::InvalidKeyLength {
+            expected: AES_KEY_SIZE,
+            actual: aes_key_vec.len(),
+        });
+    }
+
+    let mut aes_key = [0u8; AES_KEY_SIZE];
+    aes_key.copy_from_slice(&aes_key_vec);
+
+    // Decode AES IV
+    let aes_iv_vec = BASE64.decode(aesiv_b64.trim())
+        .map_err(|e| CryptoError::DecryptionFailed(format!("invalid base64: {}", e)))?;
+
+    if aes_iv_vec.len() != AES_IV_SIZE {
+        return Err(CryptoError::InvalidKeyLength {
+            expected: AES_IV_SIZE,
+            actual: aes_iv_vec.len(),
+        });
+    }
+
+    let mut aes_iv = [0u8; AES_IV_SIZE];
+    aes_iv.copy_from_slice(&aes_iv_vec);
+
+    Ok((aes_key, aes_iv))
+}
+```
+
+---
+
+### 26.4 Module Integration
+
+- [ ] **26.4.1** Update crypto module exports
+
+**File:** `src/protocol/crypto/mod.rs` (additions)
+
+```rust
+// Add to existing mod.rs:
+mod rsa;
+
+pub use self::rsa::{AppleRsaPublicKey, RaopRsaPrivateKey, sizes as rsa_sizes};
+```
+
+- [ ] **26.4.2** Create RAOP protocol module
+
+**File:** `src/protocol/raop/mod.rs`
+
+```rust
+//! RAOP (AirPlay 1) protocol implementation
+
+mod auth;
+mod key_exchange;
+
+pub use auth::{
+    RaopAuthenticator, AuthState,
+    generate_challenge, encode_challenge, decode_challenge,
+    generate_response, verify_response,
+    CHALLENGE_SIZE,
+};
+
+pub use key_exchange::{
+    RaopSessionKeys, parse_session_keys,
+    AES_KEY_SIZE, AES_IV_SIZE,
+};
+```
+
+---
+
+## Unit Tests
+
+### Test File: `src/protocol/crypto/rsa.rs`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rsa_key_generation() {
+        let key = RaopRsaPrivateKey::generate().unwrap();
+        let public = key.public_key();
+
+        assert_eq!(public.size(), sizes::MODULUS_BYTES);
+    }
+
+    #[test]
+    fn test_oaep_encrypt_decrypt() {
+        let private = RaopRsaPrivateKey::generate().unwrap();
+
+        // Create a "public key" struct from the private key's public component
+        // In real code, this would use AppleRsaPublicKey with actual Apple key
+
+        let plaintext = b"test AES key data";
+        let public = private.public_key();
+
+        // Encrypt with public key
+        use rsa::Oaep;
+        use sha1::Sha1;
+        use rand::rngs::OsRng;
+
+        let padding = Oaep::new::<Sha1>();
+        let ciphertext = public.encrypt(&mut OsRng, padding, plaintext).unwrap();
+
+        // Decrypt with private key
+        let decrypted = private.decrypt_oaep(&ciphertext).unwrap();
+
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_pkcs1_sign_verify() {
+        let private = RaopRsaPrivateKey::generate().unwrap();
+        let message = b"challenge||ip||mac";
+
+        let signature = private.sign_pkcs1(message).unwrap();
+
+        assert_eq!(signature.len(), sizes::SIGNATURE_BYTES);
+
+        // Verify signature
+        use rsa::pkcs1v15::{Signature, VerifyingKey};
+        use rsa::signature::Verifier;
+        use sha1::Sha1;
+
+        let verifying_key = VerifyingKey::<Sha1>::new(private.public_key());
+        let sig = Signature::try_from(signature.as_slice()).unwrap();
+        verifying_key.verify(message, &sig).unwrap();
+    }
+
+    #[test]
+    fn test_oaep_max_plaintext() {
+        let private = RaopRsaPrivateKey::generate().unwrap();
+
+        // 16 bytes (AES key) should work
+        let aes_key = [0u8; 16];
+        let result = private.decrypt_oaep(&[0u8; 128]);
+
+        // Will fail because random bytes won't decrypt properly,
+        // but validates that size checks work
+    }
+}
+```
+
+### Test File: `src/protocol/raop/auth.rs`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::IpAddr;
+
+    #[test]
+    fn test_challenge_generation() {
+        let c1 = generate_challenge();
+        let c2 = generate_challenge();
+
+        // Should be different (with overwhelming probability)
+        assert_ne!(c1, c2);
+        assert_eq!(c1.len(), CHALLENGE_SIZE);
+    }
+
+    #[test]
+    fn test_challenge_encode_decode() {
+        let challenge = generate_challenge();
+        let encoded = encode_challenge(&challenge);
+        let decoded = decode_challenge(&encoded).unwrap();
+
+        assert_eq!(decoded, challenge);
+    }
+
+    #[test]
+    fn test_response_message_building() {
+        let challenge = [0x01u8; CHALLENGE_SIZE];
+        let ip: IpAddr = "192.168.1.100".parse().unwrap();
+        let mac = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
+
+        let message = build_response_message(&challenge, &ip, &mac);
+
+        // Should contain challenge + IP + MAC (padded to 32 bytes)
+        assert!(message.len() >= 32);
+        assert!(message.starts_with(&challenge));
+    }
+
+    #[test]
+    fn test_response_message_ipv6() {
+        let challenge = [0x01u8; CHALLENGE_SIZE];
+        let ip: IpAddr = "::1".parse().unwrap();
+        let mac = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
+
+        let message = build_response_message(&challenge, &ip, &mac);
+
+        // IPv6 address is 16 bytes
+        assert!(message.len() >= CHALLENGE_SIZE + 16 + 6);
+    }
+
+    #[test]
+    fn test_authenticator_state_machine() {
+        let mut auth = RaopAuthenticator::new();
+
+        assert_eq!(auth.state(), AuthState::Initial);
+        assert!(!auth.is_authenticated());
+
+        // Get challenge header
+        let header = auth.challenge_header();
+        assert!(!header.is_empty());
+
+        auth.mark_sent();
+        assert_eq!(auth.state(), AuthState::ChallengeSent);
+    }
+
+    #[test]
+    fn test_full_auth_flow_with_generated_key() {
+        // Generate a test RSA key pair
+        let private = super::super::super::crypto::rsa::RaopRsaPrivateKey::generate().unwrap();
+
+        let challenge = generate_challenge();
+        let ip: IpAddr = "192.168.1.100".parse().unwrap();
+        let mac = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
+
+        // Server generates response
+        let response = generate_response(&private, &challenge, &ip, &mac).unwrap();
+
+        // In real code, client would verify with Apple's public key
+        // Here we just verify the signature format
+        let decoded = BASE64.decode(&response).unwrap();
+        assert_eq!(decoded.len(), 128); // 1024-bit RSA signature
+    }
+}
+```
+
+### Test File: `src/protocol/raop/key_exchange.rs`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_key_generation() {
+        // This test requires the actual Apple public key to work
+        // In testing, we'd mock this or use a test key pair
+
+        // Test the base64 encoding/decoding functions
+        let test_key = [0x42u8; AES_KEY_SIZE];
+        let test_iv = [0x00u8; AES_IV_SIZE];
+
+        let key_b64 = BASE64.encode(&test_key);
+        let iv_b64 = BASE64.encode(&test_iv);
+
+        let decoded_key = BASE64.decode(&key_b64).unwrap();
+        let decoded_iv = BASE64.decode(&iv_b64).unwrap();
+
+        assert_eq!(decoded_key, test_key);
+        assert_eq!(decoded_iv, test_iv);
+    }
+
+    #[test]
+    fn test_session_keys_with_test_keypair() {
+        use super::super::super::crypto::rsa::RaopRsaPrivateKey;
+
+        // Generate test key pair
+        let private = RaopRsaPrivateKey::generate().unwrap();
+
+        // Generate AES key and IV
+        let mut aes_key = [0u8; AES_KEY_SIZE];
+        let mut aes_iv = [0u8; AES_IV_SIZE];
+        rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut aes_key);
+        rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut aes_iv);
+
+        // Encrypt with public key
+        use rsa::Oaep;
+        use sha1::Sha1;
+        use rand::rngs::OsRng;
+
+        let public = private.public_key();
+        let padding = Oaep::new::<Sha1>();
+        let encrypted = public.encrypt(&mut OsRng, padding, &aes_key).unwrap();
+
+        // Encode as SDP attributes
+        let rsaaeskey = BASE64.encode(&encrypted);
+        let aesiv = BASE64.encode(&aes_iv);
+
+        // Parse back
+        let (parsed_key, parsed_iv) = parse_session_keys(&rsaaeskey, &aesiv, &private).unwrap();
+
+        assert_eq!(parsed_key, aes_key);
+        assert_eq!(parsed_iv, aes_iv);
+    }
+
+    #[test]
+    fn test_zeroization() {
+        // Verify keys are zeroized on drop
+        let key_ptr: *const u8;
+        {
+            let keys = RaopSessionKeys {
+                aes_key: [0x42; AES_KEY_SIZE],
+                aes_iv: [0x42; AES_IV_SIZE],
+                encrypted_key: vec![0x42; 128],
+            };
+            key_ptr = keys.aes_key.as_ptr();
+            // Keys dropped here
+        }
+
+        // In debug builds, memory might not be immediately reused
+        // This is a best-effort check
+    }
+}
+```
+
+---
+
+## Integration Tests
+
+### Test: Full authentication flow simulation
+
+```rust
+// tests/raop_auth_integration.rs
+
+use airplay2_rs::protocol::raop::{
+    RaopAuthenticator, AuthState,
+    generate_challenge, generate_response, verify_response,
+    RaopSessionKeys,
+};
+use airplay2_rs::protocol::crypto::rsa::RaopRsaPrivateKey;
+
+#[test]
+fn test_simulated_airplay1_auth() {
+    // Simulate client-server authentication
+
+    // Server has private key
+    let server_key = RaopRsaPrivateKey::generate().unwrap();
+    let server_ip: std::net::IpAddr = "192.168.1.50".parse().unwrap();
+    let server_mac = [0x00, 0x50, 0xC2, 0x12, 0xA2, 0x3F];
+
+    // Client generates challenge
+    let challenge = generate_challenge();
+
+    // Server generates response
+    let response = generate_response(
+        &server_key,
+        &challenge,
+        &server_ip,
+        &server_mac,
+    ).unwrap();
+
+    // In real scenario, client would verify with Apple's public key
+    // Here we verify with the test server's public key
+    let public = server_key.public_key();
+
+    use rsa::pkcs1v15::{Signature, VerifyingKey};
+    use rsa::signature::Verifier;
+    use sha1::Sha1;
+    use base64::Engine;
+
+    let sig_bytes = base64::engine::general_purpose::STANDARD_NO_PAD
+        .decode(&response).unwrap();
+    let verifying_key = VerifyingKey::<Sha1>::new(public);
+    let sig = Signature::try_from(sig_bytes.as_slice()).unwrap();
+
+    let message = airplay2_rs::protocol::raop::build_response_message(
+        &challenge,
+        &server_ip,
+        &server_mac,
+    );
+
+    verifying_key.verify(&message, &sig).unwrap();
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] RSA-OAEP encryption works for AES key wrapping
+- [ ] RSA-PKCS#1 v1.5 signatures verify correctly
+- [ ] Challenge-response protocol matches RAOP specification
+- [ ] Session keys are properly generated and encoded
+- [ ] Base64 encoding matches Apple's format (no padding)
+- [ ] Keys are zeroized on drop
+- [ ] Full authentication simulation passes
+- [ ] All unit tests pass
+- [ ] Integration tests pass
+
+---
+
+## Notes
+
+- The actual Apple RSA public key must be embedded for real authentication
+- Some RAOP receivers may use different RSA key sizes
+- FairPlay encryption is not supported (requires Apple DRM)
+- Consider adding timing-safe comparison for signature verification
+- Mock server testing requires generated key pairs
+
+## Cargo Dependencies
+
+Add to `Cargo.toml`:
+
+```toml
+[dependencies]
+rsa = "0.9"
+sha1 = "0.10"
+base64 = "0.22"
+```

--- a/docs/27-rtsp-raop-session.md
+++ b/docs/27-rtsp-raop-session.md
@@ -1,0 +1,1125 @@
+# Section 27: RTSP Session for RAOP
+
+## Dependencies
+- **Section 05**: RTSP Protocol (must be complete)
+- **Section 26**: RSA Authentication (must be complete)
+- **Section 25**: RAOP Discovery (recommended)
+
+## Overview
+
+AirPlay 1 uses RTSP (Real Time Streaming Protocol) for session control, similar to AirPlay 2 but with significant differences:
+
+- **SDP bodies** instead of binary plist for stream configuration
+- **Apple-Challenge/Response headers** for device authentication
+- **Different method sequence** (OPTIONS → ANNOUNCE → SETUP → RECORD)
+- **Legacy headers** (CSeq, Session, RTP-Info)
+
+This section extends the existing RTSP codec to support RAOP-specific requirements.
+
+## Objectives
+
+- Implement SDP (Session Description Protocol) parsing and generation
+- Add RAOP-specific RTSP headers
+- Implement RAOP session state machine
+- Support all RAOP RTSP methods
+- Handle audio format negotiation via SDP
+
+---
+
+## Tasks
+
+### 27.1 SDP Protocol Implementation
+
+- [ ] **27.1.1** Define SDP types and parser
+
+**File:** `src/protocol/sdp/mod.rs`
+
+```rust
+//! SDP (Session Description Protocol) for RAOP
+//!
+//! RAOP uses SDP in the ANNOUNCE request to describe the audio stream.
+
+mod parser;
+mod builder;
+
+pub use parser::{SdpParser, SdpParseError};
+pub use builder::SdpBuilder;
+
+use std::collections::HashMap;
+
+/// SDP session description
+#[derive(Debug, Clone, Default)]
+pub struct SessionDescription {
+    /// Protocol version (v=)
+    pub version: u8,
+    /// Origin (o=)
+    pub origin: Option<SdpOrigin>,
+    /// Session name (s=)
+    pub session_name: String,
+    /// Connection info (c=)
+    pub connection: Option<SdpConnection>,
+    /// Timing (t=)
+    pub timing: Option<(u64, u64)>,
+    /// Media descriptions (m=)
+    pub media: Vec<MediaDescription>,
+    /// Session-level attributes (a=)
+    pub attributes: HashMap<String, Option<String>>,
+}
+
+/// SDP origin field (o=)
+#[derive(Debug, Clone)]
+pub struct SdpOrigin {
+    /// Username
+    pub username: String,
+    /// Session ID
+    pub session_id: String,
+    /// Session version
+    pub session_version: String,
+    /// Network type (usually "IN")
+    pub net_type: String,
+    /// Address type (usually "IP4" or "IP6")
+    pub addr_type: String,
+    /// Unicast address
+    pub unicast_address: String,
+}
+
+/// SDP connection field (c=)
+#[derive(Debug, Clone)]
+pub struct SdpConnection {
+    /// Network type
+    pub net_type: String,
+    /// Address type
+    pub addr_type: String,
+    /// Connection address
+    pub address: String,
+}
+
+/// SDP media description (m=)
+#[derive(Debug, Clone)]
+pub struct MediaDescription {
+    /// Media type (audio, video, etc.)
+    pub media_type: String,
+    /// Port number
+    pub port: u16,
+    /// Protocol (RTP/AVP, etc.)
+    pub protocol: String,
+    /// Format list (payload types)
+    pub formats: Vec<String>,
+    /// Media-level attributes
+    pub attributes: HashMap<String, Option<String>>,
+}
+
+impl SessionDescription {
+    /// Get a session-level attribute
+    pub fn get_attribute(&self, name: &str) -> Option<&str> {
+        self.attributes.get(name)?.as_deref()
+    }
+
+    /// Get the audio media description
+    pub fn audio_media(&self) -> Option<&MediaDescription> {
+        self.media.iter().find(|m| m.media_type == "audio")
+    }
+
+    /// Get the rsaaeskey attribute (encrypted AES key)
+    pub fn rsaaeskey(&self) -> Option<&str> {
+        self.audio_media()?
+            .attributes
+            .get("rsaaeskey")?
+            .as_deref()
+            .or_else(|| self.get_attribute("rsaaeskey"))
+    }
+
+    /// Get the aesiv attribute (AES initialization vector)
+    pub fn aesiv(&self) -> Option<&str> {
+        self.audio_media()?
+            .attributes
+            .get("aesiv")?
+            .as_deref()
+            .or_else(|| self.get_attribute("aesiv"))
+    }
+
+    /// Get the fmtp attribute (format parameters)
+    pub fn fmtp(&self) -> Option<&str> {
+        self.audio_media()?
+            .attributes
+            .get("fmtp")?
+            .as_deref()
+    }
+
+    /// Get the rtpmap attribute
+    pub fn rtpmap(&self) -> Option<&str> {
+        self.audio_media()?
+            .attributes
+            .get("rtpmap")?
+            .as_deref()
+    }
+}
+
+impl MediaDescription {
+    /// Get a media-level attribute
+    pub fn get_attribute(&self, name: &str) -> Option<&str> {
+        self.attributes.get(name)?.as_deref()
+    }
+}
+```
+
+- [ ] **27.1.2** Implement SDP parser
+
+**File:** `src/protocol/sdp/parser.rs`
+
+```rust
+use super::*;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SdpParseError {
+    #[error("invalid version line")]
+    InvalidVersion,
+    #[error("invalid origin line: {0}")]
+    InvalidOrigin(String),
+    #[error("invalid connection line: {0}")]
+    InvalidConnection(String),
+    #[error("invalid media line: {0}")]
+    InvalidMedia(String),
+    #[error("invalid attribute: {0}")]
+    InvalidAttribute(String),
+    #[error("missing required field: {0}")]
+    MissingField(&'static str),
+}
+
+/// SDP parser
+pub struct SdpParser;
+
+impl SdpParser {
+    /// Parse SDP from string
+    pub fn parse(input: &str) -> Result<SessionDescription, SdpParseError> {
+        let mut sdp = SessionDescription::default();
+        let mut current_media: Option<MediaDescription> = None;
+
+        for line in input.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            if line.len() < 2 || line.chars().nth(1) != Some('=') {
+                continue;
+            }
+
+            let type_char = line.chars().next().unwrap();
+            let value = &line[2..];
+
+            match type_char {
+                'v' => {
+                    sdp.version = value.parse().map_err(|_| SdpParseError::InvalidVersion)?;
+                }
+                'o' => {
+                    sdp.origin = Some(Self::parse_origin(value)?);
+                }
+                's' => {
+                    sdp.session_name = value.to_string();
+                }
+                'c' => {
+                    let conn = Self::parse_connection(value)?;
+                    if current_media.is_some() {
+                        // Connection for current media
+                    } else {
+                        sdp.connection = Some(conn);
+                    }
+                }
+                't' => {
+                    let parts: Vec<&str> = value.split_whitespace().collect();
+                    if parts.len() >= 2 {
+                        sdp.timing = Some((
+                            parts[0].parse().unwrap_or(0),
+                            parts[1].parse().unwrap_or(0),
+                        ));
+                    }
+                }
+                'm' => {
+                    // Save previous media if any
+                    if let Some(media) = current_media.take() {
+                        sdp.media.push(media);
+                    }
+                    current_media = Some(Self::parse_media(value)?);
+                }
+                'a' => {
+                    let (name, value) = Self::parse_attribute(value)?;
+                    if let Some(ref mut media) = current_media {
+                        media.attributes.insert(name, value);
+                    } else {
+                        sdp.attributes.insert(name, value);
+                    }
+                }
+                _ => {
+                    // Ignore unknown lines
+                }
+            }
+        }
+
+        // Save last media
+        if let Some(media) = current_media {
+            sdp.media.push(media);
+        }
+
+        Ok(sdp)
+    }
+
+    fn parse_origin(value: &str) -> Result<SdpOrigin, SdpParseError> {
+        let parts: Vec<&str> = value.split_whitespace().collect();
+        if parts.len() < 6 {
+            return Err(SdpParseError::InvalidOrigin(value.to_string()));
+        }
+
+        Ok(SdpOrigin {
+            username: parts[0].to_string(),
+            session_id: parts[1].to_string(),
+            session_version: parts[2].to_string(),
+            net_type: parts[3].to_string(),
+            addr_type: parts[4].to_string(),
+            unicast_address: parts[5].to_string(),
+        })
+    }
+
+    fn parse_connection(value: &str) -> Result<SdpConnection, SdpParseError> {
+        let parts: Vec<&str> = value.split_whitespace().collect();
+        if parts.len() < 3 {
+            return Err(SdpParseError::InvalidConnection(value.to_string()));
+        }
+
+        Ok(SdpConnection {
+            net_type: parts[0].to_string(),
+            addr_type: parts[1].to_string(),
+            address: parts[2].to_string(),
+        })
+    }
+
+    fn parse_media(value: &str) -> Result<MediaDescription, SdpParseError> {
+        let parts: Vec<&str> = value.split_whitespace().collect();
+        if parts.len() < 4 {
+            return Err(SdpParseError::InvalidMedia(value.to_string()));
+        }
+
+        Ok(MediaDescription {
+            media_type: parts[0].to_string(),
+            port: parts[1].parse().unwrap_or(0),
+            protocol: parts[2].to_string(),
+            formats: parts[3..].iter().map(|s| s.to_string()).collect(),
+            attributes: HashMap::new(),
+        })
+    }
+
+    fn parse_attribute(value: &str) -> Result<(String, Option<String>), SdpParseError> {
+        if let Some(colon_pos) = value.find(':') {
+            let name = value[..colon_pos].to_string();
+            let attr_value = value[colon_pos + 1..].to_string();
+            Ok((name, Some(attr_value)))
+        } else {
+            Ok((value.to_string(), None))
+        }
+    }
+}
+```
+
+- [ ] **27.1.3** Implement SDP builder
+
+**File:** `src/protocol/sdp/builder.rs`
+
+```rust
+use super::*;
+
+/// Builder for SDP session descriptions
+pub struct SdpBuilder {
+    sdp: SessionDescription,
+    current_media: Option<MediaDescription>,
+}
+
+impl SdpBuilder {
+    /// Create a new SDP builder
+    pub fn new() -> Self {
+        Self {
+            sdp: SessionDescription {
+                version: 0,
+                ..Default::default()
+            },
+            current_media: None,
+        }
+    }
+
+    /// Set origin
+    pub fn origin(
+        mut self,
+        username: &str,
+        session_id: &str,
+        addr: &str,
+    ) -> Self {
+        self.sdp.origin = Some(SdpOrigin {
+            username: username.to_string(),
+            session_id: session_id.to_string(),
+            session_version: "1".to_string(),
+            net_type: "IN".to_string(),
+            addr_type: if addr.contains(':') { "IP6" } else { "IP4" }.to_string(),
+            unicast_address: addr.to_string(),
+        });
+        self
+    }
+
+    /// Set session name
+    pub fn session_name(mut self, name: &str) -> Self {
+        self.sdp.session_name = name.to_string();
+        self
+    }
+
+    /// Set connection info
+    pub fn connection(mut self, addr: &str) -> Self {
+        self.sdp.connection = Some(SdpConnection {
+            net_type: "IN".to_string(),
+            addr_type: if addr.contains(':') { "IP6" } else { "IP4" }.to_string(),
+            address: addr.to_string(),
+        });
+        self
+    }
+
+    /// Set timing (usually 0 0 for live streams)
+    pub fn timing(mut self, start: u64, stop: u64) -> Self {
+        self.sdp.timing = Some((start, stop));
+        self
+    }
+
+    /// Add session-level attribute
+    pub fn attribute(mut self, name: &str, value: Option<&str>) -> Self {
+        self.sdp.attributes.insert(
+            name.to_string(),
+            value.map(String::from),
+        );
+        self
+    }
+
+    /// Start a media section
+    pub fn media(
+        mut self,
+        media_type: &str,
+        port: u16,
+        protocol: &str,
+        formats: &[&str],
+    ) -> Self {
+        // Save previous media if any
+        if let Some(media) = self.current_media.take() {
+            self.sdp.media.push(media);
+        }
+
+        self.current_media = Some(MediaDescription {
+            media_type: media_type.to_string(),
+            port,
+            protocol: protocol.to_string(),
+            formats: formats.iter().map(|s| s.to_string()).collect(),
+            attributes: HashMap::new(),
+        });
+
+        self
+    }
+
+    /// Add media-level attribute
+    pub fn media_attribute(mut self, name: &str, value: Option<&str>) -> Self {
+        if let Some(ref mut media) = self.current_media {
+            media.attributes.insert(
+                name.to_string(),
+                value.map(String::from),
+            );
+        }
+        self
+    }
+
+    /// Build the SDP
+    pub fn build(mut self) -> SessionDescription {
+        // Save last media
+        if let Some(media) = self.current_media.take() {
+            self.sdp.media.push(media);
+        }
+        self.sdp
+    }
+
+    /// Build and encode as string
+    pub fn encode(self) -> String {
+        let sdp = self.build();
+        encode_sdp(&sdp)
+    }
+}
+
+/// Encode SDP to string format
+pub fn encode_sdp(sdp: &SessionDescription) -> String {
+    let mut output = String::new();
+
+    // Version
+    output.push_str(&format!("v={}\r\n", sdp.version));
+
+    // Origin
+    if let Some(ref o) = sdp.origin {
+        output.push_str(&format!(
+            "o={} {} {} {} {} {}\r\n",
+            o.username, o.session_id, o.session_version,
+            o.net_type, o.addr_type, o.unicast_address
+        ));
+    }
+
+    // Session name
+    output.push_str(&format!("s={}\r\n", sdp.session_name));
+
+    // Connection
+    if let Some(ref c) = sdp.connection {
+        output.push_str(&format!(
+            "c={} {} {}\r\n",
+            c.net_type, c.addr_type, c.address
+        ));
+    }
+
+    // Timing
+    if let Some((start, stop)) = sdp.timing {
+        output.push_str(&format!("t={} {}\r\n", start, stop));
+    }
+
+    // Session attributes
+    for (name, value) in &sdp.attributes {
+        if let Some(v) = value {
+            output.push_str(&format!("a={}:{}\r\n", name, v));
+        } else {
+            output.push_str(&format!("a={}\r\n", name));
+        }
+    }
+
+    // Media sections
+    for media in &sdp.media {
+        output.push_str(&format!(
+            "m={} {} {} {}\r\n",
+            media.media_type,
+            media.port,
+            media.protocol,
+            media.formats.join(" ")
+        ));
+
+        for (name, value) in &media.attributes {
+            if let Some(v) = value {
+                output.push_str(&format!("a={}:{}\r\n", name, v));
+            } else {
+                output.push_str(&format!("a={}\r\n", name));
+            }
+        }
+    }
+
+    output
+}
+
+/// Create RAOP ANNOUNCE SDP for Apple Lossless audio
+pub fn create_raop_announce_sdp(
+    session_id: &str,
+    client_ip: &str,
+    server_ip: &str,
+    rsaaeskey: &str,
+    aesiv: &str,
+) -> String {
+    SdpBuilder::new()
+        .origin("iTunes", session_id, client_ip)
+        .session_name("iTunes")
+        .connection(server_ip)
+        .timing(0, 0)
+        .media("audio", 0, "RTP/AVP", &["96"])
+        .media_attribute("rtpmap", Some("96 AppleLossless"))
+        .media_attribute("fmtp", Some("96 352 0 16 40 10 14 2 255 0 0 44100"))
+        .media_attribute("rsaaeskey", Some(rsaaeskey))
+        .media_attribute("aesiv", Some(aesiv))
+        .media_attribute("min-latency", Some("11025"))
+        .encode()
+}
+```
+
+---
+
+### 27.2 RAOP RTSP Extensions
+
+- [ ] **27.2.1** Add RAOP-specific headers
+
+**File:** `src/protocol/rtsp/headers.rs` (additions)
+
+```rust
+// Add to existing headers module:
+
+/// RAOP-specific header names
+pub mod raop {
+    /// Apple challenge for authentication
+    pub const APPLE_CHALLENGE: &str = "Apple-Challenge";
+    /// Apple response to challenge
+    pub const APPLE_RESPONSE: &str = "Apple-Response";
+    /// Audio latency in samples
+    pub const AUDIO_LATENCY: &str = "Audio-Latency";
+    /// Audio jack status
+    pub const AUDIO_JACK_STATUS: &str = "Audio-Jack-Status";
+    /// Client instance ID
+    pub const CLIENT_INSTANCE: &str = "Client-Instance";
+    /// DACP ID for remote control
+    pub const DACP_ID: &str = "DACP-ID";
+    /// Active remote token
+    pub const ACTIVE_REMOTE: &str = "Active-Remote";
+    /// Server info header
+    pub const SERVER: &str = "Server";
+    /// Range header for RECORD
+    pub const RANGE: &str = "Range";
+}
+```
+
+- [ ] **27.2.2** Implement RAOP RTSP session
+
+**File:** `src/protocol/raop/session.rs`
+
+```rust
+//! RAOP RTSP session management
+
+use crate::protocol::rtsp::{
+    Method, RtspRequest, RtspRequestBuilder, RtspResponse,
+    Headers, headers::names, headers::raop,
+};
+use super::auth::RaopAuthenticator;
+use super::key_exchange::RaopSessionKeys;
+
+/// RAOP session states
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RaopSessionState {
+    /// Initial state
+    Init,
+    /// OPTIONS sent, checking authentication
+    OptionsExchange,
+    /// ANNOUNCE sent with stream params
+    Announcing,
+    /// SETUP sent, configuring transport
+    SettingUp,
+    /// RECORD sent, streaming
+    Recording,
+    /// Paused (FLUSH sent)
+    Paused,
+    /// Session terminated
+    Terminated,
+}
+
+/// Transport configuration from SETUP
+#[derive(Debug, Clone)]
+pub struct RaopTransport {
+    /// Server audio data port
+    pub server_port: u16,
+    /// Server control port
+    pub control_port: u16,
+    /// Server timing port
+    pub timing_port: u16,
+    /// Client control port
+    pub client_control_port: u16,
+    /// Client timing port
+    pub client_timing_port: u16,
+}
+
+/// RAOP RTSP session manager
+pub struct RaopRtspSession {
+    /// Current state
+    state: RaopSessionState,
+    /// CSeq counter
+    cseq: u32,
+    /// Server session ID
+    session_id: Option<String>,
+    /// Client instance ID (64-bit hex)
+    client_instance: String,
+    /// DACP ID for remote control
+    dacp_id: String,
+    /// Active remote token
+    active_remote: String,
+    /// Server address
+    server_addr: String,
+    /// Server port
+    server_port: u16,
+    /// Authentication state
+    authenticator: RaopAuthenticator,
+    /// Session encryption keys
+    session_keys: Option<RaopSessionKeys>,
+    /// Transport configuration
+    transport: Option<RaopTransport>,
+    /// Audio latency (samples)
+    audio_latency: u32,
+}
+
+impl RaopRtspSession {
+    /// Create a new RAOP session
+    pub fn new(server_addr: &str, server_port: u16) -> Self {
+        use rand::Rng;
+
+        let mut rng = rand::thread_rng();
+
+        Self {
+            state: RaopSessionState::Init,
+            cseq: 0,
+            session_id: None,
+            client_instance: format!("{:016X}", rng.gen::<u64>()),
+            dacp_id: format!("{:016X}", rng.gen::<u64>()),
+            active_remote: rng.gen::<u32>().to_string(),
+            server_addr: server_addr.to_string(),
+            server_port,
+            authenticator: RaopAuthenticator::new(),
+            session_keys: None,
+            transport: None,
+            audio_latency: 11025, // Default ~250ms at 44.1kHz
+        }
+    }
+
+    /// Get current state
+    pub fn state(&self) -> RaopSessionState {
+        self.state
+    }
+
+    /// Get transport configuration
+    pub fn transport(&self) -> Option<&RaopTransport> {
+        self.transport.as_ref()
+    }
+
+    /// Get session keys
+    pub fn session_keys(&self) -> Option<&RaopSessionKeys> {
+        self.session_keys.as_ref()
+    }
+
+    /// Get next CSeq
+    fn next_cseq(&mut self) -> u32 {
+        self.cseq += 1;
+        self.cseq
+    }
+
+    /// Get base URI
+    fn uri(&self, path: &str) -> String {
+        if path.is_empty() {
+            format!("rtsp://{}:{}/{}", self.server_addr, self.server_port, self.client_instance)
+        } else {
+            format!("rtsp://{}:{}/{}", self.server_addr, self.server_port, path)
+        }
+    }
+
+    /// Add common headers to request
+    fn add_common_headers(&self, builder: RtspRequestBuilder, cseq: u32) -> RtspRequestBuilder {
+        let mut b = builder
+            .cseq(cseq)
+            .header(names::USER_AGENT, "iTunes/12.0 (Macintosh)")
+            .header(raop::CLIENT_INSTANCE, &self.client_instance)
+            .header(raop::DACP_ID, &self.dacp_id)
+            .header(raop::ACTIVE_REMOTE, &self.active_remote);
+
+        if let Some(ref session) = self.session_id {
+            b = b.session(session);
+        }
+
+        b
+    }
+
+    /// Create OPTIONS request
+    pub fn options_request(&mut self) -> RtspRequest {
+        let cseq = self.next_cseq();
+        let builder = RtspRequest::builder(Method::Options, self.uri("*"));
+
+        self.add_common_headers(builder, cseq)
+            .header(raop::APPLE_CHALLENGE, self.authenticator.challenge_header())
+            .build()
+    }
+
+    /// Create ANNOUNCE request with SDP
+    pub fn announce_request(&mut self, sdp: &str) -> RtspRequest {
+        let cseq = self.next_cseq();
+        let builder = RtspRequest::builder(Method::Announce, self.uri(""));
+
+        self.add_common_headers(builder, cseq)
+            .header(names::CONTENT_TYPE, "application/sdp")
+            .body(sdp.as_bytes().to_vec())
+            .build()
+    }
+
+    /// Create SETUP request
+    pub fn setup_request(
+        &mut self,
+        control_port: u16,
+        timing_port: u16,
+    ) -> RtspRequest {
+        let cseq = self.next_cseq();
+        let builder = RtspRequest::builder(Method::Setup, self.uri(""));
+
+        let transport = format!(
+            "RTP/AVP/UDP;unicast;interleaved=0-1;mode=record;control_port={};timing_port={}",
+            control_port, timing_port
+        );
+
+        self.add_common_headers(builder, cseq)
+            .header(names::TRANSPORT, &transport)
+            .build()
+    }
+
+    /// Create RECORD request
+    pub fn record_request(&mut self, seq: u16, rtptime: u32) -> RtspRequest {
+        let cseq = self.next_cseq();
+        let builder = RtspRequest::builder(Method::Record, self.uri(""));
+
+        self.add_common_headers(builder, cseq)
+            .header(raop::RANGE, "npt=0-")
+            .header("RTP-Info", format!("seq={};rtptime={}", seq, rtptime))
+            .build()
+    }
+
+    /// Create SET_PARAMETER request for volume
+    pub fn set_volume_request(&mut self, volume_db: f32) -> RtspRequest {
+        let cseq = self.next_cseq();
+        let builder = RtspRequest::builder(Method::SetParameter, self.uri(""));
+
+        let body = format!("volume: {:.6}\r\n", volume_db);
+
+        self.add_common_headers(builder, cseq)
+            .header(names::CONTENT_TYPE, "text/parameters")
+            .body(body.into_bytes())
+            .build()
+    }
+
+    /// Create SET_PARAMETER request for progress
+    pub fn set_progress_request(
+        &mut self,
+        start: u32,
+        current: u32,
+        end: u32,
+    ) -> RtspRequest {
+        let cseq = self.next_cseq();
+        let builder = RtspRequest::builder(Method::SetParameter, self.uri(""));
+
+        let body = format!("progress: {}/{}/{}\r\n", start, current, end);
+
+        self.add_common_headers(builder, cseq)
+            .header(names::CONTENT_TYPE, "text/parameters")
+            .body(body.into_bytes())
+            .build()
+    }
+
+    /// Create FLUSH request
+    pub fn flush_request(&mut self, seq: u16, rtptime: u32) -> RtspRequest {
+        let cseq = self.next_cseq();
+        let builder = RtspRequest::builder(Method::Flush, self.uri(""));
+
+        self.add_common_headers(builder, cseq)
+            .header("RTP-Info", format!("seq={};rtptime={}", seq, rtptime))
+            .build()
+    }
+
+    /// Create TEARDOWN request
+    pub fn teardown_request(&mut self) -> RtspRequest {
+        let cseq = self.next_cseq();
+        let builder = RtspRequest::builder(Method::Teardown, self.uri(""));
+
+        self.add_common_headers(builder, cseq).build()
+    }
+
+    /// Process response and update state
+    pub fn process_response(
+        &mut self,
+        method: Method,
+        response: &RtspResponse,
+    ) -> Result<(), String> {
+        if !response.is_success() {
+            return Err(format!(
+                "{} failed: {} {}",
+                method.as_str(),
+                response.status.as_u16(),
+                response.reason
+            ));
+        }
+
+        // Extract session ID
+        if let Some(session) = response.session() {
+            let session_id = session.split(';').next().unwrap_or(session);
+            self.session_id = Some(session_id.to_string());
+        }
+
+        match method {
+            Method::Options => {
+                // Verify Apple-Response if present
+                if let Some(apple_response) = response.headers.get(raop::APPLE_RESPONSE) {
+                    // TODO: Verify with known server parameters
+                    // For now, accept any response
+                }
+                self.authenticator.mark_sent();
+                self.state = RaopSessionState::OptionsExchange;
+            }
+            Method::Announce => {
+                self.state = RaopSessionState::Announcing;
+            }
+            Method::Setup => {
+                // Parse transport response
+                if let Some(transport) = response.headers.get(names::TRANSPORT) {
+                    self.transport = Some(Self::parse_transport(transport)?);
+                }
+                // Extract audio latency
+                if let Some(latency) = response.headers.get(raop::AUDIO_LATENCY) {
+                    self.audio_latency = latency.parse().unwrap_or(11025);
+                }
+                self.state = RaopSessionState::SettingUp;
+            }
+            Method::Record => {
+                self.state = RaopSessionState::Recording;
+            }
+            Method::Flush => {
+                self.state = RaopSessionState::Paused;
+            }
+            Method::Teardown => {
+                self.state = RaopSessionState::Terminated;
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+
+    fn parse_transport(transport: &str) -> Result<RaopTransport, String> {
+        // Parse transport header like:
+        // RTP/AVP/UDP;unicast;mode=record;server_port=6000;control_port=6001;timing_port=6002
+
+        let mut server_port = 0u16;
+        let mut control_port = 0u16;
+        let mut timing_port = 0u16;
+
+        for part in transport.split(';') {
+            let part = part.trim();
+            if let Some((key, value)) = part.split_once('=') {
+                match key {
+                    "server_port" => server_port = value.parse().unwrap_or(0),
+                    "control_port" => control_port = value.parse().unwrap_or(0),
+                    "timing_port" => timing_port = value.parse().unwrap_or(0),
+                    _ => {}
+                }
+            }
+        }
+
+        if server_port == 0 {
+            return Err("missing server_port in transport".to_string());
+        }
+
+        Ok(RaopTransport {
+            server_port,
+            control_port,
+            timing_port,
+            client_control_port: 0, // Set by caller
+            client_timing_port: 0,
+        })
+    }
+
+    /// Generate session keys and prepare ANNOUNCE
+    pub fn prepare_announce(&mut self) -> Result<String, String> {
+        let keys = RaopSessionKeys::generate()
+            .map_err(|e| e.to_string())?;
+
+        let sdp = crate::protocol::sdp::create_raop_announce_sdp(
+            &self.client_instance,
+            "0.0.0.0", // Will be filled by actual client IP
+            &self.server_addr,
+            &keys.rsaaeskey(),
+            &keys.aesiv(),
+        );
+
+        self.session_keys = Some(keys);
+        Ok(sdp)
+    }
+}
+```
+
+---
+
+## Unit Tests
+
+### Test File: `src/protocol/sdp/parser.rs`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_basic_sdp() {
+        let sdp_text = r#"v=0
+o=iTunes 1234567890 1 IN IP4 192.168.1.100
+s=iTunes
+c=IN IP4 192.168.1.50
+t=0 0
+m=audio 0 RTP/AVP 96
+a=rtpmap:96 AppleLossless
+a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100
+"#;
+
+        let sdp = SdpParser::parse(sdp_text).unwrap();
+
+        assert_eq!(sdp.version, 0);
+        assert_eq!(sdp.session_name, "iTunes");
+        assert_eq!(sdp.media.len(), 1);
+
+        let audio = sdp.audio_media().unwrap();
+        assert_eq!(audio.media_type, "audio");
+        assert_eq!(audio.protocol, "RTP/AVP");
+    }
+
+    #[test]
+    fn test_parse_raop_announce() {
+        let sdp_text = r#"v=0
+o=iTunes 3413821438 1 IN IP4 fe80::217:f2ff:fe0f:e0f6
+s=iTunes
+c=IN IP4 fe80::5a55:caff:fe1a:e288
+t=0 0
+m=audio 0 RTP/AVP 96
+a=rtpmap:96 AppleLossless
+a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100
+a=rsaaeskey:ABCDEF123456
+a=aesiv:0011223344556677
+a=min-latency:11025
+"#;
+
+        let sdp = SdpParser::parse(sdp_text).unwrap();
+
+        assert_eq!(sdp.rsaaeskey(), Some("ABCDEF123456"));
+        assert_eq!(sdp.aesiv(), Some("0011223344556677"));
+        assert_eq!(sdp.fmtp(), Some("96 352 0 16 40 10 14 2 255 0 0 44100"));
+    }
+
+    #[test]
+    fn test_parse_origin() {
+        let sdp_text = "v=0\no=user 123 1 IN IP4 192.168.1.1\ns=test\n";
+        let sdp = SdpParser::parse(sdp_text).unwrap();
+
+        let origin = sdp.origin.unwrap();
+        assert_eq!(origin.username, "user");
+        assert_eq!(origin.session_id, "123");
+        assert_eq!(origin.addr_type, "IP4");
+    }
+}
+```
+
+### Test File: `src/protocol/raop/session.rs`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_creation() {
+        let session = RaopRtspSession::new("192.168.1.50", 5000);
+
+        assert_eq!(session.state(), RaopSessionState::Init);
+        assert!(session.session_id.is_none());
+        assert!(!session.client_instance.is_empty());
+    }
+
+    #[test]
+    fn test_options_request() {
+        let mut session = RaopRtspSession::new("192.168.1.50", 5000);
+        let request = session.options_request();
+
+        assert_eq!(request.method, Method::Options);
+        assert!(request.headers.get("Apple-Challenge").is_some());
+        assert!(request.headers.get("CSeq").is_some());
+        assert!(request.headers.get("Client-Instance").is_some());
+    }
+
+    #[test]
+    fn test_setup_request() {
+        let mut session = RaopRtspSession::new("192.168.1.50", 5000);
+        let request = session.setup_request(6001, 6002);
+
+        assert_eq!(request.method, Method::Setup);
+        let transport = request.headers.get("Transport").unwrap();
+        assert!(transport.contains("control_port=6001"));
+        assert!(transport.contains("timing_port=6002"));
+    }
+
+    #[test]
+    fn test_transport_parsing() {
+        let transport_str = "RTP/AVP/UDP;unicast;mode=record;server_port=6000;control_port=6001;timing_port=6002";
+        let transport = RaopRtspSession::parse_transport(transport_str).unwrap();
+
+        assert_eq!(transport.server_port, 6000);
+        assert_eq!(transport.control_port, 6001);
+        assert_eq!(transport.timing_port, 6002);
+    }
+
+    #[test]
+    fn test_volume_request() {
+        let mut session = RaopRtspSession::new("192.168.1.50", 5000);
+        let request = session.set_volume_request(-15.0);
+
+        assert_eq!(request.method, Method::SetParameter);
+        let body = String::from_utf8_lossy(&request.body);
+        assert!(body.contains("volume:"));
+        assert!(body.contains("-15"));
+    }
+}
+```
+
+---
+
+## Integration Tests
+
+### Test: Full RAOP RTSP session flow
+
+```rust
+// tests/raop_rtsp_integration.rs
+
+use airplay2_rs::protocol::raop::{RaopRtspSession, RaopSessionState};
+use airplay2_rs::protocol::rtsp::{Method, RtspResponse, StatusCode, Headers};
+
+#[test]
+fn test_full_session_flow() {
+    let mut session = RaopRtspSession::new("192.168.1.50", 5000);
+
+    // 1. OPTIONS
+    let options = session.options_request();
+    assert_eq!(options.method, Method::Options);
+
+    // Simulate successful response
+    let mut headers = Headers::new();
+    headers.insert("CSeq", "1");
+    headers.insert("Public", "ANNOUNCE, SETUP, RECORD, PAUSE, FLUSH, TEARDOWN");
+
+    let response = RtspResponse {
+        version: "RTSP/1.0".to_string(),
+        status: StatusCode::OK,
+        reason: "OK".to_string(),
+        headers,
+        body: Vec::new(),
+    };
+
+    session.process_response(Method::Options, &response).unwrap();
+    assert_eq!(session.state(), RaopSessionState::OptionsExchange);
+
+    // 2. ANNOUNCE
+    let sdp = session.prepare_announce().unwrap();
+    let announce = session.announce_request(&sdp);
+    assert_eq!(announce.method, Method::Announce);
+    assert!(!announce.body.is_empty());
+
+    // ... continue flow
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] SDP parsing handles all RAOP fields correctly
+- [ ] SDP generation produces valid output
+- [ ] RAOP session state machine transitions correctly
+- [ ] All RAOP RTSP methods are implemented
+- [ ] Apple-Challenge header is included in OPTIONS
+- [ ] Transport header parsing extracts all ports
+- [ ] Volume control uses correct dB format
+- [ ] Session keys are generated and encoded correctly
+- [ ] All unit tests pass
+- [ ] Integration tests pass
+
+---
+
+## Notes
+
+- SDP parser should be lenient with whitespace variations
+- Some devices may have non-standard SDP attributes
+- Transport response format may vary between implementations
+- Consider adding support for AAC codec SDP format
+- Debug logging should show full request/response for protocol debugging

--- a/docs/28-rtp-raop-streaming.md
+++ b/docs/28-rtp-raop-streaming.md
@@ -1,0 +1,1038 @@
+# Section 28: RTP Audio Streaming for RAOP
+
+## Dependencies
+- **Section 06**: RTP/RAOP Protocol (must be complete)
+- **Section 27**: RTSP Session for RAOP (must be complete)
+- **Section 29**: RAOP Audio Encryption (recommended)
+
+## Overview
+
+RAOP uses RTP (Real-time Transport Protocol) for audio data transmission over UDP. Unlike standard RTP, RAOP includes Apple-specific extensions for synchronization, retransmission, and timing. Three UDP channels are used:
+
+1. **Audio Channel**: Encrypted audio packets
+2. **Control Channel**: Sync packets and retransmission requests
+3. **Timing Channel**: NTP-style clock synchronization
+
+## Objectives
+
+- Extend RTP packet types for RAOP-specific formats
+- Implement sync packet generation and parsing
+- Implement timing protocol (NTP-style)
+- Handle retransmission requests and responses
+- Support packet loss detection and recovery
+
+---
+
+## Tasks
+
+### 28.1 RAOP RTP Packet Types
+
+- [ ] **28.1.1** Define RAOP-specific RTP payload types
+
+**File:** `src/protocol/rtp/raop.rs`
+
+```rust
+//! RAOP-specific RTP packet types
+
+use super::packet::{RtpHeader, RtpDecodeError};
+use super::timing::NtpTimestamp;
+
+/// RAOP RTP payload types
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum RaopPayloadType {
+    /// Timing request (client -> server)
+    TimingRequest = 0x52,
+    /// Timing response (server -> client)
+    TimingResponse = 0x53,
+    /// Sync packet (server -> client on control channel)
+    Sync = 0x54,
+    /// Retransmit request (server -> client on control channel)
+    RetransmitRequest = 0x55,
+    /// Retransmit response (client -> server, audio data)
+    RetransmitResponse = 0x56,
+    /// Audio data (realtime mode)
+    AudioRealtime = 0x60,
+    /// Audio data (buffered mode)
+    AudioBuffered = 0x61,
+}
+
+impl RaopPayloadType {
+    /// Parse from byte value
+    pub fn from_byte(b: u8) -> Option<Self> {
+        match b & 0x7F {
+            0x52 => Some(Self::TimingRequest),
+            0x53 => Some(Self::TimingResponse),
+            0x54 => Some(Self::Sync),
+            0x55 => Some(Self::RetransmitRequest),
+            0x56 => Some(Self::RetransmitResponse),
+            0x60 => Some(Self::AudioRealtime),
+            0x61 => Some(Self::AudioBuffered),
+            _ => None,
+        }
+    }
+
+    /// Check if this is an audio payload type
+    pub fn is_audio(&self) -> bool {
+        matches!(self, Self::AudioRealtime | Self::AudioBuffered | Self::RetransmitResponse)
+    }
+}
+
+/// RAOP sync packet (sent on control channel)
+///
+/// Provides synchronization between RTP timestamps and wall clock time.
+#[derive(Debug, Clone)]
+pub struct SyncPacket {
+    /// Extension flag (set on first sync after RECORD/FLUSH)
+    pub extension: bool,
+    /// Current RTP timestamp being played
+    pub rtp_timestamp: u32,
+    /// Current NTP time
+    pub ntp_time: NtpTimestamp,
+    /// RTP timestamp of next audio packet
+    pub next_timestamp: u32,
+}
+
+impl SyncPacket {
+    /// Sync packet size (8-byte header + 4 + 8 + 4 = 24 bytes)
+    pub const SIZE: usize = 20;
+
+    /// Create a new sync packet
+    pub fn new(
+        rtp_timestamp: u32,
+        ntp_time: NtpTimestamp,
+        next_timestamp: u32,
+        is_first: bool,
+    ) -> Self {
+        Self {
+            extension: is_first,
+            rtp_timestamp,
+            ntp_time,
+            next_timestamp,
+        }
+    }
+
+    /// Encode to bytes
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(Self::SIZE);
+
+        // RTP header (without SSRC)
+        let flags = 0x80 | if self.extension { 0x10 } else { 0x00 };
+        buf.push(flags);
+        buf.push(0xD4); // Marker + PT=0x54
+
+        // Sequence number (unused, set to 0x0007)
+        buf.extend_from_slice(&0x0007u16.to_be_bytes());
+
+        // RTP timestamp being played
+        buf.extend_from_slice(&self.rtp_timestamp.to_be_bytes());
+
+        // NTP timestamp (8 bytes)
+        buf.extend_from_slice(&self.ntp_time.encode());
+
+        // Next RTP timestamp
+        buf.extend_from_slice(&self.next_timestamp.to_be_bytes());
+
+        buf
+    }
+
+    /// Decode from bytes
+    pub fn decode(buf: &[u8]) -> Result<Self, RtpDecodeError> {
+        if buf.len() < Self::SIZE {
+            return Err(RtpDecodeError::BufferTooSmall {
+                needed: Self::SIZE,
+                have: buf.len(),
+            });
+        }
+
+        let extension = (buf[0] & 0x10) != 0;
+        let rtp_timestamp = u32::from_be_bytes([buf[4], buf[5], buf[6], buf[7]]);
+        let ntp_time = NtpTimestamp::decode(&buf[8..16]);
+        let next_timestamp = u32::from_be_bytes([buf[16], buf[17], buf[18], buf[19]]);
+
+        Ok(Self {
+            extension,
+            rtp_timestamp,
+            ntp_time,
+            next_timestamp,
+        })
+    }
+}
+
+/// Retransmit request packet
+#[derive(Debug, Clone)]
+pub struct RetransmitRequest {
+    /// First sequence number to retransmit
+    pub seq_start: u16,
+    /// Number of packets to retransmit
+    pub count: u16,
+}
+
+impl RetransmitRequest {
+    /// Packet size
+    pub const SIZE: usize = 8;
+
+    /// Decode from bytes (after 8-byte header)
+    pub fn decode(buf: &[u8]) -> Result<Self, RtpDecodeError> {
+        if buf.len() < 4 {
+            return Err(RtpDecodeError::BufferTooSmall {
+                needed: 4,
+                have: buf.len(),
+            });
+        }
+
+        Ok(Self {
+            seq_start: u16::from_be_bytes([buf[0], buf[1]]),
+            count: u16::from_be_bytes([buf[2], buf[3]]),
+        })
+    }
+}
+
+/// RAOP audio packet with header
+#[derive(Debug, Clone)]
+pub struct RaopAudioPacket {
+    /// Marker bit (set on first packet after RECORD/FLUSH)
+    pub marker: bool,
+    /// Sequence number
+    pub sequence: u16,
+    /// RTP timestamp
+    pub timestamp: u32,
+    /// SSRC
+    pub ssrc: u32,
+    /// Audio payload (encrypted)
+    pub payload: Vec<u8>,
+}
+
+impl RaopAudioPacket {
+    /// RTP header size
+    pub const HEADER_SIZE: usize = 12;
+
+    /// Create a new audio packet
+    pub fn new(sequence: u16, timestamp: u32, ssrc: u32, payload: Vec<u8>) -> Self {
+        Self {
+            marker: false,
+            sequence,
+            timestamp,
+            ssrc,
+            payload,
+        }
+    }
+
+    /// Set marker bit (first packet after RECORD/FLUSH)
+    pub fn with_marker(mut self) -> Self {
+        self.marker = true;
+        self
+    }
+
+    /// Encode to bytes
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(Self::HEADER_SIZE + self.payload.len());
+
+        // RTP header
+        buf.push(0x80); // V=2, P=0, X=0, CC=0
+        buf.push(0x60 | if self.marker { 0x80 } else { 0x00 }); // PT=0x60, M bit
+
+        buf.extend_from_slice(&self.sequence.to_be_bytes());
+        buf.extend_from_slice(&self.timestamp.to_be_bytes());
+        buf.extend_from_slice(&self.ssrc.to_be_bytes());
+
+        // Payload
+        buf.extend_from_slice(&self.payload);
+
+        buf
+    }
+
+    /// Decode from bytes
+    pub fn decode(buf: &[u8]) -> Result<Self, RtpDecodeError> {
+        if buf.len() < Self::HEADER_SIZE {
+            return Err(RtpDecodeError::BufferTooSmall {
+                needed: Self::HEADER_SIZE,
+                have: buf.len(),
+            });
+        }
+
+        let marker = (buf[1] & 0x80) != 0;
+        let sequence = u16::from_be_bytes([buf[2], buf[3]]);
+        let timestamp = u32::from_be_bytes([buf[4], buf[5], buf[6], buf[7]]);
+        let ssrc = u32::from_be_bytes([buf[8], buf[9], buf[10], buf[11]]);
+        let payload = buf[Self::HEADER_SIZE..].to_vec();
+
+        Ok(Self {
+            marker,
+            sequence,
+            timestamp,
+            ssrc,
+            payload,
+        })
+    }
+}
+```
+
+---
+
+### 28.2 Timing Protocol
+
+- [ ] **28.2.1** Implement NTP-style timing exchange
+
+**File:** `src/protocol/rtp/raop_timing.rs`
+
+```rust
+//! RAOP timing protocol implementation
+
+use super::timing::NtpTimestamp;
+use super::packet::RtpDecodeError;
+
+/// Timing request packet (sent every 3 seconds)
+#[derive(Debug, Clone)]
+pub struct RaopTimingRequest {
+    /// Reference time (when we sent this request)
+    pub reference_time: NtpTimestamp,
+}
+
+impl RaopTimingRequest {
+    /// Packet size
+    pub const SIZE: usize = 32;
+
+    /// Create new timing request
+    pub fn new() -> Self {
+        Self {
+            reference_time: NtpTimestamp::now(),
+        }
+    }
+
+    /// Encode to bytes
+    pub fn encode(&self, sequence: u16) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(Self::SIZE);
+
+        // RTP header (no SSRC)
+        buf.push(0x80); // V=2
+        buf.push(0xD2); // M=1, PT=0x52
+
+        buf.extend_from_slice(&sequence.to_be_bytes());
+        buf.extend_from_slice(&0u32.to_be_bytes()); // Timestamp (unused)
+
+        // Padding (4 bytes)
+        buf.extend_from_slice(&[0u8; 4]);
+
+        // Reference time
+        buf.extend_from_slice(&self.reference_time.encode());
+
+        // Receive time (0 for request)
+        buf.extend_from_slice(&[0u8; 8]);
+
+        // Send time (same as reference for request)
+        buf.extend_from_slice(&self.reference_time.encode());
+
+        buf
+    }
+}
+
+/// Timing response packet (from server)
+#[derive(Debug, Clone)]
+pub struct RaopTimingResponse {
+    /// Original reference time (from our request)
+    pub reference_time: NtpTimestamp,
+    /// Time server received our request
+    pub receive_time: NtpTimestamp,
+    /// Time server sent this response
+    pub send_time: NtpTimestamp,
+}
+
+impl RaopTimingResponse {
+    /// Decode from bytes
+    pub fn decode(buf: &[u8]) -> Result<Self, RtpDecodeError> {
+        if buf.len() < 32 {
+            return Err(RtpDecodeError::BufferTooSmall {
+                needed: 32,
+                have: buf.len(),
+            });
+        }
+
+        // Skip header (8 bytes)
+        let reference_time = NtpTimestamp::decode(&buf[8..16]);
+        let receive_time = NtpTimestamp::decode(&buf[16..24]);
+        let send_time = NtpTimestamp::decode(&buf[24..32]);
+
+        Ok(Self {
+            reference_time,
+            receive_time,
+            send_time,
+        })
+    }
+
+    /// Calculate clock offset (microseconds)
+    ///
+    /// offset = ((T2 - T1) + (T3 - T4)) / 2
+    pub fn calculate_offset(&self, client_receive: NtpTimestamp) -> i64 {
+        let t1 = self.reference_time.to_micros() as i64;
+        let t2 = self.receive_time.to_micros() as i64;
+        let t3 = self.send_time.to_micros() as i64;
+        let t4 = client_receive.to_micros() as i64;
+
+        ((t2 - t1) + (t3 - t4)) / 2
+    }
+
+    /// Calculate round-trip time (microseconds)
+    ///
+    /// RTT = (T4 - T1) - (T3 - T2)
+    pub fn calculate_rtt(&self, client_receive: NtpTimestamp) -> u64 {
+        let t1 = self.reference_time.to_micros();
+        let t2 = self.receive_time.to_micros();
+        let t3 = self.send_time.to_micros();
+        let t4 = client_receive.to_micros();
+
+        (t4 - t1).saturating_sub(t3 - t2)
+    }
+}
+
+/// Timing synchronization manager
+pub struct TimingSync {
+    /// Sequence number for timing packets
+    sequence: u16,
+    /// Current clock offset (microseconds)
+    offset: i64,
+    /// Current RTT (microseconds)
+    rtt: u64,
+    /// Number of samples for averaging
+    sample_count: u32,
+    /// Last timing request sent
+    last_request: Option<RaopTimingRequest>,
+}
+
+impl TimingSync {
+    /// Create new timing sync manager
+    pub fn new() -> Self {
+        Self {
+            sequence: 0,
+            offset: 0,
+            rtt: 0,
+            sample_count: 0,
+            last_request: None,
+        }
+    }
+
+    /// Get current clock offset
+    pub fn offset(&self) -> i64 {
+        self.offset
+    }
+
+    /// Get current RTT
+    pub fn rtt(&self) -> u64 {
+        self.rtt
+    }
+
+    /// Create a timing request packet
+    pub fn create_request(&mut self) -> Vec<u8> {
+        let request = RaopTimingRequest::new();
+        let data = request.encode(self.sequence);
+        self.sequence = self.sequence.wrapping_add(1);
+        self.last_request = Some(request);
+        data
+    }
+
+    /// Process timing response
+    pub fn process_response(&mut self, data: &[u8]) -> Result<(), RtpDecodeError> {
+        let response = RaopTimingResponse::decode(data)?;
+        let receive_time = NtpTimestamp::now();
+
+        let offset = response.calculate_offset(receive_time);
+        let rtt = response.calculate_rtt(receive_time);
+
+        // Exponential moving average
+        if self.sample_count == 0 {
+            self.offset = offset;
+            self.rtt = rtt;
+        } else {
+            // α = 0.125 (1/8) for smoothing
+            self.offset = self.offset + (offset - self.offset) / 8;
+            self.rtt = self.rtt + (rtt.saturating_sub(self.rtt)) / 8;
+        }
+
+        self.sample_count += 1;
+        Ok(())
+    }
+
+    /// Convert local RTP timestamp to synchronized timestamp
+    pub fn local_to_remote(&self, local_ts: u32) -> u32 {
+        // Adjust by offset (converted to RTP timestamp units)
+        let offset_samples = (self.offset * 44100 / 1_000_000) as i32;
+        (local_ts as i32 + offset_samples) as u32
+    }
+
+    /// Convert remote RTP timestamp to local timestamp
+    pub fn remote_to_local(&self, remote_ts: u32) -> u32 {
+        let offset_samples = (self.offset * 44100 / 1_000_000) as i32;
+        (remote_ts as i32 - offset_samples) as u32
+    }
+}
+```
+
+---
+
+### 28.3 Audio Packet Buffer
+
+- [ ] **28.3.1** Implement packet buffer for retransmission
+
+**File:** `src/protocol/rtp/packet_buffer.rs`
+
+```rust
+//! Packet buffer for retransmission support
+
+use std::collections::VecDeque;
+
+/// Audio packet with sequence tracking
+#[derive(Debug, Clone)]
+pub struct BufferedPacket {
+    /// Sequence number
+    pub sequence: u16,
+    /// RTP timestamp
+    pub timestamp: u32,
+    /// Encoded packet data (ready for retransmission)
+    pub data: Vec<u8>,
+}
+
+/// Circular buffer for recently sent packets
+pub struct PacketBuffer {
+    /// Maximum buffer size
+    max_size: usize,
+    /// Buffered packets
+    packets: VecDeque<BufferedPacket>,
+}
+
+impl PacketBuffer {
+    /// Default buffer size (1 second at ~125 packets/sec)
+    pub const DEFAULT_SIZE: usize = 128;
+
+    /// Create new packet buffer
+    pub fn new(max_size: usize) -> Self {
+        Self {
+            max_size,
+            packets: VecDeque::with_capacity(max_size),
+        }
+    }
+
+    /// Add a packet to the buffer
+    pub fn push(&mut self, packet: BufferedPacket) {
+        if self.packets.len() >= self.max_size {
+            self.packets.pop_front();
+        }
+        self.packets.push_back(packet);
+    }
+
+    /// Get a packet by sequence number
+    pub fn get(&self, sequence: u16) -> Option<&BufferedPacket> {
+        self.packets.iter().find(|p| p.sequence == sequence)
+    }
+
+    /// Get a range of packets for retransmission
+    pub fn get_range(&self, start: u16, count: u16) -> Vec<&BufferedPacket> {
+        let mut result = Vec::new();
+        for seq in start..(start.wrapping_add(count)) {
+            if let Some(packet) = self.get(seq) {
+                result.push(packet);
+            }
+        }
+        result
+    }
+
+    /// Clear the buffer
+    pub fn clear(&mut self) {
+        self.packets.clear();
+    }
+
+    /// Number of packets in buffer
+    pub fn len(&self) -> usize {
+        self.packets.len()
+    }
+
+    /// Check if buffer is empty
+    pub fn is_empty(&self) -> bool {
+        self.packets.is_empty()
+    }
+
+    /// Get sequence number range
+    pub fn sequence_range(&self) -> Option<(u16, u16)> {
+        if self.packets.is_empty() {
+            None
+        } else {
+            Some((
+                self.packets.front()?.sequence,
+                self.packets.back()?.sequence,
+            ))
+        }
+    }
+}
+
+/// Packet loss detector
+pub struct PacketLossDetector {
+    /// Expected next sequence number
+    expected_seq: u16,
+    /// First sequence received
+    first_received: bool,
+}
+
+impl PacketLossDetector {
+    /// Create new loss detector
+    pub fn new() -> Self {
+        Self {
+            expected_seq: 0,
+            first_received: false,
+        }
+    }
+
+    /// Process received sequence number
+    ///
+    /// Returns list of missing sequence numbers
+    pub fn process(&mut self, sequence: u16) -> Vec<u16> {
+        if !self.first_received {
+            self.first_received = true;
+            self.expected_seq = sequence.wrapping_add(1);
+            return Vec::new();
+        }
+
+        let mut missing = Vec::new();
+
+        // Calculate how many packets were skipped
+        let diff = sequence.wrapping_sub(self.expected_seq);
+
+        if diff > 0 && diff < 100 {
+            // Packets were lost
+            for i in 0..diff {
+                missing.push(self.expected_seq.wrapping_add(i));
+            }
+        }
+
+        // Update expected
+        self.expected_seq = sequence.wrapping_add(1);
+
+        missing
+    }
+
+    /// Reset detector
+    pub fn reset(&mut self) {
+        self.first_received = false;
+        self.expected_seq = 0;
+    }
+}
+```
+
+---
+
+### 28.4 RAOP Audio Streamer
+
+- [ ] **28.4.1** Implement audio streaming coordinator
+
+**File:** `src/streaming/raop_streamer.rs`
+
+```rust
+//! RAOP audio streaming coordinator
+
+use crate::protocol::rtp::raop::{RaopAudioPacket, SyncPacket};
+use crate::protocol::rtp::packet_buffer::{PacketBuffer, BufferedPacket};
+use crate::protocol::rtp::raop_timing::TimingSync;
+use crate::protocol::raop::RaopSessionKeys;
+use std::time::{Duration, Instant};
+
+/// RAOP streaming configuration
+#[derive(Debug, Clone)]
+pub struct RaopStreamConfig {
+    /// Sample rate (Hz)
+    pub sample_rate: u32,
+    /// Samples per packet (352 for ALAC)
+    pub samples_per_packet: u32,
+    /// SSRC for RTP packets
+    pub ssrc: u32,
+    /// Enable retransmission buffer
+    pub enable_retransmit: bool,
+}
+
+impl Default for RaopStreamConfig {
+    fn default() -> Self {
+        Self {
+            sample_rate: 44100,
+            samples_per_packet: 352,
+            ssrc: rand::random(),
+            enable_retransmit: true,
+        }
+    }
+}
+
+/// RAOP audio streamer
+pub struct RaopStreamer {
+    /// Configuration
+    config: RaopStreamConfig,
+    /// Current sequence number
+    sequence: u16,
+    /// Current RTP timestamp
+    timestamp: u32,
+    /// Session encryption keys
+    keys: RaopSessionKeys,
+    /// Packet buffer for retransmission
+    buffer: PacketBuffer,
+    /// Timing synchronization
+    timing: TimingSync,
+    /// Is first packet after start/flush
+    is_first_packet: bool,
+    /// Last sync packet sent
+    last_sync: Instant,
+    /// Last timing request sent
+    last_timing: Instant,
+}
+
+impl RaopStreamer {
+    /// Timing request interval
+    const TIMING_INTERVAL: Duration = Duration::from_secs(3);
+
+    /// Sync packet interval
+    const SYNC_INTERVAL: Duration = Duration::from_millis(1000);
+
+    /// Create new streamer
+    pub fn new(keys: RaopSessionKeys, config: RaopStreamConfig) -> Self {
+        Self {
+            config,
+            sequence: 0,
+            timestamp: 0,
+            keys,
+            buffer: PacketBuffer::new(PacketBuffer::DEFAULT_SIZE),
+            timing: TimingSync::new(),
+            is_first_packet: true,
+            last_sync: Instant::now(),
+            last_timing: Instant::now(),
+        }
+    }
+
+    /// Get current sequence number
+    pub fn sequence(&self) -> u16 {
+        self.sequence
+    }
+
+    /// Get current timestamp
+    pub fn timestamp(&self) -> u32 {
+        self.timestamp
+    }
+
+    /// Encode audio frame to RTP packet
+    ///
+    /// Audio should be encoded ALAC data (or raw PCM depending on codec)
+    pub fn encode_frame(&mut self, audio_data: &[u8]) -> Vec<u8> {
+        // Encrypt audio if keys are set
+        let encrypted = self.encrypt_audio(audio_data);
+
+        // Create packet
+        let mut packet = RaopAudioPacket::new(
+            self.sequence,
+            self.timestamp,
+            self.config.ssrc,
+            encrypted,
+        );
+
+        if self.is_first_packet {
+            packet = packet.with_marker();
+            self.is_first_packet = false;
+        }
+
+        let encoded = packet.encode();
+
+        // Buffer for retransmission
+        if self.config.enable_retransmit {
+            self.buffer.push(BufferedPacket {
+                sequence: self.sequence,
+                timestamp: self.timestamp,
+                data: encoded.clone(),
+            });
+        }
+
+        // Update state
+        self.sequence = self.sequence.wrapping_add(1);
+        self.timestamp = self.timestamp.wrapping_add(self.config.samples_per_packet);
+
+        encoded
+    }
+
+    fn encrypt_audio(&self, data: &[u8]) -> Vec<u8> {
+        use crate::protocol::crypto::Aes128Ctr;
+
+        let mut cipher = Aes128Ctr::new(
+            self.keys.aes_key(),
+            self.keys.aes_iv(),
+        ).expect("invalid AES keys");
+
+        // AES-CTR encryption
+        let mut encrypted = data.to_vec();
+        cipher.apply_keystream(&mut encrypted);
+        encrypted
+    }
+
+    /// Handle retransmit request
+    pub fn handle_retransmit(&self, seq_start: u16, count: u16) -> Vec<Vec<u8>> {
+        self.buffer
+            .get_range(seq_start, count)
+            .into_iter()
+            .map(|p| {
+                // Wrap in retransmit response header
+                let mut response = Vec::with_capacity(4 + p.data.len());
+                response.push(0x80);
+                response.push(0xD6); // PT=0x56 (retransmit response)
+                response.extend_from_slice(&p.sequence.to_be_bytes());
+                response.extend_from_slice(&p.data[4..]); // Skip original header
+                response
+            })
+            .collect()
+    }
+
+    /// Check if sync packet should be sent
+    pub fn should_send_sync(&self) -> bool {
+        self.last_sync.elapsed() >= Self::SYNC_INTERVAL
+    }
+
+    /// Create sync packet
+    pub fn create_sync_packet(&mut self) -> Vec<u8> {
+        let ntp_time = crate::protocol::rtp::timing::NtpTimestamp::now();
+        let packet = SyncPacket::new(
+            self.timestamp,
+            ntp_time,
+            self.timestamp.wrapping_add(self.config.samples_per_packet),
+            false,
+        );
+        self.last_sync = Instant::now();
+        packet.encode()
+    }
+
+    /// Check if timing request should be sent
+    pub fn should_send_timing(&self) -> bool {
+        self.last_timing.elapsed() >= Self::TIMING_INTERVAL
+    }
+
+    /// Create timing request
+    pub fn create_timing_request(&mut self) -> Vec<u8> {
+        self.last_timing = Instant::now();
+        self.timing.create_request()
+    }
+
+    /// Process timing response
+    pub fn process_timing_response(&mut self, data: &[u8]) -> Result<(), String> {
+        self.timing.process_response(data)
+            .map_err(|e| e.to_string())
+    }
+
+    /// Flush and prepare for new playback
+    pub fn flush(&mut self) {
+        self.is_first_packet = true;
+        self.buffer.clear();
+    }
+
+    /// Reset to initial state
+    pub fn reset(&mut self) {
+        self.sequence = 0;
+        self.timestamp = 0;
+        self.is_first_packet = true;
+        self.buffer.clear();
+        self.timing = TimingSync::new();
+    }
+}
+```
+
+---
+
+## Unit Tests
+
+### Test File: `src/protocol/rtp/raop.rs`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sync_packet_encode_decode() {
+        let ntp = NtpTimestamp::now();
+        let packet = SyncPacket::new(1000, ntp, 1352, true);
+
+        let encoded = packet.encode();
+        assert_eq!(encoded.len(), SyncPacket::SIZE);
+
+        let decoded = SyncPacket::decode(&encoded).unwrap();
+        assert_eq!(decoded.rtp_timestamp, 1000);
+        assert_eq!(decoded.next_timestamp, 1352);
+        assert!(decoded.extension);
+    }
+
+    #[test]
+    fn test_audio_packet_encode_decode() {
+        let payload = vec![0x01, 0x02, 0x03, 0x04];
+        let packet = RaopAudioPacket::new(100, 44100, 0x12345678, payload.clone())
+            .with_marker();
+
+        let encoded = packet.encode();
+        let decoded = RaopAudioPacket::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.sequence, 100);
+        assert_eq!(decoded.timestamp, 44100);
+        assert_eq!(decoded.ssrc, 0x12345678);
+        assert!(decoded.marker);
+        assert_eq!(decoded.payload, payload);
+    }
+
+    #[test]
+    fn test_retransmit_request_decode() {
+        let data = [0x00, 0x0A, 0x00, 0x05]; // seq=10, count=5
+        let request = RetransmitRequest::decode(&data).unwrap();
+
+        assert_eq!(request.seq_start, 10);
+        assert_eq!(request.count, 5);
+    }
+
+    #[test]
+    fn test_payload_type_parsing() {
+        assert_eq!(RaopPayloadType::from_byte(0x60), Some(RaopPayloadType::AudioRealtime));
+        assert_eq!(RaopPayloadType::from_byte(0xE0), Some(RaopPayloadType::AudioRealtime)); // With marker
+        assert!(RaopPayloadType::AudioRealtime.is_audio());
+        assert!(!RaopPayloadType::Sync.is_audio());
+    }
+}
+```
+
+### Test File: `src/protocol/rtp/packet_buffer.rs`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_buffer_push_get() {
+        let mut buffer = PacketBuffer::new(10);
+
+        buffer.push(BufferedPacket {
+            sequence: 100,
+            timestamp: 0,
+            data: vec![1, 2, 3],
+        });
+
+        let packet = buffer.get(100).unwrap();
+        assert_eq!(packet.sequence, 100);
+    }
+
+    #[test]
+    fn test_buffer_overflow() {
+        let mut buffer = PacketBuffer::new(2);
+
+        buffer.push(BufferedPacket { sequence: 1, timestamp: 0, data: vec![] });
+        buffer.push(BufferedPacket { sequence: 2, timestamp: 0, data: vec![] });
+        buffer.push(BufferedPacket { sequence: 3, timestamp: 0, data: vec![] });
+
+        assert!(buffer.get(1).is_none()); // Evicted
+        assert!(buffer.get(2).is_some());
+        assert!(buffer.get(3).is_some());
+    }
+
+    #[test]
+    fn test_buffer_range() {
+        let mut buffer = PacketBuffer::new(10);
+
+        for i in 0..5 {
+            buffer.push(BufferedPacket {
+                sequence: i,
+                timestamp: i as u32 * 352,
+                data: vec![i as u8],
+            });
+        }
+
+        let range = buffer.get_range(1, 3);
+        assert_eq!(range.len(), 3);
+        assert_eq!(range[0].sequence, 1);
+        assert_eq!(range[2].sequence, 3);
+    }
+
+    #[test]
+    fn test_loss_detector() {
+        let mut detector = PacketLossDetector::new();
+
+        // First packet
+        let missing = detector.process(100);
+        assert!(missing.is_empty());
+
+        // Sequential
+        let missing = detector.process(101);
+        assert!(missing.is_empty());
+
+        // Gap (102 missing)
+        let missing = detector.process(103);
+        assert_eq!(missing, vec![102]);
+
+        // Larger gap
+        let missing = detector.process(106);
+        assert_eq!(missing, vec![104, 105]);
+    }
+}
+```
+
+---
+
+## Integration Tests
+
+### Test: Streaming simulation
+
+```rust
+// tests/raop_streaming_integration.rs
+
+use airplay2_rs::streaming::raop_streamer::{RaopStreamer, RaopStreamConfig};
+use airplay2_rs::protocol::raop::RaopSessionKeys;
+
+#[test]
+fn test_streaming_sequence() {
+    // Create mock session keys
+    let keys = create_test_keys();
+    let config = RaopStreamConfig::default();
+
+    let mut streamer = RaopStreamer::new(keys, config);
+
+    // Simulate streaming audio frames
+    let frame = vec![0u8; 352 * 4]; // 352 samples * 4 bytes (16-bit stereo)
+
+    let packet1 = streamer.encode_frame(&frame);
+    let packet2 = streamer.encode_frame(&frame);
+    let packet3 = streamer.encode_frame(&frame);
+
+    // Check sequence numbers
+    assert_eq!(streamer.sequence(), 3);
+
+    // Check timestamp progression
+    assert_eq!(streamer.timestamp(), 352 * 3);
+
+    // First packet should have marker bit
+    assert_eq!(packet1[1] & 0x80, 0x80);
+    // Subsequent packets should not
+    assert_eq!(packet2[1] & 0x80, 0x00);
+}
+
+fn create_test_keys() -> RaopSessionKeys {
+    // In tests, create mock keys
+    todo!()
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] RAOP audio packets encode/decode correctly
+- [ ] Sync packets include correct timestamps
+- [ ] Timing protocol calculates offset accurately
+- [ ] Packet buffer stores packets for retransmission
+- [ ] Retransmit handler returns correct packets
+- [ ] Marker bit set on first packet after flush
+- [ ] Sequence numbers increment correctly
+- [ ] Timestamps increment by samples-per-packet
+- [ ] All unit tests pass
+- [ ] Integration tests pass
+
+---
+
+## Notes
+
+- Sync packets should be sent approximately once per second
+- Timing packets should be sent every 3 seconds
+- Packet buffer size should be tunable based on network conditions
+- Consider adaptive bitrate based on packet loss
+- Real-time constraints require careful scheduling

--- a/docs/29-raop-encryption.md
+++ b/docs/29-raop-encryption.md
@@ -1,0 +1,741 @@
+# Section 29: RAOP Audio Encryption
+
+## Dependencies
+- **Section 04**: Cryptographic Primitives (must be complete)
+- **Section 26**: RSA Authentication (must be complete)
+- **Section 28**: RTP Audio Streaming (recommended)
+
+## Overview
+
+RAOP uses AES-128 encryption in Counter (CTR) mode for audio payload protection. The encryption key is exchanged using RSA-OAEP during the ANNOUNCE phase. This section details the encryption scheme and its integration with the audio streaming pipeline.
+
+## Encryption Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Key Exchange (ANNOUNCE)                       │
+│                                                                  │
+│  Client                                           Server         │
+│    │                                                │            │
+│    │  1. Generate random AES-128 key              │            │
+│    │  2. Generate random 128-bit IV               │            │
+│    │  3. Encrypt AES key with RSA-OAEP            │            │
+│    │  4. Send rsaaeskey + aesiv in SDP            │            │
+│    │─────────────────────────────────────────────>│            │
+│    │                                                │            │
+│    │                        5. Decrypt AES key with RSA private  │
+│    │                        6. Store key + IV for session        │
+│    │<─────────────────────────────────────────────│            │
+│    │             200 OK                            │            │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│                    Audio Encryption (RTP)                        │
+│                                                                  │
+│    ┌──────────────┐    ┌──────────────┐    ┌──────────────┐     │
+│    │  PCM/ALAC    │───>│  AES-128-CTR │───>│  RTP Packet  │     │
+│    │  Audio Data  │    │  Encrypt     │    │              │     │
+│    └──────────────┘    └──────────────┘    └──────────────┘     │
+│                              │                                   │
+│                    Key + IV + Counter                            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Objectives
+
+- Implement AES-128-CTR encryption for audio payloads
+- Handle proper counter management for streaming
+- Integrate encryption with RTP packet generation
+- Support unencrypted mode for compatible devices
+
+---
+
+## Tasks
+
+### 29.1 AES-CTR Encryption Module
+
+- [ ] **29.1.1** Implement RAOP-specific AES-CTR wrapper
+
+**File:** `src/protocol/raop/encryption.rs`
+
+```rust
+//! RAOP audio encryption using AES-128-CTR
+
+use crate::protocol::crypto::{Aes128Ctr, CryptoError};
+
+/// AES key size (128 bits)
+pub const AES_KEY_SIZE: usize = 16;
+/// AES IV size (128 bits)
+pub const AES_IV_SIZE: usize = 16;
+/// Audio frame size (352 samples * 4 bytes)
+pub const FRAME_SIZE: usize = 352 * 4;
+
+/// RAOP audio encryptor
+///
+/// Handles AES-128-CTR encryption for audio packets.
+/// The counter is based on the IV and packet sequence/timestamp.
+pub struct RaopEncryptor {
+    /// AES encryption key
+    key: [u8; AES_KEY_SIZE],
+    /// Base initialization vector
+    iv: [u8; AES_IV_SIZE],
+    /// Whether encryption is enabled
+    enabled: bool,
+}
+
+impl RaopEncryptor {
+    /// Create a new encryptor with given key and IV
+    pub fn new(key: [u8; AES_KEY_SIZE], iv: [u8; AES_IV_SIZE]) -> Self {
+        Self {
+            key,
+            iv,
+            enabled: true,
+        }
+    }
+
+    /// Create an encryptor with encryption disabled
+    pub fn disabled() -> Self {
+        Self {
+            key: [0; AES_KEY_SIZE],
+            iv: [0; AES_IV_SIZE],
+            enabled: false,
+        }
+    }
+
+    /// Check if encryption is enabled
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Encrypt audio data for a packet
+    ///
+    /// # Arguments
+    /// * `audio_data` - Raw audio bytes (PCM or encoded)
+    /// * `packet_index` - Packet index for counter derivation
+    ///
+    /// # Returns
+    /// Encrypted audio data
+    pub fn encrypt(&self, audio_data: &[u8], packet_index: u64) -> Result<Vec<u8>, CryptoError> {
+        if !self.enabled {
+            return Ok(audio_data.to_vec());
+        }
+
+        let mut cipher = Aes128Ctr::new(&self.key, &self.iv)?;
+
+        // Seek to the correct position in the keystream
+        // Each packet uses FRAME_SIZE bytes of keystream
+        cipher.seek(packet_index * FRAME_SIZE as u64);
+
+        let mut output = audio_data.to_vec();
+        cipher.apply_keystream(&mut output);
+
+        Ok(output)
+    }
+
+    /// Encrypt audio data in place
+    pub fn encrypt_in_place(
+        &self,
+        audio_data: &mut [u8],
+        packet_index: u64,
+    ) -> Result<(), CryptoError> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        let mut cipher = Aes128Ctr::new(&self.key, &self.iv)?;
+        cipher.seek(packet_index * FRAME_SIZE as u64);
+        cipher.apply_keystream(audio_data);
+
+        Ok(())
+    }
+
+    /// Get a reference to the key (for session info)
+    pub fn key(&self) -> &[u8; AES_KEY_SIZE] {
+        &self.key
+    }
+
+    /// Get a reference to the IV
+    pub fn iv(&self) -> &[u8; AES_IV_SIZE] {
+        &self.iv
+    }
+}
+
+impl Drop for RaopEncryptor {
+    fn drop(&mut self) {
+        // Zeroize sensitive data
+        self.key.iter_mut().for_each(|b| *b = 0);
+        self.iv.iter_mut().for_each(|b| *b = 0);
+    }
+}
+
+/// RAOP audio decryptor (for receiver/testing)
+pub struct RaopDecryptor {
+    /// AES decryption key
+    key: [u8; AES_KEY_SIZE],
+    /// Base initialization vector
+    iv: [u8; AES_IV_SIZE],
+    /// Whether encryption is enabled
+    enabled: bool,
+}
+
+impl RaopDecryptor {
+    /// Create a new decryptor with given key and IV
+    pub fn new(key: [u8; AES_KEY_SIZE], iv: [u8; AES_IV_SIZE]) -> Self {
+        Self {
+            key,
+            iv,
+            enabled: true,
+        }
+    }
+
+    /// Decrypt audio data from a packet
+    pub fn decrypt(&self, audio_data: &[u8], packet_index: u64) -> Result<Vec<u8>, CryptoError> {
+        if !self.enabled {
+            return Ok(audio_data.to_vec());
+        }
+
+        // AES-CTR decryption is the same as encryption
+        let mut cipher = Aes128Ctr::new(&self.key, &self.iv)?;
+        cipher.seek(packet_index * FRAME_SIZE as u64);
+
+        let mut output = audio_data.to_vec();
+        cipher.apply_keystream(&mut output);
+
+        Ok(output)
+    }
+}
+
+impl Drop for RaopDecryptor {
+    fn drop(&mut self) {
+        self.key.iter_mut().for_each(|b| *b = 0);
+        self.iv.iter_mut().for_each(|b| *b = 0);
+    }
+}
+```
+
+---
+
+### 29.2 Key Generation and Exchange
+
+- [ ] **29.2.1** Implement secure key generation
+
+**File:** `src/protocol/raop/encryption.rs` (continued)
+
+```rust
+/// Generate random AES key and IV
+pub fn generate_encryption_keys() -> Result<([u8; AES_KEY_SIZE], [u8; AES_IV_SIZE]), CryptoError> {
+    use rand::RngCore;
+
+    let mut key = [0u8; AES_KEY_SIZE];
+    let mut iv = [0u8; AES_IV_SIZE];
+
+    let mut rng = rand::thread_rng();
+    rng.try_fill_bytes(&mut key)
+        .map_err(|_| CryptoError::RngError)?;
+    rng.try_fill_bytes(&mut iv)
+        .map_err(|_| CryptoError::RngError)?;
+
+    Ok((key, iv))
+}
+
+/// RSA-wrapped session keys for SDP
+pub struct WrappedSessionKeys {
+    /// RSA-OAEP encrypted AES key (Base64)
+    pub rsaaeskey: String,
+    /// AES IV (Base64)
+    pub aesiv: String,
+    /// Plain AES key (for local encryption)
+    key: [u8; AES_KEY_SIZE],
+    /// Plain AES IV
+    iv: [u8; AES_IV_SIZE],
+}
+
+impl WrappedSessionKeys {
+    /// Generate new session keys and wrap with RSA
+    pub fn generate() -> Result<Self, CryptoError> {
+        use crate::protocol::crypto::rsa::AppleRsaPublicKey;
+        use base64::{Engine as _, engine::general_purpose::STANDARD_NO_PAD as BASE64};
+
+        let (key, iv) = generate_encryption_keys()?;
+
+        // Encrypt AES key with Apple's RSA public key
+        let public_key = AppleRsaPublicKey::load()?;
+        let encrypted_key = public_key.encrypt_oaep(&key)?;
+
+        Ok(Self {
+            rsaaeskey: BASE64.encode(&encrypted_key),
+            aesiv: BASE64.encode(&iv),
+            key,
+            iv,
+        })
+    }
+
+    /// Create encryptor from these keys
+    pub fn encryptor(&self) -> RaopEncryptor {
+        RaopEncryptor::new(self.key, self.iv)
+    }
+
+    /// Get plain AES key (for debugging/testing)
+    #[cfg(test)]
+    pub fn plain_key(&self) -> &[u8; AES_KEY_SIZE] {
+        &self.key
+    }
+
+    /// Get plain IV (for debugging/testing)
+    #[cfg(test)]
+    pub fn plain_iv(&self) -> &[u8; AES_IV_SIZE] {
+        &self.iv
+    }
+}
+
+impl Drop for WrappedSessionKeys {
+    fn drop(&mut self) {
+        self.key.iter_mut().for_each(|b| *b = 0);
+        self.iv.iter_mut().for_each(|b| *b = 0);
+    }
+}
+
+/// Parse received session keys (receiver side)
+pub fn parse_wrapped_keys(
+    rsaaeskey_b64: &str,
+    aesiv_b64: &str,
+    private_key: &crate::protocol::crypto::rsa::RaopRsaPrivateKey,
+) -> Result<(RaopDecryptor, [u8; AES_KEY_SIZE], [u8; AES_IV_SIZE]), CryptoError> {
+    use base64::{Engine as _, engine::general_purpose::STANDARD_NO_PAD as BASE64};
+
+    // Decode Base64
+    let encrypted_key = BASE64.decode(rsaaeskey_b64.trim())
+        .map_err(|e| CryptoError::DecryptionFailed(format!("invalid base64: {}", e)))?;
+
+    let iv_bytes = BASE64.decode(aesiv_b64.trim())
+        .map_err(|e| CryptoError::DecryptionFailed(format!("invalid base64: {}", e)))?;
+
+    // Decrypt AES key
+    let key_bytes = private_key.decrypt_oaep(&encrypted_key)?;
+
+    if key_bytes.len() != AES_KEY_SIZE {
+        return Err(CryptoError::InvalidKeyLength {
+            expected: AES_KEY_SIZE,
+            actual: key_bytes.len(),
+        });
+    }
+
+    if iv_bytes.len() != AES_IV_SIZE {
+        return Err(CryptoError::InvalidKeyLength {
+            expected: AES_IV_SIZE,
+            actual: iv_bytes.len(),
+        });
+    }
+
+    let mut key = [0u8; AES_KEY_SIZE];
+    let mut iv = [0u8; AES_IV_SIZE];
+    key.copy_from_slice(&key_bytes);
+    iv.copy_from_slice(&iv_bytes);
+
+    let decryptor = RaopDecryptor::new(key, iv);
+
+    Ok((decryptor, key, iv))
+}
+```
+
+---
+
+### 29.3 ALAC Encryption Integration
+
+- [ ] **29.3.1** Integrate encryption with audio encoding
+
+**File:** `src/audio/raop_encoder.rs`
+
+```rust
+//! RAOP audio encoding with encryption
+
+use crate::protocol::raop::encryption::{RaopEncryptor, FRAME_SIZE};
+use crate::protocol::crypto::CryptoError;
+
+/// RAOP audio encoder with encryption
+pub struct RaopAudioEncoder {
+    /// Audio encryptor
+    encryptor: RaopEncryptor,
+    /// Current packet index
+    packet_index: u64,
+    /// Sample rate
+    sample_rate: u32,
+    /// Samples per frame
+    samples_per_frame: u32,
+}
+
+impl RaopAudioEncoder {
+    /// Samples per ALAC frame
+    pub const ALAC_FRAME_SAMPLES: u32 = 352;
+
+    /// Create new encoder
+    pub fn new(encryptor: RaopEncryptor) -> Self {
+        Self {
+            encryptor,
+            packet_index: 0,
+            sample_rate: 44100,
+            samples_per_frame: Self::ALAC_FRAME_SAMPLES,
+        }
+    }
+
+    /// Encode and encrypt a frame of audio
+    ///
+    /// # Arguments
+    /// * `pcm_samples` - 16-bit stereo PCM samples (interleaved L/R)
+    ///
+    /// # Returns
+    /// Encrypted audio data ready for RTP packet
+    pub fn encode_frame(&mut self, pcm_samples: &[i16]) -> Result<Vec<u8>, AudioEncodeError> {
+        // Convert to bytes
+        let mut audio_bytes = Vec::with_capacity(pcm_samples.len() * 2);
+        for sample in pcm_samples {
+            audio_bytes.extend_from_slice(&sample.to_le_bytes());
+        }
+
+        // For PCM mode, use raw bytes
+        // For ALAC mode, would encode here
+
+        // Encrypt
+        let encrypted = self.encryptor.encrypt(&audio_bytes, self.packet_index)
+            .map_err(|e| AudioEncodeError::Encryption(e.to_string()))?;
+
+        self.packet_index += 1;
+
+        Ok(encrypted)
+    }
+
+    /// Encode raw audio bytes
+    pub fn encode_raw(&mut self, audio_data: &[u8]) -> Result<Vec<u8>, AudioEncodeError> {
+        let encrypted = self.encryptor.encrypt(audio_data, self.packet_index)
+            .map_err(|e| AudioEncodeError::Encryption(e.to_string()))?;
+
+        self.packet_index += 1;
+
+        Ok(encrypted)
+    }
+
+    /// Reset packet index (after flush)
+    pub fn reset(&mut self) {
+        self.packet_index = 0;
+    }
+
+    /// Get current packet index
+    pub fn packet_index(&self) -> u64 {
+        self.packet_index
+    }
+}
+
+/// Audio encoding errors
+#[derive(Debug, thiserror::Error)]
+pub enum AudioEncodeError {
+    #[error("encryption error: {0}")]
+    Encryption(String),
+    #[error("invalid frame size: expected {expected}, got {actual}")]
+    InvalidFrameSize { expected: usize, actual: usize },
+    #[error("encoding error: {0}")]
+    Encoding(String),
+}
+```
+
+---
+
+### 29.4 Unencrypted Mode
+
+- [ ] **29.4.1** Support devices that accept unencrypted audio
+
+**File:** `src/protocol/raop/encryption.rs` (continued)
+
+```rust
+/// Encryption mode for RAOP session
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EncryptionMode {
+    /// No encryption (et=0 in TXT records)
+    None,
+    /// RSA encryption (et=1)
+    Rsa,
+    /// FairPlay encryption (et=3, not supported)
+    FairPlay,
+    /// MFi-SAP encryption (et=4, not supported)
+    MfiSap,
+    /// FairPlay SAPv2.5 (et=5, not supported)
+    FairPlaySap25,
+}
+
+impl EncryptionMode {
+    /// Parse from TXT record value
+    pub fn from_txt(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(Self::None),
+            1 => Some(Self::Rsa),
+            3 => Some(Self::FairPlay),
+            4 => Some(Self::MfiSap),
+            5 => Some(Self::FairPlaySap25),
+            _ => None,
+        }
+    }
+
+    /// Check if this mode is supported
+    pub fn is_supported(&self) -> bool {
+        matches!(self, Self::None | Self::Rsa)
+    }
+}
+
+/// Session encryption configuration
+pub struct EncryptionConfig {
+    /// Encryption mode
+    pub mode: EncryptionMode,
+    /// Encryptor (if encryption enabled)
+    encryptor: Option<RaopEncryptor>,
+    /// Session keys (if encryption enabled)
+    keys: Option<WrappedSessionKeys>,
+}
+
+impl EncryptionConfig {
+    /// Create unencrypted configuration
+    pub fn unencrypted() -> Self {
+        Self {
+            mode: EncryptionMode::None,
+            encryptor: Some(RaopEncryptor::disabled()),
+            keys: None,
+        }
+    }
+
+    /// Create RSA-encrypted configuration
+    pub fn rsa() -> Result<Self, CryptoError> {
+        let keys = WrappedSessionKeys::generate()?;
+        let encryptor = keys.encryptor();
+
+        Ok(Self {
+            mode: EncryptionMode::Rsa,
+            encryptor: Some(encryptor),
+            keys: Some(keys),
+        })
+    }
+
+    /// Get encryptor
+    pub fn encryptor(&self) -> Option<&RaopEncryptor> {
+        self.encryptor.as_ref()
+    }
+
+    /// Get session keys for SDP
+    pub fn session_keys(&self) -> Option<&WrappedSessionKeys> {
+        self.keys.as_ref()
+    }
+
+    /// Check if encryption is active
+    pub fn is_encrypted(&self) -> bool {
+        self.mode != EncryptionMode::None
+    }
+}
+```
+
+---
+
+## Unit Tests
+
+### Test File: `src/protocol/raop/encryption.rs`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        let key = [0x42u8; AES_KEY_SIZE];
+        let iv = [0x00u8; AES_IV_SIZE];
+
+        let encryptor = RaopEncryptor::new(key, iv);
+        let decryptor = RaopDecryptor::new(key, iv);
+
+        let original = vec![0xAA; FRAME_SIZE];
+        let packet_index = 0;
+
+        let encrypted = encryptor.encrypt(&original, packet_index).unwrap();
+        assert_ne!(encrypted, original);
+
+        let decrypted = decryptor.decrypt(&encrypted, packet_index).unwrap();
+        assert_eq!(decrypted, original);
+    }
+
+    #[test]
+    fn test_different_packets_different_ciphertext() {
+        let key = [0x42u8; AES_KEY_SIZE];
+        let iv = [0x00u8; AES_IV_SIZE];
+
+        let encryptor = RaopEncryptor::new(key, iv);
+
+        let data = vec![0xAA; FRAME_SIZE];
+
+        let encrypted1 = encryptor.encrypt(&data, 0).unwrap();
+        let encrypted2 = encryptor.encrypt(&data, 1).unwrap();
+
+        // Same plaintext, different packet index -> different ciphertext
+        assert_ne!(encrypted1, encrypted2);
+    }
+
+    #[test]
+    fn test_disabled_encryption() {
+        let encryptor = RaopEncryptor::disabled();
+
+        let data = vec![0xAA; 100];
+        let encrypted = encryptor.encrypt(&data, 0).unwrap();
+
+        // Should be unchanged
+        assert_eq!(encrypted, data);
+    }
+
+    #[test]
+    fn test_key_generation() {
+        let (key1, iv1) = generate_encryption_keys().unwrap();
+        let (key2, iv2) = generate_encryption_keys().unwrap();
+
+        // Should be different each time
+        assert_ne!(key1, key2);
+        assert_ne!(iv1, iv2);
+
+        // Should be correct size
+        assert_eq!(key1.len(), AES_KEY_SIZE);
+        assert_eq!(iv1.len(), AES_IV_SIZE);
+    }
+
+    #[test]
+    fn test_encrypt_in_place() {
+        let key = [0x42u8; AES_KEY_SIZE];
+        let iv = [0x00u8; AES_IV_SIZE];
+
+        let encryptor = RaopEncryptor::new(key, iv);
+        let decryptor = RaopDecryptor::new(key, iv);
+
+        let original = vec![0xAA; FRAME_SIZE];
+        let mut data = original.clone();
+
+        encryptor.encrypt_in_place(&mut data, 0).unwrap();
+        assert_ne!(data, original);
+
+        let decrypted = decryptor.decrypt(&data, 0).unwrap();
+        assert_eq!(decrypted, original);
+    }
+
+    #[test]
+    fn test_encryption_mode_parsing() {
+        assert_eq!(EncryptionMode::from_txt(0), Some(EncryptionMode::None));
+        assert_eq!(EncryptionMode::from_txt(1), Some(EncryptionMode::Rsa));
+        assert_eq!(EncryptionMode::from_txt(3), Some(EncryptionMode::FairPlay));
+        assert_eq!(EncryptionMode::from_txt(99), None);
+
+        assert!(EncryptionMode::None.is_supported());
+        assert!(EncryptionMode::Rsa.is_supported());
+        assert!(!EncryptionMode::FairPlay.is_supported());
+    }
+
+    #[test]
+    fn test_sequential_packet_encryption() {
+        let key = [0x42u8; AES_KEY_SIZE];
+        let iv = [0x00u8; AES_IV_SIZE];
+
+        let encryptor = RaopEncryptor::new(key, iv);
+        let decryptor = RaopDecryptor::new(key, iv);
+
+        // Simulate streaming multiple packets
+        for i in 0..10u64 {
+            let data = vec![(i & 0xFF) as u8; FRAME_SIZE];
+            let encrypted = encryptor.encrypt(&data, i).unwrap();
+            let decrypted = decryptor.decrypt(&encrypted, i).unwrap();
+            assert_eq!(decrypted, data);
+        }
+    }
+}
+```
+
+---
+
+## Integration Tests
+
+### Test: Full encryption flow simulation
+
+```rust
+// tests/raop_encryption_integration.rs
+
+use airplay2_rs::protocol::raop::encryption::{
+    RaopEncryptor, RaopDecryptor, WrappedSessionKeys,
+    EncryptionConfig, EncryptionMode, FRAME_SIZE,
+};
+use airplay2_rs::protocol::crypto::rsa::RaopRsaPrivateKey;
+
+#[test]
+fn test_key_exchange_simulation() {
+    // Server generates RSA key pair
+    let server_key = RaopRsaPrivateKey::generate().unwrap();
+
+    // Client generates session keys (would use Apple public key normally)
+    let (client_key, client_iv) = airplay2_rs::protocol::raop::encryption::generate_encryption_keys().unwrap();
+
+    // Client encrypts AES key with server's public key
+    use rsa::Oaep;
+    use sha1::Sha1;
+    use rand::rngs::OsRng;
+
+    let public = server_key.public_key();
+    let padding = Oaep::new::<Sha1>();
+    let encrypted_key = public.encrypt(&mut OsRng, padding, &client_key).unwrap();
+
+    // Server decrypts to get AES key
+    let decrypted_key = server_key.decrypt_oaep(&encrypted_key).unwrap();
+
+    assert_eq!(decrypted_key, client_key);
+
+    // Both sides can now encrypt/decrypt
+    let client_encryptor = RaopEncryptor::new(client_key, client_iv);
+    let server_decryptor = RaopDecryptor::new(
+        client_key.try_into().unwrap(),
+        client_iv,
+    );
+
+    let test_audio = vec![0x55u8; FRAME_SIZE];
+    let encrypted = client_encryptor.encrypt(&test_audio, 0).unwrap();
+    let decrypted = server_decryptor.decrypt(&encrypted, 0).unwrap();
+
+    assert_eq!(decrypted, test_audio);
+}
+
+#[test]
+fn test_unencrypted_mode() {
+    let config = EncryptionConfig::unencrypted();
+
+    assert_eq!(config.mode, EncryptionMode::None);
+    assert!(!config.is_encrypted());
+
+    let encryptor = config.encryptor().unwrap();
+    assert!(!encryptor.is_enabled());
+
+    let data = vec![0xAA; 100];
+    let result = encryptor.encrypt(&data, 0).unwrap();
+    assert_eq!(result, data);
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] AES-128-CTR encryption works correctly
+- [ ] Different packets produce different ciphertext
+- [ ] Decrypt correctly reverses encryption
+- [ ] Key generation produces random keys
+- [ ] RSA key wrapping integrates with key exchange
+- [ ] Unencrypted mode passes data through unchanged
+- [ ] Keys are zeroized on drop
+- [ ] Sequential packet encryption works correctly
+- [ ] All unit tests pass
+- [ ] Integration tests pass
+
+---
+
+## Notes
+
+- The AES counter is derived from packet index, not RTP sequence number
+- Some implementations may use different counter derivation methods
+- FairPlay encryption is not supported (Apple DRM)
+- MFi-SAP encryption requires licensed hardware
+- Consider adding AEAD (AES-GCM) for integrity checking in future

--- a/docs/30-dacp-remote-control.md
+++ b/docs/30-dacp-remote-control.md
@@ -1,0 +1,769 @@
+# Section 30: DACP Remote Control Protocol
+
+## Dependencies
+- **Section 27**: RTSP Session for RAOP (must be complete)
+- **Section 02**: Core Types, Errors & Configuration (must be complete)
+
+## Overview
+
+DACP (Digital Audio Control Protocol) enables AirPlay receivers to send playback commands back to the client (iTunes/Music app). When streaming to an AirPlay device, the client advertises a DACP service that the receiver can use for remote control.
+
+The receiver sends HTTP GET requests to control playback:
+- Play/Pause/Stop
+- Next/Previous track
+- Fast forward/Rewind
+- Volume adjustment
+- Shuffle toggle
+
+## Protocol Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    DACP Service Advertisement                    │
+│                                                                  │
+│  Client (iTunes)                            Receiver (AirPlay)  │
+│    │                                              │              │
+│    │  1. Advertise _dacp._tcp service            │              │
+│    │     (iTunes_Ctrl_{DACP-ID})                 │              │
+│    │                                              │              │
+│    │  2. Include DACP-ID in RTSP headers         │              │
+│    │─────────────────────────────────────────────>│              │
+│    │                                              │              │
+│    │  3. Receiver browses for matching service   │              │
+│    │<─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─│              │
+│    │                                              │              │
+│    │  4. Receiver sends commands via HTTP        │              │
+│    │<─────────────────────────────────────────────│              │
+│    │     GET /ctrl-int/1/playpause               │              │
+│    │     Active-Remote: {token}                  │              │
+│    │                                              │              │
+│    │  5. Client executes command                 │              │
+│    │─────────────────────────────────────────────>│              │
+│    │     204 No Content                          │              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Objectives
+
+- Implement DACP service advertisement
+- Handle incoming HTTP command requests
+- Execute playback control commands
+- Provide callback interface for command handling
+
+---
+
+## Tasks
+
+### 30.1 DACP Service Types
+
+- [ ] **30.1.1** Define DACP constants and types
+
+**File:** `src/protocol/dacp/mod.rs`
+
+```rust
+//! DACP (Digital Audio Control Protocol) for AirPlay remote control
+
+mod service;
+mod commands;
+mod server;
+
+pub use service::{DacpService, DacpServiceConfig};
+pub use commands::{DacpCommand, CommandResult};
+pub use server::{DacpServer, DacpHandler};
+
+/// DACP service type for mDNS
+pub const DACP_SERVICE_TYPE: &str = "_dacp._tcp.local.";
+
+/// Default DACP port
+pub const DACP_DEFAULT_PORT: u16 = 3689;
+
+/// DACP TXT record keys
+pub mod txt_keys {
+    /// TXT record version
+    pub const TXTVERS: &str = "txtvers";
+    /// DACP version
+    pub const VER: &str = "Ver";
+    /// Database ID
+    pub const DBID: &str = "DbId";
+    /// OS information
+    pub const OSSI: &str = "OSsi";
+}
+```
+
+- [ ] **30.1.2** Define DACP commands
+
+**File:** `src/protocol/dacp/commands.rs`
+
+```rust
+//! DACP command definitions
+
+/// DACP playback commands
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DacpCommand {
+    /// Start/resume playback
+    Play,
+    /// Pause playback
+    Pause,
+    /// Toggle play/pause
+    PlayPause,
+    /// Resume from pause
+    PlayResume,
+    /// Stop playback
+    Stop,
+    /// Skip to next track
+    NextItem,
+    /// Go to previous track
+    PrevItem,
+    /// Begin fast forward
+    BeginFastForward,
+    /// Begin rewind
+    BeginRewind,
+    /// End fast forward/rewind
+    PlayResume2,
+    /// Increase volume
+    VolumeUp,
+    /// Decrease volume
+    VolumeDown,
+    /// Toggle mute
+    MuteToggle,
+    /// Shuffle songs
+    ShuffleSongs,
+}
+
+impl DacpCommand {
+    /// Parse from URL path
+    pub fn from_path(path: &str) -> Option<Self> {
+        // Path format: /ctrl-int/1/{command}
+        let command = path.strip_prefix("/ctrl-int/1/")?;
+
+        match command {
+            "play" => Some(Self::Play),
+            "pause" => Some(Self::Pause),
+            "playpause" => Some(Self::PlayPause),
+            "playresume" => Some(Self::PlayResume),
+            "stop" => Some(Self::Stop),
+            "nextitem" => Some(Self::NextItem),
+            "previtem" => Some(Self::PrevItem),
+            "beginff" => Some(Self::BeginFastForward),
+            "beginrew" => Some(Self::BeginRewind),
+            "playresume" => Some(Self::PlayResume2),
+            "volumeup" => Some(Self::VolumeUp),
+            "volumedown" => Some(Self::VolumeDown),
+            "mutetoggle" => Some(Self::MuteToggle),
+            "shuffle_songs" => Some(Self::ShuffleSongs),
+            _ => None,
+        }
+    }
+
+    /// Get URL path for command
+    pub fn path(&self) -> &'static str {
+        match self {
+            Self::Play => "/ctrl-int/1/play",
+            Self::Pause => "/ctrl-int/1/pause",
+            Self::PlayPause => "/ctrl-int/1/playpause",
+            Self::PlayResume | Self::PlayResume2 => "/ctrl-int/1/playresume",
+            Self::Stop => "/ctrl-int/1/stop",
+            Self::NextItem => "/ctrl-int/1/nextitem",
+            Self::PrevItem => "/ctrl-int/1/previtem",
+            Self::BeginFastForward => "/ctrl-int/1/beginff",
+            Self::BeginRewind => "/ctrl-int/1/beginrew",
+            Self::VolumeUp => "/ctrl-int/1/volumeup",
+            Self::VolumeDown => "/ctrl-int/1/volumedown",
+            Self::MuteToggle => "/ctrl-int/1/mutetoggle",
+            Self::ShuffleSongs => "/ctrl-int/1/shuffle_songs",
+        }
+    }
+
+    /// Get human-readable description
+    pub fn description(&self) -> &'static str {
+        match self {
+            Self::Play => "Play",
+            Self::Pause => "Pause",
+            Self::PlayPause => "Play/Pause",
+            Self::PlayResume | Self::PlayResume2 => "Resume",
+            Self::Stop => "Stop",
+            Self::NextItem => "Next Track",
+            Self::PrevItem => "Previous Track",
+            Self::BeginFastForward => "Fast Forward",
+            Self::BeginRewind => "Rewind",
+            Self::VolumeUp => "Volume Up",
+            Self::VolumeDown => "Volume Down",
+            Self::MuteToggle => "Toggle Mute",
+            Self::ShuffleSongs => "Shuffle",
+        }
+    }
+}
+
+/// Result of command execution
+#[derive(Debug, Clone)]
+pub enum CommandResult {
+    /// Command executed successfully
+    Success,
+    /// Command not supported
+    NotSupported,
+    /// Command failed
+    Failed(String),
+}
+```
+
+---
+
+### 30.2 DACP Service Advertisement
+
+- [ ] **30.2.1** Implement DACP service registration
+
+**File:** `src/protocol/dacp/service.rs`
+
+```rust
+//! DACP service advertisement
+
+use super::{DACP_SERVICE_TYPE, DACP_DEFAULT_PORT, txt_keys};
+use std::collections::HashMap;
+
+/// DACP service configuration
+#[derive(Debug, Clone)]
+pub struct DacpServiceConfig {
+    /// DACP ID (64-bit identifier)
+    pub dacp_id: String,
+    /// Active remote token
+    pub active_remote: String,
+    /// Service port
+    pub port: u16,
+    /// Database ID (typically same as DACP ID)
+    pub db_id: String,
+}
+
+impl DacpServiceConfig {
+    /// Create new configuration with random identifiers
+    pub fn new() -> Self {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+
+        let dacp_id = format!("{:016X}", rng.gen::<u64>());
+        let active_remote = rng.gen::<u32>().to_string();
+
+        Self {
+            dacp_id: dacp_id.clone(),
+            active_remote,
+            port: DACP_DEFAULT_PORT,
+            db_id: dacp_id,
+        }
+    }
+
+    /// Get service instance name (iTunes_Ctrl_{DACP_ID})
+    pub fn instance_name(&self) -> String {
+        format!("iTunes_Ctrl_{}", self.dacp_id)
+    }
+
+    /// Get TXT records for service advertisement
+    pub fn txt_records(&self) -> HashMap<String, String> {
+        let mut records = HashMap::new();
+        records.insert(txt_keys::TXTVERS.to_string(), "1".to_string());
+        records.insert(txt_keys::VER.to_string(), "131073".to_string());
+        records.insert(txt_keys::DBID.to_string(), self.db_id.clone());
+        records.insert(txt_keys::OSSI.to_string(), "0x1F5".to_string());
+        records
+    }
+}
+
+impl Default for DacpServiceConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// DACP service for mDNS registration
+pub struct DacpService {
+    /// Configuration
+    config: DacpServiceConfig,
+    /// Whether service is registered
+    registered: bool,
+}
+
+impl DacpService {
+    /// Create new DACP service
+    pub fn new(config: DacpServiceConfig) -> Self {
+        Self {
+            config,
+            registered: false,
+        }
+    }
+
+    /// Get configuration
+    pub fn config(&self) -> &DacpServiceConfig {
+        &self.config
+    }
+
+    /// Get DACP-ID header value
+    pub fn dacp_id(&self) -> &str {
+        &self.config.dacp_id
+    }
+
+    /// Get Active-Remote header value
+    pub fn active_remote(&self) -> &str {
+        &self.config.active_remote
+    }
+
+    /// Register service with mDNS
+    pub async fn register(&mut self) -> Result<(), DacpError> {
+        // Use mdns-sd to register service
+        // Implementation depends on mDNS library
+
+        self.registered = true;
+        Ok(())
+    }
+
+    /// Unregister service
+    pub async fn unregister(&mut self) -> Result<(), DacpError> {
+        self.registered = false;
+        Ok(())
+    }
+
+    /// Check if service is registered
+    pub fn is_registered(&self) -> bool {
+        self.registered
+    }
+}
+
+/// DACP errors
+#[derive(Debug, thiserror::Error)]
+pub enum DacpError {
+    #[error("service registration failed: {0}")]
+    RegistrationFailed(String),
+    #[error("service not registered")]
+    NotRegistered,
+    #[error("invalid command")]
+    InvalidCommand,
+    #[error("authentication failed")]
+    AuthenticationFailed,
+}
+```
+
+---
+
+### 30.3 DACP HTTP Server
+
+- [ ] **30.3.1** Implement HTTP server for DACP commands
+
+**File:** `src/protocol/dacp/server.rs`
+
+```rust
+//! DACP HTTP server for receiving commands
+
+use super::commands::{DacpCommand, CommandResult};
+use super::service::DacpError;
+use std::sync::Arc;
+
+/// Handler trait for DACP commands
+pub trait DacpHandler: Send + Sync {
+    /// Handle incoming command
+    fn handle_command(&self, command: DacpCommand) -> CommandResult;
+
+    /// Verify Active-Remote token
+    fn verify_token(&self, token: &str) -> bool;
+}
+
+/// DACP HTTP server
+pub struct DacpServer<H: DacpHandler> {
+    /// Handler for commands
+    handler: Arc<H>,
+    /// Expected Active-Remote token
+    expected_token: String,
+    /// Server port
+    port: u16,
+    /// Running state
+    running: bool,
+}
+
+impl<H: DacpHandler + 'static> DacpServer<H> {
+    /// Create new DACP server
+    pub fn new(handler: H, expected_token: String, port: u16) -> Self {
+        Self {
+            handler: Arc::new(handler),
+            expected_token,
+            port,
+            running: false,
+        }
+    }
+
+    /// Start the HTTP server
+    pub async fn start(&mut self) -> Result<(), DacpError> {
+        // HTTP server implementation using hyper or similar
+        // Listen for GET requests on /ctrl-int/1/*
+
+        self.running = true;
+
+        // Pseudo-code for request handling:
+        // loop {
+        //     let request = accept_connection().await;
+        //     let token = request.headers.get("Active-Remote");
+        //
+        //     if !self.handler.verify_token(token) {
+        //         respond_403();
+        //         continue;
+        //     }
+        //
+        //     let command = DacpCommand::from_path(request.path());
+        //     let result = self.handler.handle_command(command);
+        //
+        //     respond_204();
+        // }
+
+        Ok(())
+    }
+
+    /// Stop the server
+    pub async fn stop(&mut self) {
+        self.running = false;
+    }
+
+    /// Check if server is running
+    pub fn is_running(&self) -> bool {
+        self.running
+    }
+
+    /// Process an HTTP request (for testing)
+    pub fn process_request(
+        &self,
+        method: &str,
+        path: &str,
+        active_remote: Option<&str>,
+    ) -> HttpResponse {
+        // Only accept GET requests
+        if method != "GET" {
+            return HttpResponse::method_not_allowed();
+        }
+
+        // Verify Active-Remote token
+        match active_remote {
+            Some(token) if self.handler.verify_token(token) => {}
+            _ => return HttpResponse::forbidden(),
+        }
+
+        // Parse command
+        let command = match DacpCommand::from_path(path) {
+            Some(cmd) => cmd,
+            None => return HttpResponse::not_found(),
+        };
+
+        // Execute command
+        let result = self.handler.handle_command(command);
+
+        match result {
+            CommandResult::Success => HttpResponse::no_content(),
+            CommandResult::NotSupported => HttpResponse::not_implemented(),
+            CommandResult::Failed(_) => HttpResponse::internal_error(),
+        }
+    }
+}
+
+/// Simple HTTP response representation
+pub struct HttpResponse {
+    pub status: u16,
+    pub reason: &'static str,
+}
+
+impl HttpResponse {
+    pub fn no_content() -> Self {
+        Self { status: 204, reason: "No Content" }
+    }
+
+    pub fn forbidden() -> Self {
+        Self { status: 403, reason: "Forbidden" }
+    }
+
+    pub fn not_found() -> Self {
+        Self { status: 404, reason: "Not Found" }
+    }
+
+    pub fn method_not_allowed() -> Self {
+        Self { status: 405, reason: "Method Not Allowed" }
+    }
+
+    pub fn not_implemented() -> Self {
+        Self { status: 501, reason: "Not Implemented" }
+    }
+
+    pub fn internal_error() -> Self {
+        Self { status: 500, reason: "Internal Server Error" }
+    }
+}
+
+/// Default command handler that forwards to callbacks
+pub struct CallbackHandler {
+    token: String,
+    on_play: Option<Box<dyn Fn() + Send + Sync>>,
+    on_pause: Option<Box<dyn Fn() + Send + Sync>>,
+    on_next: Option<Box<dyn Fn() + Send + Sync>>,
+    on_previous: Option<Box<dyn Fn() + Send + Sync>>,
+    on_volume_up: Option<Box<dyn Fn() + Send + Sync>>,
+    on_volume_down: Option<Box<dyn Fn() + Send + Sync>>,
+}
+
+impl CallbackHandler {
+    /// Create new callback handler
+    pub fn new(token: String) -> Self {
+        Self {
+            token,
+            on_play: None,
+            on_pause: None,
+            on_next: None,
+            on_previous: None,
+            on_volume_up: None,
+            on_volume_down: None,
+        }
+    }
+
+    /// Set play callback
+    pub fn on_play<F: Fn() + Send + Sync + 'static>(mut self, f: F) -> Self {
+        self.on_play = Some(Box::new(f));
+        self
+    }
+
+    /// Set pause callback
+    pub fn on_pause<F: Fn() + Send + Sync + 'static>(mut self, f: F) -> Self {
+        self.on_pause = Some(Box::new(f));
+        self
+    }
+
+    /// Set next track callback
+    pub fn on_next<F: Fn() + Send + Sync + 'static>(mut self, f: F) -> Self {
+        self.on_next = Some(Box::new(f));
+        self
+    }
+
+    /// Set previous track callback
+    pub fn on_previous<F: Fn() + Send + Sync + 'static>(mut self, f: F) -> Self {
+        self.on_previous = Some(Box::new(f));
+        self
+    }
+}
+
+impl DacpHandler for CallbackHandler {
+    fn handle_command(&self, command: DacpCommand) -> CommandResult {
+        match command {
+            DacpCommand::Play | DacpCommand::PlayResume | DacpCommand::PlayResume2 => {
+                if let Some(ref f) = self.on_play {
+                    f();
+                    CommandResult::Success
+                } else {
+                    CommandResult::NotSupported
+                }
+            }
+            DacpCommand::Pause => {
+                if let Some(ref f) = self.on_pause {
+                    f();
+                    CommandResult::Success
+                } else {
+                    CommandResult::NotSupported
+                }
+            }
+            DacpCommand::PlayPause => {
+                // Toggle - implementation depends on current state
+                CommandResult::Success
+            }
+            DacpCommand::NextItem => {
+                if let Some(ref f) = self.on_next {
+                    f();
+                    CommandResult::Success
+                } else {
+                    CommandResult::NotSupported
+                }
+            }
+            DacpCommand::PrevItem => {
+                if let Some(ref f) = self.on_previous {
+                    f();
+                    CommandResult::Success
+                } else {
+                    CommandResult::NotSupported
+                }
+            }
+            DacpCommand::VolumeUp => {
+                if let Some(ref f) = self.on_volume_up {
+                    f();
+                    CommandResult::Success
+                } else {
+                    CommandResult::NotSupported
+                }
+            }
+            DacpCommand::VolumeDown => {
+                if let Some(ref f) = self.on_volume_down {
+                    f();
+                    CommandResult::Success
+                } else {
+                    CommandResult::NotSupported
+                }
+            }
+            _ => CommandResult::NotSupported,
+        }
+    }
+
+    fn verify_token(&self, token: &str) -> bool {
+        token == self.token
+    }
+}
+```
+
+---
+
+## Unit Tests
+
+### Test File: `src/protocol/dacp/commands.rs`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_from_path() {
+        assert_eq!(
+            DacpCommand::from_path("/ctrl-int/1/play"),
+            Some(DacpCommand::Play)
+        );
+        assert_eq!(
+            DacpCommand::from_path("/ctrl-int/1/playpause"),
+            Some(DacpCommand::PlayPause)
+        );
+        assert_eq!(
+            DacpCommand::from_path("/ctrl-int/1/nextitem"),
+            Some(DacpCommand::NextItem)
+        );
+        assert_eq!(DacpCommand::from_path("/invalid"), None);
+        assert_eq!(DacpCommand::from_path("/ctrl-int/1/unknown"), None);
+    }
+
+    #[test]
+    fn test_command_path_roundtrip() {
+        let commands = [
+            DacpCommand::Play,
+            DacpCommand::Pause,
+            DacpCommand::NextItem,
+            DacpCommand::VolumeUp,
+        ];
+
+        for cmd in commands {
+            let path = cmd.path();
+            let parsed = DacpCommand::from_path(path);
+            assert_eq!(parsed, Some(cmd));
+        }
+    }
+}
+```
+
+### Test File: `src/protocol/dacp/server.rs`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct TestHandler {
+        token: String,
+        play_called: AtomicBool,
+    }
+
+    impl DacpHandler for TestHandler {
+        fn handle_command(&self, command: DacpCommand) -> CommandResult {
+            match command {
+                DacpCommand::Play => {
+                    self.play_called.store(true, Ordering::SeqCst);
+                    CommandResult::Success
+                }
+                _ => CommandResult::NotSupported,
+            }
+        }
+
+        fn verify_token(&self, token: &str) -> bool {
+            token == self.token
+        }
+    }
+
+    #[test]
+    fn test_process_request_success() {
+        let handler = TestHandler {
+            token: "12345".to_string(),
+            play_called: AtomicBool::new(false),
+        };
+
+        let server = DacpServer::new(handler, "12345".to_string(), 3689);
+
+        let response = server.process_request(
+            "GET",
+            "/ctrl-int/1/play",
+            Some("12345"),
+        );
+
+        assert_eq!(response.status, 204);
+    }
+
+    #[test]
+    fn test_process_request_bad_token() {
+        let handler = TestHandler {
+            token: "12345".to_string(),
+            play_called: AtomicBool::new(false),
+        };
+
+        let server = DacpServer::new(handler, "12345".to_string(), 3689);
+
+        let response = server.process_request(
+            "GET",
+            "/ctrl-int/1/play",
+            Some("wrong"),
+        );
+
+        assert_eq!(response.status, 403);
+    }
+
+    #[test]
+    fn test_process_request_unknown_command() {
+        let handler = TestHandler {
+            token: "12345".to_string(),
+            play_called: AtomicBool::new(false),
+        };
+
+        let server = DacpServer::new(handler, "12345".to_string(), 3689);
+
+        let response = server.process_request(
+            "GET",
+            "/ctrl-int/1/unknown",
+            Some("12345"),
+        );
+
+        assert_eq!(response.status, 404);
+    }
+
+    #[test]
+    fn test_service_config() {
+        let config = DacpServiceConfig::new();
+
+        assert!(!config.dacp_id.is_empty());
+        assert!(!config.active_remote.is_empty());
+        assert!(config.instance_name().starts_with("iTunes_Ctrl_"));
+    }
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] DACP service can be advertised via mDNS
+- [ ] All playback commands are recognized
+- [ ] Active-Remote token verification works
+- [ ] HTTP server responds with correct status codes
+- [ ] Callback handlers execute correctly
+- [ ] Service registration and unregistration works
+- [ ] All unit tests pass
+- [ ] Integration tests pass
+
+---
+
+## Notes
+
+- DACP server should run on a separate port from RTSP
+- Some receivers may not use DACP (manual control only)
+- Consider implementing persistent connection for faster response
+- Active-Remote token should be included in all RTSP requests
+- DACP is optional - streaming works without it

--- a/docs/31-daap-metadata.md
+++ b/docs/31-daap-metadata.md
@@ -1,0 +1,861 @@
+# Section 31: DAAP/DMAP Metadata Protocol
+
+## Dependencies
+- **Section 27**: RTSP Session for RAOP (must be complete)
+- **Section 03**: Binary Plist Codec (helpful for understanding encoding)
+
+## Overview
+
+RAOP supports transmitting track metadata (title, artist, album), artwork (cover images), and playback progress to AirPlay receivers. This uses a subset of DAAP (Digital Audio Access Protocol) with DMAP (Digital Media Access Protocol) encoding.
+
+Metadata is sent via RTSP `SET_PARAMETER` requests with specific content types:
+- **Track info**: `application/x-dmap-tagged` (DAAP format)
+- **Artwork**: `image/jpeg` or `image/png`
+- **Progress**: `text/parameters` (plain text)
+
+## Protocol Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Metadata Transmission                         │
+│                                                                  │
+│  Client                                           Server         │
+│    │                                                │            │
+│    │  SET_PARAMETER (track info)                   │            │
+│    │  Content-Type: application/x-dmap-tagged      │            │
+│    │  RTP-Info: rtptime={timestamp}                │            │
+│    │─────────────────────────────────────────────>│            │
+│    │                                                │            │
+│    │  SET_PARAMETER (artwork)                      │            │
+│    │  Content-Type: image/jpeg                     │            │
+│    │  RTP-Info: rtptime={timestamp}                │            │
+│    │─────────────────────────────────────────────>│            │
+│    │                                                │            │
+│    │  SET_PARAMETER (progress)                     │            │
+│    │  Content-Type: text/parameters                │            │
+│    │─────────────────────────────────────────────>│            │
+│    │                                                │            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Objectives
+
+- Implement DMAP encoding for track metadata
+- Support JPEG/PNG artwork transmission
+- Implement progress reporting
+- Integrate with RTSP session management
+
+---
+
+## Tasks
+
+### 31.1 DMAP Encoding
+
+- [ ] **31.1.1** Implement DMAP types and encoder
+
+**File:** `src/protocol/daap/mod.rs`
+
+```rust
+//! DAAP/DMAP metadata protocol for RAOP
+
+mod dmap;
+mod metadata;
+mod artwork;
+mod progress;
+
+pub use dmap::{DmapEncoder, DmapTag};
+pub use metadata::{TrackMetadata, MetadataBuilder};
+pub use artwork::{Artwork, ArtworkFormat};
+pub use progress::PlaybackProgress;
+```
+
+**File:** `src/protocol/daap/dmap.rs`
+
+```rust
+//! DMAP (Digital Media Access Protocol) encoding
+
+use std::io::Write;
+
+/// DMAP content codes (tags)
+#[derive(Debug, Clone, Copy)]
+pub enum DmapTag {
+    /// Item name (track title)
+    ItemName,
+    /// Song artist
+    SongArtist,
+    /// Song album
+    SongAlbum,
+    /// Song genre
+    SongGenre,
+    /// Song track number
+    SongTrackNumber,
+    /// Song disc number
+    SongDiscNumber,
+    /// Song year
+    SongYear,
+    /// Song time (duration in ms)
+    SongTime,
+    /// Container listing
+    Listing,
+    /// Listing item
+    ListingItem,
+    /// Database songs
+    DatabaseSongs,
+}
+
+impl DmapTag {
+    /// Get 4-character code for tag
+    pub fn code(&self) -> &'static [u8; 4] {
+        match self {
+            Self::ItemName => b"minm",
+            Self::SongArtist => b"asar",
+            Self::SongAlbum => b"asal",
+            Self::SongGenre => b"asgn",
+            Self::SongTrackNumber => b"astn",
+            Self::SongDiscNumber => b"asdn",
+            Self::SongYear => b"asyr",
+            Self::SongTime => b"astm",
+            Self::Listing => b"mlcl",
+            Self::ListingItem => b"mlit",
+            Self::DatabaseSongs => b"adbs",
+        }
+    }
+}
+
+/// DMAP value types
+pub enum DmapValue {
+    /// String value (UTF-8)
+    String(String),
+    /// Integer value (various sizes)
+    Int(i64),
+    /// Container (nested DMAP)
+    Container(Vec<(DmapTag, DmapValue)>),
+    /// Raw bytes
+    Raw(Vec<u8>),
+}
+
+/// DMAP encoder
+pub struct DmapEncoder {
+    buffer: Vec<u8>,
+}
+
+impl DmapEncoder {
+    /// Create new encoder
+    pub fn new() -> Self {
+        Self {
+            buffer: Vec::new(),
+        }
+    }
+
+    /// Encode a tag-value pair
+    pub fn encode_tag(&mut self, tag: DmapTag, value: &DmapValue) {
+        // Write 4-byte tag code
+        self.buffer.extend_from_slice(tag.code());
+
+        match value {
+            DmapValue::String(s) => {
+                // Write length (4 bytes, big-endian)
+                let len = s.len() as u32;
+                self.buffer.extend_from_slice(&len.to_be_bytes());
+                // Write string bytes
+                self.buffer.extend_from_slice(s.as_bytes());
+            }
+            DmapValue::Int(n) => {
+                // Determine appropriate size
+                if *n >= 0 && *n <= 255 {
+                    self.buffer.extend_from_slice(&1u32.to_be_bytes());
+                    self.buffer.push(*n as u8);
+                } else if *n >= i16::MIN as i64 && *n <= i16::MAX as i64 {
+                    self.buffer.extend_from_slice(&2u32.to_be_bytes());
+                    self.buffer.extend_from_slice(&(*n as i16).to_be_bytes());
+                } else if *n >= i32::MIN as i64 && *n <= i32::MAX as i64 {
+                    self.buffer.extend_from_slice(&4u32.to_be_bytes());
+                    self.buffer.extend_from_slice(&(*n as i32).to_be_bytes());
+                } else {
+                    self.buffer.extend_from_slice(&8u32.to_be_bytes());
+                    self.buffer.extend_from_slice(&n.to_be_bytes());
+                }
+            }
+            DmapValue::Container(items) => {
+                // Encode container contents first
+                let mut inner = DmapEncoder::new();
+                for (inner_tag, inner_value) in items {
+                    inner.encode_tag(*inner_tag, inner_value);
+                }
+                let inner_data = inner.finish();
+
+                // Write length and contents
+                let len = inner_data.len() as u32;
+                self.buffer.extend_from_slice(&len.to_be_bytes());
+                self.buffer.extend_from_slice(&inner_data);
+            }
+            DmapValue::Raw(data) => {
+                let len = data.len() as u32;
+                self.buffer.extend_from_slice(&len.to_be_bytes());
+                self.buffer.extend_from_slice(data);
+            }
+        }
+    }
+
+    /// Add string tag
+    pub fn string(&mut self, tag: DmapTag, value: &str) {
+        self.encode_tag(tag, &DmapValue::String(value.to_string()));
+    }
+
+    /// Add integer tag
+    pub fn int(&mut self, tag: DmapTag, value: i64) {
+        self.encode_tag(tag, &DmapValue::Int(value));
+    }
+
+    /// Finish encoding and return bytes
+    pub fn finish(self) -> Vec<u8> {
+        self.buffer
+    }
+}
+
+impl Default for DmapEncoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Decode DMAP data (for testing/debugging)
+pub fn decode_dmap(data: &[u8]) -> Result<Vec<(String, String)>, DmapDecodeError> {
+    let mut result = Vec::new();
+    let mut pos = 0;
+
+    while pos + 8 <= data.len() {
+        let tag = std::str::from_utf8(&data[pos..pos + 4])
+            .map_err(|_| DmapDecodeError::InvalidTag)?;
+        let len = u32::from_be_bytes([
+            data[pos + 4],
+            data[pos + 5],
+            data[pos + 6],
+            data[pos + 7],
+        ]) as usize;
+
+        pos += 8;
+
+        if pos + len > data.len() {
+            return Err(DmapDecodeError::UnexpectedEnd);
+        }
+
+        let value_bytes = &data[pos..pos + len];
+
+        // Try to decode as string
+        let value = String::from_utf8_lossy(value_bytes).to_string();
+
+        result.push((tag.to_string(), value));
+        pos += len;
+    }
+
+    Ok(result)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DmapDecodeError {
+    #[error("invalid tag")]
+    InvalidTag,
+    #[error("unexpected end of data")]
+    UnexpectedEnd,
+}
+```
+
+---
+
+### 31.2 Track Metadata
+
+- [ ] **31.2.1** Implement track metadata encoding
+
+**File:** `src/protocol/daap/metadata.rs`
+
+```rust
+//! Track metadata for RAOP
+
+use super::dmap::{DmapEncoder, DmapTag};
+
+/// Track metadata information
+#[derive(Debug, Clone, Default)]
+pub struct TrackMetadata {
+    /// Track title
+    pub title: Option<String>,
+    /// Artist name
+    pub artist: Option<String>,
+    /// Album name
+    pub album: Option<String>,
+    /// Genre
+    pub genre: Option<String>,
+    /// Track number
+    pub track_number: Option<u32>,
+    /// Disc number
+    pub disc_number: Option<u32>,
+    /// Year
+    pub year: Option<u32>,
+    /// Duration in milliseconds
+    pub duration_ms: Option<u32>,
+}
+
+impl TrackMetadata {
+    /// Create new empty metadata
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create builder
+    pub fn builder() -> MetadataBuilder {
+        MetadataBuilder::new()
+    }
+
+    /// Encode as DMAP for SET_PARAMETER
+    pub fn encode_dmap(&self) -> Vec<u8> {
+        let mut encoder = DmapEncoder::new();
+
+        // Wrap in mlit (listing item) container
+        let mut item_encoder = DmapEncoder::new();
+
+        if let Some(ref title) = self.title {
+            item_encoder.string(DmapTag::ItemName, title);
+        }
+
+        if let Some(ref artist) = self.artist {
+            item_encoder.string(DmapTag::SongArtist, artist);
+        }
+
+        if let Some(ref album) = self.album {
+            item_encoder.string(DmapTag::SongAlbum, album);
+        }
+
+        if let Some(ref genre) = self.genre {
+            item_encoder.string(DmapTag::SongGenre, genre);
+        }
+
+        if let Some(track) = self.track_number {
+            item_encoder.int(DmapTag::SongTrackNumber, track as i64);
+        }
+
+        if let Some(disc) = self.disc_number {
+            item_encoder.int(DmapTag::SongDiscNumber, disc as i64);
+        }
+
+        if let Some(year) = self.year {
+            item_encoder.int(DmapTag::SongYear, year as i64);
+        }
+
+        if let Some(duration) = self.duration_ms {
+            item_encoder.int(DmapTag::SongTime, duration as i64);
+        }
+
+        item_encoder.finish()
+    }
+
+    /// Check if metadata is empty
+    pub fn is_empty(&self) -> bool {
+        self.title.is_none()
+            && self.artist.is_none()
+            && self.album.is_none()
+            && self.genre.is_none()
+            && self.track_number.is_none()
+            && self.duration_ms.is_none()
+    }
+}
+
+/// Builder for track metadata
+pub struct MetadataBuilder {
+    metadata: TrackMetadata,
+}
+
+impl MetadataBuilder {
+    /// Create new builder
+    pub fn new() -> Self {
+        Self {
+            metadata: TrackMetadata::new(),
+        }
+    }
+
+    /// Set title
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.metadata.title = Some(title.into());
+        self
+    }
+
+    /// Set artist
+    pub fn artist(mut self, artist: impl Into<String>) -> Self {
+        self.metadata.artist = Some(artist.into());
+        self
+    }
+
+    /// Set album
+    pub fn album(mut self, album: impl Into<String>) -> Self {
+        self.metadata.album = Some(album.into());
+        self
+    }
+
+    /// Set genre
+    pub fn genre(mut self, genre: impl Into<String>) -> Self {
+        self.metadata.genre = Some(genre.into());
+        self
+    }
+
+    /// Set track number
+    pub fn track_number(mut self, track: u32) -> Self {
+        self.metadata.track_number = Some(track);
+        self
+    }
+
+    /// Set disc number
+    pub fn disc_number(mut self, disc: u32) -> Self {
+        self.metadata.disc_number = Some(disc);
+        self
+    }
+
+    /// Set year
+    pub fn year(mut self, year: u32) -> Self {
+        self.metadata.year = Some(year);
+        self
+    }
+
+    /// Set duration in milliseconds
+    pub fn duration_ms(mut self, duration: u32) -> Self {
+        self.metadata.duration_ms = Some(duration);
+        self
+    }
+
+    /// Build the metadata
+    pub fn build(self) -> TrackMetadata {
+        self.metadata
+    }
+}
+
+impl Default for MetadataBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+```
+
+---
+
+### 31.3 Artwork
+
+- [ ] **31.3.1** Implement artwork transmission
+
+**File:** `src/protocol/daap/artwork.rs`
+
+```rust
+//! Album artwork for RAOP
+
+/// Artwork image format
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtworkFormat {
+    /// JPEG image
+    Jpeg,
+    /// PNG image
+    Png,
+}
+
+impl ArtworkFormat {
+    /// Get MIME type
+    pub fn mime_type(&self) -> &'static str {
+        match self {
+            Self::Jpeg => "image/jpeg",
+            Self::Png => "image/png",
+        }
+    }
+
+    /// Detect format from data
+    pub fn detect(data: &[u8]) -> Option<Self> {
+        if data.len() < 4 {
+            return None;
+        }
+
+        // JPEG magic bytes
+        if data[0..2] == [0xFF, 0xD8] {
+            return Some(Self::Jpeg);
+        }
+
+        // PNG magic bytes
+        if data[0..4] == [0x89, 0x50, 0x4E, 0x47] {
+            return Some(Self::Png);
+        }
+
+        None
+    }
+}
+
+/// Album artwork
+#[derive(Debug, Clone)]
+pub struct Artwork {
+    /// Image data
+    pub data: Vec<u8>,
+    /// Image format
+    pub format: ArtworkFormat,
+}
+
+impl Artwork {
+    /// Create artwork from JPEG data
+    pub fn jpeg(data: Vec<u8>) -> Self {
+        Self {
+            data,
+            format: ArtworkFormat::Jpeg,
+        }
+    }
+
+    /// Create artwork from PNG data
+    pub fn png(data: Vec<u8>) -> Self {
+        Self {
+            data,
+            format: ArtworkFormat::Png,
+        }
+    }
+
+    /// Create artwork with auto-detected format
+    pub fn from_data(data: Vec<u8>) -> Option<Self> {
+        let format = ArtworkFormat::detect(&data)?;
+        Some(Self { data, format })
+    }
+
+    /// Get MIME type for Content-Type header
+    pub fn mime_type(&self) -> &'static str {
+        self.format.mime_type()
+    }
+
+    /// Get image dimensions (basic parsing)
+    pub fn dimensions(&self) -> Option<(u32, u32)> {
+        match self.format {
+            ArtworkFormat::Jpeg => self.jpeg_dimensions(),
+            ArtworkFormat::Png => self.png_dimensions(),
+        }
+    }
+
+    fn jpeg_dimensions(&self) -> Option<(u32, u32)> {
+        // Simple JPEG dimension parser
+        let mut pos = 2;
+
+        while pos < self.data.len() - 4 {
+            if self.data[pos] != 0xFF {
+                pos += 1;
+                continue;
+            }
+
+            let marker = self.data[pos + 1];
+
+            // SOF markers contain dimensions
+            if (0xC0..=0xCF).contains(&marker) && marker != 0xC4 && marker != 0xC8 && marker != 0xCC {
+                if pos + 9 < self.data.len() {
+                    let height = u16::from_be_bytes([
+                        self.data[pos + 5],
+                        self.data[pos + 6],
+                    ]) as u32;
+                    let width = u16::from_be_bytes([
+                        self.data[pos + 7],
+                        self.data[pos + 8],
+                    ]) as u32;
+                    return Some((width, height));
+                }
+            }
+
+            // Skip to next marker
+            if pos + 3 < self.data.len() {
+                let len = u16::from_be_bytes([
+                    self.data[pos + 2],
+                    self.data[pos + 3],
+                ]) as usize;
+                pos += 2 + len;
+            } else {
+                break;
+            }
+        }
+
+        None
+    }
+
+    fn png_dimensions(&self) -> Option<(u32, u32)> {
+        // PNG IHDR chunk contains dimensions at bytes 16-23
+        if self.data.len() < 24 {
+            return None;
+        }
+
+        let width = u32::from_be_bytes([
+            self.data[16],
+            self.data[17],
+            self.data[18],
+            self.data[19],
+        ]);
+        let height = u32::from_be_bytes([
+            self.data[20],
+            self.data[21],
+            self.data[22],
+            self.data[23],
+        ]);
+
+        Some((width, height))
+    }
+}
+```
+
+---
+
+### 31.4 Progress Reporting
+
+- [ ] **31.4.1** Implement progress updates
+
+**File:** `src/protocol/daap/progress.rs`
+
+```rust
+//! Playback progress for RAOP
+
+/// Playback progress information
+#[derive(Debug, Clone, Copy)]
+pub struct PlaybackProgress {
+    /// RTP timestamp of track start
+    pub start: u32,
+    /// RTP timestamp of current position
+    pub current: u32,
+    /// RTP timestamp of track end
+    pub end: u32,
+}
+
+impl PlaybackProgress {
+    /// Create new progress
+    pub fn new(start: u32, current: u32, end: u32) -> Self {
+        Self { start, current, end }
+    }
+
+    /// Create progress for track at given position
+    ///
+    /// # Arguments
+    /// * `base_timestamp` - RTP timestamp at track start
+    /// * `position_samples` - Current position in samples
+    /// * `duration_samples` - Total duration in samples
+    pub fn from_samples(
+        base_timestamp: u32,
+        position_samples: u32,
+        duration_samples: u32,
+    ) -> Self {
+        Self {
+            start: base_timestamp,
+            current: base_timestamp.wrapping_add(position_samples),
+            end: base_timestamp.wrapping_add(duration_samples),
+        }
+    }
+
+    /// Encode as text/parameters body
+    pub fn encode(&self) -> String {
+        format!("progress: {}/{}/{}\r\n", self.start, self.current, self.end)
+    }
+
+    /// Get current position in seconds (at 44.1kHz)
+    pub fn position_secs(&self) -> f64 {
+        let samples = self.current.wrapping_sub(self.start);
+        samples as f64 / 44100.0
+    }
+
+    /// Get duration in seconds (at 44.1kHz)
+    pub fn duration_secs(&self) -> f64 {
+        let samples = self.end.wrapping_sub(self.start);
+        samples as f64 / 44100.0
+    }
+
+    /// Get progress as percentage (0.0 - 1.0)
+    pub fn percentage(&self) -> f64 {
+        let total = self.end.wrapping_sub(self.start) as f64;
+        if total == 0.0 {
+            return 0.0;
+        }
+        let current = self.current.wrapping_sub(self.start) as f64;
+        (current / total).clamp(0.0, 1.0)
+    }
+
+    /// Parse from text/parameters body
+    pub fn parse(text: &str) -> Option<Self> {
+        let line = text.lines().find(|l| l.starts_with("progress:"))?;
+        let values = line.strip_prefix("progress:")?.trim();
+        let parts: Vec<&str> = values.split('/').collect();
+
+        if parts.len() != 3 {
+            return None;
+        }
+
+        Some(Self {
+            start: parts[0].trim().parse().ok()?,
+            current: parts[1].trim().parse().ok()?,
+            end: parts[2].trim().parse().ok()?,
+        })
+    }
+}
+```
+
+---
+
+### 31.5 Metadata RTSP Integration
+
+- [ ] **31.5.1** Add metadata methods to RAOP session
+
+**File:** `src/protocol/raop/session.rs` (additions)
+
+```rust
+impl RaopRtspSession {
+    /// Send track metadata
+    pub fn set_metadata_request(
+        &mut self,
+        metadata: &TrackMetadata,
+        rtptime: u32,
+    ) -> RtspRequest {
+        let cseq = self.next_cseq();
+        let builder = RtspRequest::builder(Method::SetParameter, self.uri(""));
+
+        let body = metadata.encode_dmap();
+
+        self.add_common_headers(builder, cseq)
+            .header(names::CONTENT_TYPE, "application/x-dmap-tagged")
+            .header("RTP-Info", format!("rtptime={}", rtptime))
+            .body(body)
+            .build()
+    }
+
+    /// Send artwork
+    pub fn set_artwork_request(
+        &mut self,
+        artwork: &Artwork,
+        rtptime: u32,
+    ) -> RtspRequest {
+        let cseq = self.next_cseq();
+        let builder = RtspRequest::builder(Method::SetParameter, self.uri(""));
+
+        self.add_common_headers(builder, cseq)
+            .header(names::CONTENT_TYPE, artwork.mime_type())
+            .header("RTP-Info", format!("rtptime={}", rtptime))
+            .body(artwork.data.clone())
+            .build()
+    }
+
+    /// Send progress update
+    pub fn set_progress_request(
+        &mut self,
+        progress: &PlaybackProgress,
+    ) -> RtspRequest {
+        let cseq = self.next_cseq();
+        let builder = RtspRequest::builder(Method::SetParameter, self.uri(""));
+
+        self.add_common_headers(builder, cseq)
+            .header(names::CONTENT_TYPE, "text/parameters")
+            .body(progress.encode().into_bytes())
+            .build()
+    }
+}
+```
+
+---
+
+## Unit Tests
+
+### Test File: `src/protocol/daap/dmap.rs`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_string() {
+        let mut encoder = DmapEncoder::new();
+        encoder.string(DmapTag::ItemName, "Test Song");
+
+        let data = encoder.finish();
+
+        // Tag (4) + Length (4) + "Test Song" (9) = 17 bytes
+        assert_eq!(data.len(), 17);
+        assert_eq!(&data[0..4], b"minm");
+        assert_eq!(u32::from_be_bytes([data[4], data[5], data[6], data[7]]), 9);
+        assert_eq!(&data[8..], b"Test Song");
+    }
+
+    #[test]
+    fn test_encode_decode_roundtrip() {
+        let mut encoder = DmapEncoder::new();
+        encoder.string(DmapTag::ItemName, "My Track");
+        encoder.string(DmapTag::SongArtist, "Artist Name");
+
+        let data = encoder.finish();
+        let decoded = decode_dmap(&data).unwrap();
+
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(decoded[0].0, "minm");
+        assert_eq!(decoded[0].1, "My Track");
+        assert_eq!(decoded[1].0, "asar");
+        assert_eq!(decoded[1].1, "Artist Name");
+    }
+}
+```
+
+### Test File: `src/protocol/daap/progress.rs`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_progress_encode() {
+        let progress = PlaybackProgress::new(0, 44100, 441000);
+        let encoded = progress.encode();
+
+        assert_eq!(encoded, "progress: 0/44100/441000\r\n");
+    }
+
+    #[test]
+    fn test_progress_parse() {
+        let text = "progress: 1000/2000/3000\r\n";
+        let progress = PlaybackProgress::parse(text).unwrap();
+
+        assert_eq!(progress.start, 1000);
+        assert_eq!(progress.current, 2000);
+        assert_eq!(progress.end, 3000);
+    }
+
+    #[test]
+    fn test_progress_percentage() {
+        let progress = PlaybackProgress::new(0, 50, 100);
+        assert!((progress.percentage() - 0.5).abs() < 0.001);
+
+        let progress = PlaybackProgress::new(0, 0, 100);
+        assert!((progress.percentage() - 0.0).abs() < 0.001);
+
+        let progress = PlaybackProgress::new(0, 100, 100);
+        assert!((progress.percentage() - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_progress_from_samples() {
+        // 10 seconds at 44.1kHz
+        let progress = PlaybackProgress::from_samples(1000, 441000, 4410000);
+
+        assert_eq!(progress.start, 1000);
+        assert_eq!(progress.current, 442000);
+        assert_eq!(progress.end, 4411000);
+    }
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] DMAP encoding produces valid output
+- [ ] Track metadata includes all relevant fields
+- [ ] Artwork format detection works correctly
+- [ ] Progress encoding/parsing is correct
+- [ ] RTSP integration uses correct content types
+- [ ] RTP-Info header includes timestamp
+- [ ] All unit tests pass
+- [ ] Integration tests pass
+
+---
+
+## Notes
+
+- Metadata should be sent before or at the start of playback
+- Progress updates can be sent periodically (every second)
+- Artwork should be reasonably sized (typically 500x500 or less)
+- Some receivers may ignore certain metadata fields
+- DMAP encoding is big-endian for integers

--- a/docs/32-airplay1-integration.md
+++ b/docs/32-airplay1-integration.md
@@ -1,0 +1,700 @@
+# Section 32: AirPlay 1 Integration Guide
+
+## Dependencies
+- All previous AirPlay 1 sections (24-31)
+- **Section 21**: AirPlayClient Implementation (for reference)
+- **Section 22**: High-Level API (for integration patterns)
+
+## Overview
+
+This section describes how to integrate AirPlay 1 (RAOP) support with the existing AirPlay 2 codebase, creating a unified client API that can transparently handle both protocol versions.
+
+## Architecture Design
+
+### Unified Client Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    AirPlayClient (Unified API)                   │
+│                                                                  │
+│  ┌─────────────────────────────────────────────────────────┐    │
+│  │                   Public Interface                       │    │
+│  │  connect() | play() | pause() | set_volume() | ...      │    │
+│  └─────────────────────────────────────────────────────────┘    │
+│                              │                                   │
+│              ┌───────────────┴───────────────┐                  │
+│              ▼                               ▼                   │
+│  ┌──────────────────────┐       ┌──────────────────────┐       │
+│  │   AirPlay2Session    │       │    RaopSession       │       │
+│  │                      │       │                      │       │
+│  │  - HomeKit pairing   │       │  - RSA authentication│       │
+│  │  - Binary plist RTSP │       │  - SDP-based RTSP    │       │
+│  │  - ChaCha20/AES-GCM  │       │  - AES-128-CTR       │       │
+│  │  - Multi-room        │       │  - DACP/DAAP         │       │
+│  └──────────────────────┘       └──────────────────────┘       │
+│              │                               │                   │
+│              └───────────────┬───────────────┘                  │
+│                              ▼                                   │
+│  ┌─────────────────────────────────────────────────────────┐    │
+│  │                   Shared Components                      │    │
+│  │  RTSP Codec | RTP Streaming | Audio Encoding | mDNS     │    │
+│  └─────────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Tasks
+
+### 32.1 Protocol Detection
+
+- [ ] **32.1.1** Implement automatic protocol detection
+
+**File:** `src/client/protocol.rs`
+
+```rust
+//! Protocol detection and selection
+
+use crate::discovery::{DiscoveredDevice, DeviceProtocol};
+use crate::types::DeviceCapabilities;
+use crate::discovery::raop::RaopCapabilities;
+
+/// Preferred protocol for connection
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PreferredProtocol {
+    /// Prefer AirPlay 2 when available
+    #[default]
+    PreferAirPlay2,
+    /// Prefer AirPlay 1 (RAOP) when available
+    PreferRaop,
+    /// Force AirPlay 2 only
+    ForceAirPlay2,
+    /// Force RAOP only
+    ForceRaop,
+}
+
+/// Protocol selection result
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectedProtocol {
+    /// Use AirPlay 2
+    AirPlay2,
+    /// Use AirPlay 1 (RAOP)
+    Raop,
+}
+
+/// Select protocol for device connection
+pub fn select_protocol(
+    device: &DiscoveredDevice,
+    preferred: PreferredProtocol,
+) -> Result<SelectedProtocol, ProtocolError> {
+    match preferred {
+        PreferredProtocol::ForceAirPlay2 => {
+            if device.supports_airplay2() {
+                Ok(SelectedProtocol::AirPlay2)
+            } else {
+                Err(ProtocolError::AirPlay2NotSupported)
+            }
+        }
+        PreferredProtocol::ForceRaop => {
+            if device.supports_raop() {
+                Ok(SelectedProtocol::Raop)
+            } else {
+                Err(ProtocolError::RaopNotSupported)
+            }
+        }
+        PreferredProtocol::PreferAirPlay2 => {
+            if device.supports_airplay2() {
+                Ok(SelectedProtocol::AirPlay2)
+            } else if device.supports_raop() {
+                Ok(SelectedProtocol::Raop)
+            } else {
+                Err(ProtocolError::NoSupportedProtocol)
+            }
+        }
+        PreferredProtocol::PreferRaop => {
+            if device.supports_raop() {
+                Ok(SelectedProtocol::Raop)
+            } else if device.supports_airplay2() {
+                Ok(SelectedProtocol::AirPlay2)
+            } else {
+                Err(ProtocolError::NoSupportedProtocol)
+            }
+        }
+    }
+}
+
+/// Check if RAOP encryption is compatible
+pub fn check_raop_encryption(caps: &RaopCapabilities) -> Result<(), ProtocolError> {
+    if let Some(enc) = caps.preferred_encryption() {
+        if enc.is_supported() {
+            Ok(())
+        } else {
+            Err(ProtocolError::UnsupportedEncryption)
+        }
+    } else {
+        Err(ProtocolError::UnsupportedEncryption)
+    }
+}
+
+/// Protocol errors
+#[derive(Debug, thiserror::Error)]
+pub enum ProtocolError {
+    #[error("AirPlay 2 not supported by device")]
+    AirPlay2NotSupported,
+    #[error("RAOP not supported by device")]
+    RaopNotSupported,
+    #[error("no supported protocol available")]
+    NoSupportedProtocol,
+    #[error("unsupported encryption type")]
+    UnsupportedEncryption,
+}
+```
+
+---
+
+### 32.2 Session Abstraction
+
+- [ ] **32.2.1** Define common session trait
+
+**File:** `src/client/session.rs`
+
+```rust
+//! Unified session abstraction
+
+use async_trait::async_trait;
+use crate::error::AirPlayError;
+use crate::types::{TrackInfo, PlaybackState};
+
+/// Common session operations for both AirPlay 1 and 2
+#[async_trait]
+pub trait AirPlaySession: Send + Sync {
+    /// Connect to the device
+    async fn connect(&mut self) -> Result<(), AirPlayError>;
+
+    /// Disconnect from the device
+    async fn disconnect(&mut self) -> Result<(), AirPlayError>;
+
+    /// Check if connected
+    fn is_connected(&self) -> bool;
+
+    /// Start playback
+    async fn play(&mut self) -> Result<(), AirPlayError>;
+
+    /// Pause playback
+    async fn pause(&mut self) -> Result<(), AirPlayError>;
+
+    /// Stop playback
+    async fn stop(&mut self) -> Result<(), AirPlayError>;
+
+    /// Set volume (0.0 - 1.0)
+    async fn set_volume(&mut self, volume: f32) -> Result<(), AirPlayError>;
+
+    /// Get current volume
+    async fn get_volume(&self) -> Result<f32, AirPlayError>;
+
+    /// Stream audio data
+    async fn stream_audio(&mut self, data: &[u8]) -> Result<(), AirPlayError>;
+
+    /// Flush audio buffer
+    async fn flush(&mut self) -> Result<(), AirPlayError>;
+
+    /// Set track metadata
+    async fn set_metadata(&mut self, track: &TrackInfo) -> Result<(), AirPlayError>;
+
+    /// Set artwork
+    async fn set_artwork(&mut self, data: &[u8]) -> Result<(), AirPlayError>;
+
+    /// Get playback state
+    fn playback_state(&self) -> PlaybackState;
+
+    /// Get protocol version string
+    fn protocol_version(&self) -> &'static str;
+}
+
+/// RAOP session implementation
+pub struct RaopSessionImpl {
+    // RAOP-specific fields
+    rtsp_session: crate::protocol::raop::RaopRtspSession,
+    streamer: Option<crate::streaming::raop_streamer::RaopStreamer>,
+    connected: bool,
+    volume: f32,
+    state: PlaybackState,
+}
+
+impl RaopSessionImpl {
+    /// Create new RAOP session
+    pub fn new(server_addr: &str, server_port: u16) -> Self {
+        Self {
+            rtsp_session: crate::protocol::raop::RaopRtspSession::new(server_addr, server_port),
+            streamer: None,
+            connected: false,
+            volume: 1.0,
+            state: PlaybackState::Stopped,
+        }
+    }
+}
+
+#[async_trait]
+impl AirPlaySession for RaopSessionImpl {
+    async fn connect(&mut self) -> Result<(), AirPlayError> {
+        // 1. Send OPTIONS with Apple-Challenge
+        // 2. Send ANNOUNCE with SDP
+        // 3. Send SETUP to configure transport
+        // 4. Initialize audio streamer
+
+        self.connected = true;
+        Ok(())
+    }
+
+    async fn disconnect(&mut self) -> Result<(), AirPlayError> {
+        // Send TEARDOWN
+        self.connected = false;
+        self.state = PlaybackState::Stopped;
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected
+    }
+
+    async fn play(&mut self) -> Result<(), AirPlayError> {
+        // Send RECORD
+        self.state = PlaybackState::Playing;
+        Ok(())
+    }
+
+    async fn pause(&mut self) -> Result<(), AirPlayError> {
+        // Send FLUSH
+        self.state = PlaybackState::Paused;
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<(), AirPlayError> {
+        // Send FLUSH + TEARDOWN
+        self.state = PlaybackState::Stopped;
+        Ok(())
+    }
+
+    async fn set_volume(&mut self, volume: f32) -> Result<(), AirPlayError> {
+        // Convert to dB: 0.0 = -144dB (mute), 1.0 = 0dB
+        let db = if volume <= 0.0 {
+            -144.0
+        } else {
+            30.0 * (volume.clamp(0.0, 1.0)).log10()
+        };
+
+        // Send SET_PARAMETER with volume
+        self.volume = volume;
+        Ok(())
+    }
+
+    async fn get_volume(&self) -> Result<f32, AirPlayError> {
+        Ok(self.volume)
+    }
+
+    async fn stream_audio(&mut self, data: &[u8]) -> Result<(), AirPlayError> {
+        if let Some(ref mut streamer) = self.streamer {
+            let _packet = streamer.encode_frame(data);
+            // Send packet via UDP
+        }
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<(), AirPlayError> {
+        if let Some(ref mut streamer) = self.streamer {
+            streamer.flush();
+        }
+        Ok(())
+    }
+
+    async fn set_metadata(&mut self, track: &TrackInfo) -> Result<(), AirPlayError> {
+        // Convert TrackInfo to DAAP format and send
+        Ok(())
+    }
+
+    async fn set_artwork(&mut self, data: &[u8]) -> Result<(), AirPlayError> {
+        // Send artwork via SET_PARAMETER
+        Ok(())
+    }
+
+    fn playback_state(&self) -> PlaybackState {
+        self.state.clone()
+    }
+
+    fn protocol_version(&self) -> &'static str {
+        "RAOP/1.0"
+    }
+}
+```
+
+---
+
+### 32.3 Unified Client
+
+- [ ] **32.3.1** Extend AirPlayClient for dual protocol support
+
+**File:** `src/client/mod.rs` (extensions)
+
+```rust
+//! Unified AirPlay client
+
+use crate::discovery::DiscoveredDevice;
+use crate::error::AirPlayError;
+
+mod protocol;
+mod session;
+
+pub use protocol::{PreferredProtocol, SelectedProtocol, select_protocol};
+pub use session::{AirPlaySession, RaopSessionImpl};
+
+/// Unified AirPlay client configuration
+#[derive(Debug, Clone)]
+pub struct ClientConfig {
+    /// Preferred protocol
+    pub preferred_protocol: PreferredProtocol,
+    /// Connection timeout
+    pub connection_timeout: std::time::Duration,
+    /// Enable DACP remote control (RAOP)
+    pub enable_dacp: bool,
+    /// Enable metadata transmission
+    pub enable_metadata: bool,
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        Self {
+            preferred_protocol: PreferredProtocol::PreferAirPlay2,
+            connection_timeout: std::time::Duration::from_secs(10),
+            enable_dacp: true,
+            enable_metadata: true,
+        }
+    }
+}
+
+/// Unified AirPlay client
+pub struct UnifiedAirPlayClient {
+    /// Configuration
+    config: ClientConfig,
+    /// Active session
+    session: Option<Box<dyn AirPlaySession>>,
+    /// Connected device info
+    device: Option<DiscoveredDevice>,
+    /// Selected protocol
+    protocol: Option<SelectedProtocol>,
+}
+
+impl UnifiedAirPlayClient {
+    /// Create new client with default configuration
+    pub fn new() -> Self {
+        Self::with_config(ClientConfig::default())
+    }
+
+    /// Create client with custom configuration
+    pub fn with_config(config: ClientConfig) -> Self {
+        Self {
+            config,
+            session: None,
+            device: None,
+            protocol: None,
+        }
+    }
+
+    /// Connect to a discovered device
+    pub async fn connect(&mut self, device: DiscoveredDevice) -> Result<(), AirPlayError> {
+        // Select protocol
+        let protocol = select_protocol(&device, self.config.preferred_protocol)
+            .map_err(|e| AirPlayError::ConnectionFailed {
+                message: e.to_string(),
+                source: None,
+            })?;
+
+        // Create appropriate session
+        let mut session: Box<dyn AirPlaySession> = match protocol {
+            SelectedProtocol::AirPlay2 => {
+                // Create AirPlay 2 session
+                // Box::new(AirPlay2SessionImpl::new(...))
+                todo!("AirPlay 2 session implementation")
+            }
+            SelectedProtocol::Raop => {
+                let addr = device.addresses.first()
+                    .ok_or_else(|| AirPlayError::ConnectionFailed {
+                        message: "no address available".to_string(),
+                        source: None,
+                    })?;
+                let port = device.raop_port.unwrap_or(5000);
+                Box::new(RaopSessionImpl::new(&addr.to_string(), port))
+            }
+        };
+
+        // Connect
+        session.connect().await?;
+
+        self.session = Some(session);
+        self.device = Some(device);
+        self.protocol = Some(protocol);
+
+        Ok(())
+    }
+
+    /// Disconnect from current device
+    pub async fn disconnect(&mut self) -> Result<(), AirPlayError> {
+        if let Some(ref mut session) = self.session {
+            session.disconnect().await?;
+        }
+        self.session = None;
+        self.device = None;
+        self.protocol = None;
+        Ok(())
+    }
+
+    /// Check if connected
+    pub fn is_connected(&self) -> bool {
+        self.session.as_ref().map(|s| s.is_connected()).unwrap_or(false)
+    }
+
+    /// Get selected protocol
+    pub fn protocol(&self) -> Option<SelectedProtocol> {
+        self.protocol
+    }
+
+    /// Get session reference
+    pub fn session(&self) -> Option<&dyn AirPlaySession> {
+        self.session.as_deref()
+    }
+
+    /// Get mutable session reference
+    pub fn session_mut(&mut self) -> Option<&mut dyn AirPlaySession> {
+        self.session.as_deref_mut()
+    }
+
+    // Convenience methods that delegate to session
+
+    /// Start playback
+    pub async fn play(&mut self) -> Result<(), AirPlayError> {
+        self.session.as_mut()
+            .ok_or(AirPlayError::NotConnected)?
+            .play()
+            .await
+    }
+
+    /// Pause playback
+    pub async fn pause(&mut self) -> Result<(), AirPlayError> {
+        self.session.as_mut()
+            .ok_or(AirPlayError::NotConnected)?
+            .pause()
+            .await
+    }
+
+    /// Set volume
+    pub async fn set_volume(&mut self, volume: f32) -> Result<(), AirPlayError> {
+        self.session.as_mut()
+            .ok_or(AirPlayError::NotConnected)?
+            .set_volume(volume)
+            .await
+    }
+
+    /// Stream audio data
+    pub async fn stream_audio(&mut self, data: &[u8]) -> Result<(), AirPlayError> {
+        self.session.as_mut()
+            .ok_or(AirPlayError::NotConnected)?
+            .stream_audio(data)
+            .await
+    }
+}
+
+impl Default for UnifiedAirPlayClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+```
+
+---
+
+### 32.4 Error Handling
+
+- [ ] **32.4.1** Extend error types for RAOP
+
+**File:** `src/error.rs` (additions)
+
+```rust
+// Add to existing AirPlayError enum:
+
+/// RAOP-specific errors
+#[derive(Debug, thiserror::Error)]
+pub enum RaopError {
+    #[error("RSA authentication failed")]
+    AuthenticationFailed,
+
+    #[error("unsupported encryption type: {0}")]
+    UnsupportedEncryption(String),
+
+    #[error("SDP parsing error: {0}")]
+    SdpParseError(String),
+
+    #[error("key exchange failed: {0}")]
+    KeyExchangeFailed(String),
+
+    #[error("audio encryption error: {0}")]
+    EncryptionError(String),
+
+    #[error("timing sync failed")]
+    TimingSyncFailed,
+
+    #[error("retransmit buffer overflow")]
+    RetransmitBufferOverflow,
+}
+
+// In AirPlayError, add:
+// #[error("RAOP error: {0}")]
+// Raop(#[from] RaopError),
+```
+
+---
+
+### 32.5 Feature Flags
+
+- [ ] **32.5.1** Add optional RAOP feature flag
+
+**File:** `Cargo.toml` (additions)
+
+```toml
+[features]
+default = ["tokio-runtime", "raop"]
+tokio-runtime = ["tokio"]
+async-std-runtime = ["async-std"]
+persistent-pairing = ["sled"]
+raop = ["rsa", "sha1"]  # AirPlay 1 support
+
+[dependencies]
+# RAOP-specific dependencies (optional)
+rsa = { version = "0.9", optional = true }
+sha1 = { version = "0.10", optional = true }
+```
+
+---
+
+## API Examples
+
+### Example: Automatic Protocol Selection
+
+```rust
+use airplay2_rs::{UnifiedAirPlayClient, ClientConfig, PreferredProtocol};
+use airplay2_rs::discovery::{scan_all, DiscoveryOptions};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Discover devices
+    let devices = scan_all(DiscoveryOptions::default()).await?;
+
+    // Find first audio-capable device
+    let device = devices.into_iter()
+        .find(|d| d.supports_raop() || d.supports_airplay2())
+        .expect("no devices found");
+
+    // Create client preferring AirPlay 2
+    let config = ClientConfig {
+        preferred_protocol: PreferredProtocol::PreferAirPlay2,
+        ..Default::default()
+    };
+
+    let mut client = UnifiedAirPlayClient::with_config(config);
+
+    // Connect (automatically selects best protocol)
+    client.connect(device).await?;
+
+    println!("Connected using {:?}", client.protocol());
+
+    // Stream audio...
+    client.set_volume(0.5).await?;
+    client.play().await?;
+
+    Ok(())
+}
+```
+
+### Example: Force RAOP Protocol
+
+```rust
+use airplay2_rs::{UnifiedAirPlayClient, ClientConfig, PreferredProtocol};
+
+let config = ClientConfig {
+    preferred_protocol: PreferredProtocol::ForceRaop,
+    enable_dacp: true,
+    enable_metadata: true,
+    ..Default::default()
+};
+
+let mut client = UnifiedAirPlayClient::with_config(config);
+```
+
+### Example: Handle Both Protocols
+
+```rust
+use airplay2_rs::{UnifiedAirPlayClient, SelectedProtocol};
+
+async fn stream_to_device(
+    client: &mut UnifiedAirPlayClient,
+    audio_data: &[u8],
+) -> Result<(), AirPlayError> {
+    match client.protocol() {
+        Some(SelectedProtocol::AirPlay2) => {
+            // AirPlay 2 specific handling (e.g., multi-room)
+            client.stream_audio(audio_data).await
+        }
+        Some(SelectedProtocol::Raop) => {
+            // RAOP specific handling
+            client.stream_audio(audio_data).await
+        }
+        None => Err(AirPlayError::NotConnected),
+    }
+}
+```
+
+---
+
+## Migration Guide
+
+### From AirPlay 2-Only Code
+
+```rust
+// Before (AirPlay 2 only):
+let mut client = AirPlayClient::new();
+client.connect(&device).await?;
+
+// After (Unified):
+let mut client = UnifiedAirPlayClient::new();
+client.connect(device).await?;
+
+// Protocol is automatically selected
+// For explicit AirPlay 2:
+let config = ClientConfig {
+    preferred_protocol: PreferredProtocol::ForceAirPlay2,
+    ..Default::default()
+};
+let mut client = UnifiedAirPlayClient::with_config(config);
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Protocol detection works correctly
+- [ ] Session abstraction handles both protocols
+- [ ] Unified client provides consistent API
+- [ ] Error types cover both protocols
+- [ ] Feature flags control compilation
+- [ ] Examples demonstrate usage patterns
+- [ ] Migration path is clear
+- [ ] All unit tests pass
+- [ ] Integration tests pass
+
+---
+
+## Notes
+
+- AirPlay 2 features (multi-room, buffered audio) are not available with RAOP
+- Some devices support both protocols with different feature sets
+- Protocol selection should consider device capabilities
+- Error messages should indicate which protocol failed
+- Consider adding protocol fallback on connection failure

--- a/docs/33-airplay1-testing.md
+++ b/docs/33-airplay1-testing.md
@@ -1,0 +1,1114 @@
+# Section 33: AirPlay 1 Testing Strategy
+
+## Dependencies
+- All previous AirPlay 1 sections (24-32)
+- **Section 20**: Mock AirPlay Server (for reference)
+- **Section 01**: Project Setup & CI/CD (for test infrastructure)
+
+## Overview
+
+Testing AirPlay 1 (RAOP) implementation requires a comprehensive strategy covering unit tests, integration tests, protocol compliance tests, and real device testing. This section extends the existing test infrastructure to support RAOP protocol verification.
+
+## Testing Pyramid
+
+```
+                    ┌───────────────┐
+                    │    Manual     │
+                    │  Device Tests │
+                    └───────┬───────┘
+                            │
+                ┌───────────┴───────────┐
+                │   Integration Tests    │
+                │   (Mock RAOP Server)   │
+                └───────────┬───────────┘
+                            │
+        ┌───────────────────┴───────────────────┐
+        │            Protocol Tests              │
+        │  (RTSP, RTP, DMAP, Encryption flows)  │
+        └───────────────────┬───────────────────┘
+                            │
+┌───────────────────────────┴───────────────────────────┐
+│                      Unit Tests                        │
+│  (Codecs, parsers, encoders, crypto, state machines)  │
+└───────────────────────────────────────────────────────┘
+```
+
+## Objectives
+
+- Extend mock server to support RAOP protocol
+- Create comprehensive unit test suites for all RAOP components
+- Implement protocol compliance tests
+- Define real device testing procedures
+- Establish CI/CD integration for RAOP tests
+
+---
+
+## Tasks
+
+### 33.1 Mock RAOP Server
+
+- [ ] **33.1.1** Implement mock RAOP server
+
+**File:** `src/testing/mock_raop_server.rs`
+
+```rust
+//! Mock RAOP server for testing
+
+use crate::protocol::rtp::timing::NtpTimestamp;
+use crate::protocol::crypto::rsa::RaopRsaPrivateKey;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+/// Mock RAOP server state
+#[derive(Debug, Clone, Default)]
+pub struct MockRaopState {
+    /// RTSP session ID
+    pub session_id: Option<String>,
+    /// Received audio packets
+    pub audio_packets: Vec<Vec<u8>>,
+    /// Current volume (dB)
+    pub volume_db: f32,
+    /// Received metadata
+    pub metadata: Option<Vec<u8>>,
+    /// Received artwork
+    pub artwork: Option<Vec<u8>>,
+    /// Current playback state
+    pub playing: bool,
+    /// AES key (decrypted from rsaaeskey)
+    pub aes_key: Option<[u8; 16]>,
+    /// AES IV
+    pub aes_iv: Option<[u8; 16]>,
+}
+
+/// Mock RAOP server configuration
+#[derive(Debug, Clone)]
+pub struct MockRaopConfig {
+    /// RTSP port
+    pub rtsp_port: u16,
+    /// Audio server port
+    pub audio_port: u16,
+    /// Control port
+    pub control_port: u16,
+    /// Timing port
+    pub timing_port: u16,
+    /// Device name
+    pub name: String,
+    /// MAC address
+    pub mac_address: [u8; 6],
+    /// Supported codecs
+    pub codecs: Vec<u8>,
+    /// Supported encryption types
+    pub encryption_types: Vec<u8>,
+    /// Require Apple-Challenge
+    pub require_challenge: bool,
+}
+
+impl Default for MockRaopConfig {
+    fn default() -> Self {
+        Self {
+            rtsp_port: 5000,
+            audio_port: 6000,
+            control_port: 6001,
+            timing_port: 6002,
+            name: "Mock RAOP".to_string(),
+            mac_address: [0x00, 0x11, 0x22, 0x33, 0x44, 0x55],
+            codecs: vec![0, 1, 2], // PCM, ALAC, AAC
+            encryption_types: vec![0, 1], // None, RSA
+            require_challenge: true,
+        }
+    }
+}
+
+/// Mock RAOP server
+pub struct MockRaopServer {
+    /// Configuration
+    config: MockRaopConfig,
+    /// Server state
+    state: Arc<Mutex<MockRaopState>>,
+    /// RSA private key for authentication
+    rsa_key: RaopRsaPrivateKey,
+    /// Running state
+    running: bool,
+}
+
+impl MockRaopServer {
+    /// Create new mock server
+    pub fn new(config: MockRaopConfig) -> Self {
+        Self {
+            config,
+            state: Arc::new(Mutex::new(MockRaopState::default())),
+            rsa_key: RaopRsaPrivateKey::generate().expect("failed to generate RSA key"),
+            running: false,
+        }
+    }
+
+    /// Get server address for connection
+    pub fn address(&self) -> String {
+        format!("127.0.0.1:{}", self.config.rtsp_port)
+    }
+
+    /// Get mDNS service name
+    pub fn service_name(&self) -> String {
+        let mac = self.config.mac_address
+            .iter()
+            .map(|b| format!("{:02X}", b))
+            .collect::<String>();
+        format!("{}@{}", mac, self.config.name)
+    }
+
+    /// Get TXT records for mDNS
+    pub fn txt_records(&self) -> HashMap<String, String> {
+        let mut records = HashMap::new();
+        records.insert("txtvers".to_string(), "1".to_string());
+        records.insert("ch".to_string(), "2".to_string());
+        records.insert("cn".to_string(),
+            self.config.codecs.iter()
+                .map(|c| c.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        records.insert("et".to_string(),
+            self.config.encryption_types.iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        records.insert("sr".to_string(), "44100".to_string());
+        records.insert("ss".to_string(), "16".to_string());
+        records
+    }
+
+    /// Start the server
+    pub async fn start(&mut self) -> Result<(), MockServerError> {
+        self.running = true;
+
+        // Start RTSP listener
+        // Start UDP listeners for audio, control, timing
+
+        Ok(())
+    }
+
+    /// Stop the server
+    pub async fn stop(&mut self) {
+        self.running = false;
+    }
+
+    /// Get current state
+    pub fn state(&self) -> MockRaopState {
+        self.state.lock().unwrap().clone()
+    }
+
+    /// Reset state
+    pub fn reset(&self) {
+        *self.state.lock().unwrap() = MockRaopState::default();
+    }
+
+    /// Get RSA public key (for testing client)
+    pub fn public_key(&self) -> rsa::RsaPublicKey {
+        self.rsa_key.public_key()
+    }
+
+    /// Handle RTSP OPTIONS request
+    fn handle_options(
+        &self,
+        request: &crate::protocol::rtsp::RtspRequest,
+    ) -> crate::protocol::rtsp::RtspResponse {
+        use crate::protocol::rtsp::{RtspResponse, StatusCode, Headers};
+
+        let mut headers = Headers::new();
+        headers.insert("CSeq", request.headers.cseq().unwrap_or(0).to_string());
+        headers.insert("Public", "ANNOUNCE, SETUP, RECORD, PAUSE, FLUSH, TEARDOWN, OPTIONS, GET_PARAMETER, SET_PARAMETER");
+
+        // Handle Apple-Challenge if present
+        if self.config.require_challenge {
+            if let Some(challenge) = request.headers.get("Apple-Challenge") {
+                // Generate Apple-Response
+                // let response = generate_response(...);
+                // headers.insert("Apple-Response", response);
+            }
+        }
+
+        RtspResponse {
+            version: "RTSP/1.0".to_string(),
+            status: StatusCode::OK,
+            reason: "OK".to_string(),
+            headers,
+            body: Vec::new(),
+        }
+    }
+
+    /// Handle RTSP ANNOUNCE request
+    fn handle_announce(
+        &self,
+        request: &crate::protocol::rtsp::RtspRequest,
+    ) -> crate::protocol::rtsp::RtspResponse {
+        use crate::protocol::rtsp::{RtspResponse, StatusCode, Headers};
+        use crate::protocol::sdp::SdpParser;
+
+        // Parse SDP
+        let sdp_text = String::from_utf8_lossy(&request.body);
+        if let Ok(sdp) = SdpParser::parse(&sdp_text) {
+            // Extract and decrypt AES key
+            if let (Some(rsaaeskey), Some(aesiv)) = (sdp.rsaaeskey(), sdp.aesiv()) {
+                if let Ok((_, key, iv)) = crate::protocol::raop::encryption::parse_wrapped_keys(
+                    rsaaeskey,
+                    aesiv,
+                    &self.rsa_key,
+                ) {
+                    let mut state = self.state.lock().unwrap();
+                    state.aes_key = Some(key);
+                    state.aes_iv = Some(iv);
+                }
+            }
+        }
+
+        let mut headers = Headers::new();
+        headers.insert("CSeq", request.headers.cseq().unwrap_or(0).to_string());
+
+        RtspResponse {
+            version: "RTSP/1.0".to_string(),
+            status: StatusCode::OK,
+            reason: "OK".to_string(),
+            headers,
+            body: Vec::new(),
+        }
+    }
+
+    /// Handle RTSP SETUP request
+    fn handle_setup(
+        &self,
+        request: &crate::protocol::rtsp::RtspRequest,
+    ) -> crate::protocol::rtsp::RtspResponse {
+        use crate::protocol::rtsp::{RtspResponse, StatusCode, Headers};
+
+        let session_id = format!("{:016X}", rand::random::<u64>());
+
+        {
+            let mut state = self.state.lock().unwrap();
+            state.session_id = Some(session_id.clone());
+        }
+
+        let mut headers = Headers::new();
+        headers.insert("CSeq", request.headers.cseq().unwrap_or(0).to_string());
+        headers.insert("Session", &session_id);
+        headers.insert("Transport", format!(
+            "RTP/AVP/UDP;unicast;mode=record;server_port={};control_port={};timing_port={}",
+            self.config.audio_port,
+            self.config.control_port,
+            self.config.timing_port,
+        ));
+        headers.insert("Audio-Latency", "11025");
+
+        RtspResponse {
+            version: "RTSP/1.0".to_string(),
+            status: StatusCode::OK,
+            reason: "OK".to_string(),
+            headers,
+            body: Vec::new(),
+        }
+    }
+
+    /// Handle RTSP RECORD request
+    fn handle_record(
+        &self,
+        request: &crate::protocol::rtsp::RtspRequest,
+    ) -> crate::protocol::rtsp::RtspResponse {
+        use crate::protocol::rtsp::{RtspResponse, StatusCode, Headers};
+
+        {
+            let mut state = self.state.lock().unwrap();
+            state.playing = true;
+        }
+
+        let mut headers = Headers::new();
+        headers.insert("CSeq", request.headers.cseq().unwrap_or(0).to_string());
+        headers.insert("Audio-Latency", "11025");
+
+        RtspResponse {
+            version: "RTSP/1.0".to_string(),
+            status: StatusCode::OK,
+            reason: "OK".to_string(),
+            headers,
+            body: Vec::new(),
+        }
+    }
+
+    /// Handle RTSP SET_PARAMETER request
+    fn handle_set_parameter(
+        &self,
+        request: &crate::protocol::rtsp::RtspRequest,
+    ) -> crate::protocol::rtsp::RtspResponse {
+        use crate::protocol::rtsp::{RtspResponse, StatusCode, Headers};
+
+        let content_type = request.headers.content_type().unwrap_or("");
+
+        {
+            let mut state = self.state.lock().unwrap();
+
+            match content_type {
+                "text/parameters" => {
+                    // Parse volume
+                    let body = String::from_utf8_lossy(&request.body);
+                    if let Some(line) = body.lines().find(|l| l.starts_with("volume:")) {
+                        if let Some(vol_str) = line.strip_prefix("volume:") {
+                            if let Ok(vol) = vol_str.trim().parse::<f32>() {
+                                state.volume_db = vol;
+                            }
+                        }
+                    }
+                }
+                "application/x-dmap-tagged" => {
+                    state.metadata = Some(request.body.clone());
+                }
+                "image/jpeg" | "image/png" => {
+                    state.artwork = Some(request.body.clone());
+                }
+                _ => {}
+            }
+        }
+
+        let mut headers = Headers::new();
+        headers.insert("CSeq", request.headers.cseq().unwrap_or(0).to_string());
+
+        RtspResponse {
+            version: "RTSP/1.0".to_string(),
+            status: StatusCode::OK,
+            reason: "OK".to_string(),
+            headers,
+            body: Vec::new(),
+        }
+    }
+}
+
+/// Mock server errors
+#[derive(Debug, thiserror::Error)]
+pub enum MockServerError {
+    #[error("bind failed: {0}")]
+    BindFailed(String),
+    #[error("server not running")]
+    NotRunning,
+}
+```
+
+---
+
+### 33.2 Unit Test Suites
+
+- [ ] **33.2.1** Create test modules for each component
+
+**File:** `tests/raop_unit_tests.rs`
+
+```rust
+//! RAOP unit test collection
+
+mod discovery_tests {
+    use airplay2_rs::discovery::raop::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_parse_raop_capabilities() {
+        let mut records = HashMap::new();
+        records.insert("ch".to_string(), "2".to_string());
+        records.insert("cn".to_string(), "0,1,2".to_string());
+        records.insert("et".to_string(), "0,1".to_string());
+        records.insert("sr".to_string(), "44100".to_string());
+
+        let caps = RaopCapabilities::from_txt_records(&records);
+
+        assert_eq!(caps.channels, 2);
+        assert_eq!(caps.sample_rate, 44100);
+        assert!(caps.supports_codec(RaopCodec::Alac));
+        assert!(caps.supports_rsa());
+    }
+
+    #[test]
+    fn test_service_name_parsing() {
+        let (mac, name) = parse_raop_service_name("AABBCCDDEEFF@Living Room").unwrap();
+        assert_eq!(mac, "AABBCCDDEEFF");
+        assert_eq!(name, "Living Room");
+    }
+}
+
+mod crypto_tests {
+    use airplay2_rs::protocol::crypto::rsa::*;
+
+    #[test]
+    fn test_rsa_key_generation() {
+        let key = RaopRsaPrivateKey::generate().unwrap();
+        let public = key.public_key();
+        assert_eq!(public.size(), sizes::MODULUS_BYTES);
+    }
+
+    #[test]
+    fn test_oaep_roundtrip() {
+        let private = RaopRsaPrivateKey::generate().unwrap();
+        let public = private.public_key();
+
+        // Encrypt with public
+        use rsa::Oaep;
+        use sha1::Sha1;
+        use rand::rngs::OsRng;
+
+        let plaintext = b"test AES key 16b";
+        let padding = Oaep::new::<Sha1>();
+        let encrypted = public.encrypt(&mut OsRng, padding, plaintext).unwrap();
+
+        // Decrypt with private
+        let decrypted = private.decrypt_oaep(&encrypted).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+}
+
+mod sdp_tests {
+    use airplay2_rs::protocol::sdp::*;
+
+    #[test]
+    fn test_parse_raop_sdp() {
+        let sdp_text = r#"v=0
+o=iTunes 1234567890 1 IN IP4 192.168.1.100
+s=iTunes
+c=IN IP4 192.168.1.50
+t=0 0
+m=audio 0 RTP/AVP 96
+a=rtpmap:96 AppleLossless
+a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100
+a=rsaaeskey:AAAA
+a=aesiv:BBBB
+"#;
+
+        let sdp = SdpParser::parse(sdp_text).unwrap();
+        assert_eq!(sdp.rsaaeskey(), Some("AAAA"));
+        assert_eq!(sdp.aesiv(), Some("BBBB"));
+    }
+
+    #[test]
+    fn test_build_announce_sdp() {
+        let sdp = create_raop_announce_sdp(
+            "1234567890",
+            "192.168.1.100",
+            "192.168.1.50",
+            "encrypted_key",
+            "init_vector",
+        );
+
+        assert!(sdp.contains("v=0"));
+        assert!(sdp.contains("rsaaeskey:encrypted_key"));
+        assert!(sdp.contains("aesiv:init_vector"));
+    }
+}
+
+mod encryption_tests {
+    use airplay2_rs::protocol::raop::encryption::*;
+
+    #[test]
+    fn test_aes_ctr_roundtrip() {
+        let key = [0x42u8; 16];
+        let iv = [0x00u8; 16];
+
+        let encryptor = RaopEncryptor::new(key, iv);
+        let decryptor = RaopDecryptor::new(key, iv);
+
+        let original = vec![0xAA; FRAME_SIZE];
+        let encrypted = encryptor.encrypt(&original, 0).unwrap();
+        let decrypted = decryptor.decrypt(&encrypted, 0).unwrap();
+
+        assert_eq!(decrypted, original);
+    }
+}
+
+mod rtp_tests {
+    use airplay2_rs::protocol::rtp::raop::*;
+
+    #[test]
+    fn test_audio_packet_roundtrip() {
+        let payload = vec![1, 2, 3, 4, 5];
+        let packet = RaopAudioPacket::new(100, 44100, 0x12345678, payload.clone())
+            .with_marker();
+
+        let encoded = packet.encode();
+        let decoded = RaopAudioPacket::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.sequence, 100);
+        assert_eq!(decoded.timestamp, 44100);
+        assert!(decoded.marker);
+        assert_eq!(decoded.payload, payload);
+    }
+
+    #[test]
+    fn test_sync_packet() {
+        use airplay2_rs::protocol::rtp::timing::NtpTimestamp;
+
+        let ntp = NtpTimestamp::now();
+        let packet = SyncPacket::new(1000, ntp, 1352, true);
+
+        let encoded = packet.encode();
+        let decoded = SyncPacket::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.rtp_timestamp, 1000);
+        assert_eq!(decoded.next_timestamp, 1352);
+        assert!(decoded.extension);
+    }
+}
+
+mod dmap_tests {
+    use airplay2_rs::protocol::daap::dmap::*;
+
+    #[test]
+    fn test_dmap_encoding() {
+        let mut encoder = DmapEncoder::new();
+        encoder.string(DmapTag::ItemName, "Test Track");
+        encoder.string(DmapTag::SongArtist, "Test Artist");
+
+        let data = encoder.finish();
+        let decoded = decode_dmap(&data).unwrap();
+
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(decoded[0].1, "Test Track");
+        assert_eq!(decoded[1].1, "Test Artist");
+    }
+}
+
+mod progress_tests {
+    use airplay2_rs::protocol::daap::progress::*;
+
+    #[test]
+    fn test_progress_encode_parse() {
+        let progress = PlaybackProgress::new(1000, 2000, 10000);
+        let encoded = progress.encode();
+        let parsed = PlaybackProgress::parse(&encoded).unwrap();
+
+        assert_eq!(parsed.start, 1000);
+        assert_eq!(parsed.current, 2000);
+        assert_eq!(parsed.end, 10000);
+    }
+
+    #[test]
+    fn test_progress_percentage() {
+        let progress = PlaybackProgress::new(0, 500, 1000);
+        assert!((progress.percentage() - 0.5).abs() < 0.001);
+    }
+}
+
+mod session_tests {
+    use airplay2_rs::protocol::raop::session::*;
+
+    #[test]
+    fn test_session_state_machine() {
+        let mut session = RaopRtspSession::new("192.168.1.50", 5000);
+        assert_eq!(session.state(), RaopSessionState::Init);
+
+        // Create OPTIONS request
+        let request = session.options_request();
+        assert!(request.headers.get("Apple-Challenge").is_some());
+    }
+
+    #[test]
+    fn test_transport_parsing() {
+        let transport = "RTP/AVP/UDP;unicast;mode=record;server_port=6000;control_port=6001;timing_port=6002";
+        let parsed = RaopRtspSession::parse_transport(transport).unwrap();
+
+        assert_eq!(parsed.server_port, 6000);
+        assert_eq!(parsed.control_port, 6001);
+        assert_eq!(parsed.timing_port, 6002);
+    }
+}
+```
+
+---
+
+### 33.3 Integration Tests
+
+- [ ] **33.3.1** Create integration test suite
+
+**File:** `tests/raop_integration_tests.rs`
+
+```rust
+//! RAOP integration tests using mock server
+
+use airplay2_rs::testing::mock_raop_server::{MockRaopServer, MockRaopConfig};
+use airplay2_rs::client::{UnifiedAirPlayClient, ClientConfig, PreferredProtocol};
+use std::time::Duration;
+
+async fn setup_mock_server() -> MockRaopServer {
+    let config = MockRaopConfig {
+        rtsp_port: 15000 + rand::random::<u16>() % 1000,
+        audio_port: 16000 + rand::random::<u16>() % 1000,
+        ..Default::default()
+    };
+    let mut server = MockRaopServer::new(config);
+    server.start().await.expect("failed to start mock server");
+    server
+}
+
+#[tokio::test]
+async fn test_full_raop_session() {
+    let server = setup_mock_server().await;
+
+    // Create client configured for RAOP
+    let config = ClientConfig {
+        preferred_protocol: PreferredProtocol::ForceRaop,
+        connection_timeout: Duration::from_secs(5),
+        ..Default::default()
+    };
+
+    let mut client = UnifiedAirPlayClient::with_config(config);
+
+    // Create mock device
+    let device = airplay2_rs::discovery::DiscoveredDevice {
+        id: "test-device".to_string(),
+        name: server.service_name(),
+        addresses: vec!["127.0.0.1".parse().unwrap()],
+        airplay_port: None,
+        raop_port: Some(server.config.rtsp_port),
+        airplay_capabilities: None,
+        raop_capabilities: Some(Default::default()),
+        protocol: airplay2_rs::discovery::DeviceProtocol::RaopOnly,
+    };
+
+    // Connect
+    client.connect(device).await.expect("connection failed");
+    assert!(client.is_connected());
+
+    // Set volume
+    client.set_volume(0.5).await.expect("set volume failed");
+
+    // Start playback
+    client.play().await.expect("play failed");
+
+    // Verify server state
+    let state = server.state();
+    assert!(state.playing);
+    assert!(state.volume_db < 0.0); // -15dB for 0.5 linear
+
+    // Disconnect
+    client.disconnect().await.expect("disconnect failed");
+    assert!(!client.is_connected());
+}
+
+#[tokio::test]
+async fn test_raop_audio_streaming() {
+    let server = setup_mock_server().await;
+
+    let config = ClientConfig {
+        preferred_protocol: PreferredProtocol::ForceRaop,
+        ..Default::default()
+    };
+
+    let mut client = UnifiedAirPlayClient::with_config(config);
+
+    // ... connect ...
+
+    // Stream some audio
+    let audio_frame = vec![0u8; 352 * 4]; // One frame
+    for _ in 0..10 {
+        client.stream_audio(&audio_frame).await.expect("stream failed");
+    }
+
+    // Verify packets received
+    let state = server.state();
+    assert!(!state.audio_packets.is_empty());
+
+    // Cleanup
+    client.disconnect().await.ok();
+}
+
+#[tokio::test]
+async fn test_raop_metadata() {
+    let server = setup_mock_server().await;
+
+    let config = ClientConfig {
+        preferred_protocol: PreferredProtocol::ForceRaop,
+        enable_metadata: true,
+        ..Default::default()
+    };
+
+    let mut client = UnifiedAirPlayClient::with_config(config);
+
+    // ... connect ...
+
+    // Set metadata
+    let track = airplay2_rs::types::TrackInfo {
+        title: Some("Test Song".to_string()),
+        artist: Some("Test Artist".to_string()),
+        album: Some("Test Album".to_string()),
+        ..Default::default()
+    };
+
+    client.session_mut().unwrap()
+        .set_metadata(&track)
+        .await
+        .expect("metadata failed");
+
+    // Verify
+    let state = server.state();
+    assert!(state.metadata.is_some());
+
+    // Cleanup
+    client.disconnect().await.ok();
+}
+
+#[tokio::test]
+async fn test_raop_encryption() {
+    let server = setup_mock_server().await;
+
+    // ... full flow with encryption verification ...
+
+    // Verify AES key was exchanged
+    let state = server.state();
+    assert!(state.aes_key.is_some());
+    assert!(state.aes_iv.is_some());
+}
+```
+
+---
+
+### 33.4 Protocol Compliance Tests
+
+- [ ] **33.4.1** Create protocol compliance test suite
+
+**File:** `tests/raop_protocol_compliance.rs`
+
+```rust
+//! RAOP protocol compliance tests
+//!
+//! These tests verify that the implementation conforms to the
+//! RAOP protocol specification.
+
+use airplay2_rs::protocol::rtsp::*;
+use airplay2_rs::protocol::raop::session::*;
+use airplay2_rs::protocol::sdp::*;
+
+/// Test RTSP request format compliance
+mod rtsp_compliance {
+    use super::*;
+
+    #[test]
+    fn test_options_request_format() {
+        let mut session = RaopRtspSession::new("192.168.1.50", 5000);
+        let request = session.options_request();
+        let encoded = String::from_utf8_lossy(&request.encode());
+
+        // Must have RTSP/1.0 version
+        assert!(encoded.contains("RTSP/1.0"));
+
+        // Must have required headers
+        assert!(encoded.contains("CSeq:"));
+        assert!(encoded.contains("User-Agent:"));
+
+        // Should have Apple-Challenge for authentication
+        assert!(encoded.contains("Apple-Challenge:"));
+    }
+
+    #[test]
+    fn test_announce_sdp_format() {
+        let sdp = create_raop_announce_sdp(
+            "1234567890",
+            "192.168.1.100",
+            "192.168.1.50",
+            "encrypted_key",
+            "init_vector",
+        );
+
+        // Must start with v=0
+        assert!(sdp.starts_with("v=0"));
+
+        // Must have origin line
+        assert!(sdp.contains("o=iTunes"));
+
+        // Must have connection line
+        assert!(sdp.contains("c=IN IP"));
+
+        // Must have media line
+        assert!(sdp.contains("m=audio"));
+
+        // Must have encryption attributes
+        assert!(sdp.contains("a=rsaaeskey:"));
+        assert!(sdp.contains("a=aesiv:"));
+    }
+
+    #[test]
+    fn test_setup_transport_format() {
+        let mut session = RaopRtspSession::new("192.168.1.50", 5000);
+        let request = session.setup_request(6001, 6002);
+        let encoded = String::from_utf8_lossy(&request.encode());
+
+        // Must have Transport header
+        assert!(encoded.contains("Transport:"));
+
+        // Must specify RTP/AVP/UDP
+        assert!(encoded.contains("RTP/AVP/UDP"));
+
+        // Must specify mode=record
+        assert!(encoded.contains("mode=record"));
+
+        // Must specify ports
+        assert!(encoded.contains("control_port=6001"));
+        assert!(encoded.contains("timing_port=6002"));
+    }
+
+    #[test]
+    fn test_cseq_increments() {
+        let mut session = RaopRtspSession::new("192.168.1.50", 5000);
+
+        let r1 = session.options_request();
+        let r2 = session.options_request();
+        let r3 = session.setup_request(6001, 6002);
+
+        assert_eq!(r1.headers.cseq(), Some(1));
+        assert_eq!(r2.headers.cseq(), Some(2));
+        assert_eq!(r3.headers.cseq(), Some(3));
+    }
+}
+
+/// Test RTP packet format compliance
+mod rtp_compliance {
+    use airplay2_rs::protocol::rtp::raop::*;
+
+    #[test]
+    fn test_audio_packet_header() {
+        let packet = RaopAudioPacket::new(100, 44100, 0x12345678, vec![0; 100]);
+        let encoded = packet.encode();
+
+        // Version must be 2 (bits 6-7 of byte 0)
+        assert_eq!((encoded[0] >> 6) & 0x03, 2);
+
+        // Payload type must be 0x60 (realtime) or 0x61 (buffered)
+        assert_eq!(encoded[1] & 0x7F, 0x60);
+
+        // Sequence number (bytes 2-3, big-endian)
+        assert_eq!(u16::from_be_bytes([encoded[2], encoded[3]]), 100);
+
+        // Timestamp (bytes 4-7, big-endian)
+        assert_eq!(u32::from_be_bytes([encoded[4], encoded[5], encoded[6], encoded[7]]), 44100);
+    }
+
+    #[test]
+    fn test_marker_bit_on_first_packet() {
+        let packet = RaopAudioPacket::new(0, 0, 0, vec![])
+            .with_marker();
+        let encoded = packet.encode();
+
+        // Marker bit is bit 7 of byte 1
+        assert_eq!(encoded[1] & 0x80, 0x80);
+    }
+
+    #[test]
+    fn test_sync_packet_format() {
+        use airplay2_rs::protocol::rtp::timing::NtpTimestamp;
+
+        let ntp = NtpTimestamp { seconds: 0x12345678, fraction: 0x9ABCDEF0 };
+        let packet = SyncPacket::new(1000, ntp, 1352, true);
+        let encoded = packet.encode();
+
+        // Payload type must be 0x54
+        assert_eq!(encoded[1] & 0x7F, 0x54);
+
+        // Extension bit set for first sync
+        assert_eq!(encoded[0] & 0x10, 0x10);
+
+        // Total size must be 20 bytes
+        assert_eq!(encoded.len(), 20);
+    }
+}
+
+/// Test timing protocol compliance
+mod timing_compliance {
+    use airplay2_rs::protocol::rtp::raop_timing::*;
+
+    #[test]
+    fn test_timing_request_format() {
+        let request = RaopTimingRequest::new();
+        let encoded = request.encode(1);
+
+        // Must be 32 bytes
+        assert_eq!(encoded.len(), 32);
+
+        // Payload type must be 0x52
+        assert_eq!(encoded[1] & 0x7F, 0x52);
+
+        // Marker bit should be set
+        assert_eq!(encoded[1] & 0x80, 0x80);
+    }
+}
+
+/// Test DMAP encoding compliance
+mod dmap_compliance {
+    use airplay2_rs::protocol::daap::dmap::*;
+
+    #[test]
+    fn test_dmap_tag_codes() {
+        // Verify tag codes match DAAP specification
+        assert_eq!(DmapTag::ItemName.code(), b"minm");
+        assert_eq!(DmapTag::SongArtist.code(), b"asar");
+        assert_eq!(DmapTag::SongAlbum.code(), b"asal");
+    }
+
+    #[test]
+    fn test_dmap_length_encoding() {
+        let mut encoder = DmapEncoder::new();
+        encoder.string(DmapTag::ItemName, "Test");
+        let data = encoder.finish();
+
+        // Tag (4) + Length (4) + "Test" (4) = 12 bytes
+        assert_eq!(data.len(), 12);
+
+        // Length field (bytes 4-7) should be 4
+        assert_eq!(u32::from_be_bytes([data[4], data[5], data[6], data[7]]), 4);
+    }
+}
+```
+
+---
+
+### 33.5 Real Device Testing
+
+- [ ] **33.5.1** Document manual testing procedures
+
+**File:** `tests/README_DEVICE_TESTING.md`
+
+```markdown
+# Real Device Testing Procedures
+
+## Supported Test Devices
+
+- AirPort Express (1st/2nd generation)
+- Apple TV (2nd/3rd generation)
+- HomePod (AirPlay 1 mode)
+- Third-party RAOP receivers (Shairport-sync)
+
+## Test Environment Setup
+
+1. **Network Configuration**
+   - Test device and computer on same network
+   - Multicast traffic enabled (for mDNS)
+   - UDP ports 5000-7000 accessible
+
+2. **Test Device Preparation**
+   - Reset device to factory defaults
+   - No password protection (for initial tests)
+   - Connected to audio output (speakers/headphones)
+
+## Manual Test Checklist
+
+### Discovery Tests
+
+- [ ] Device appears in mDNS scan within 5 seconds
+- [ ] TXT records parsed correctly
+- [ ] MAC address extracted from service name
+- [ ] Capabilities match device specifications
+
+### Connection Tests
+
+- [ ] OPTIONS request succeeds
+- [ ] Apple-Challenge verified (if required)
+- [ ] ANNOUNCE with SDP accepted
+- [ ] SETUP returns valid transport parameters
+- [ ] RECORD starts without error
+
+### Audio Streaming Tests
+
+- [ ] Audio plays within 500ms of first packet
+- [ ] No audible glitches with continuous stream
+- [ ] Volume changes take effect
+- [ ] Playback stops on TEARDOWN
+
+### Metadata Tests
+
+- [ ] Track title displays on device (if supported)
+- [ ] Artist/album displays correctly
+- [ ] Artwork displays (if device has screen)
+- [ ] Progress bar updates
+
+### Error Recovery Tests
+
+- [ ] Reconnects after network interruption
+- [ ] Handles device sleep/wake
+- [ ] Recovers from packet loss (retransmission)
+
+## Automated Device Tests
+
+Run with actual device:
+
+```bash
+RAOP_TEST_DEVICE=192.168.1.50:5000 cargo test --test raop_device_tests
+```
+
+## Known Device Quirks
+
+| Device | Issue | Workaround |
+|--------|-------|------------|
+| AirPort Express Gen1 | Slow OPTIONS response | Increase timeout to 5s |
+| Some Shairport builds | No Apple-Challenge | Disable challenge verification |
+| HomePod | Prefers AirPlay 2 | Force RAOP with config |
+```
+
+---
+
+## CI/CD Integration
+
+### GitHub Actions Workflow
+
+**File:** `.github/workflows/raop-tests.yml`
+
+```yaml
+name: RAOP Tests
+
+on:
+  push:
+    paths:
+      - 'src/protocol/raop/**'
+      - 'src/protocol/daap/**'
+      - 'src/protocol/sdp/**'
+      - 'tests/raop_*'
+  pull_request:
+    paths:
+      - 'src/protocol/raop/**'
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run RAOP unit tests
+        run: cargo test --lib raop
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run RAOP integration tests
+        run: cargo test --test raop_integration_tests
+
+  protocol-compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run protocol compliance tests
+        run: cargo test --test raop_protocol_compliance
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Mock RAOP server handles all RTSP methods
+- [ ] Unit tests cover all RAOP components
+- [ ] Integration tests verify full session flow
+- [ ] Protocol compliance tests pass
+- [ ] CI/CD runs RAOP tests automatically
+- [ ] Device testing procedures documented
+- [ ] All tests pass on supported platforms
+
+---
+
+## Notes
+
+- Mock server uses random ports to avoid conflicts
+- Integration tests may be slower due to network I/O
+- Real device tests require manual setup
+- Consider adding fuzzing tests for parser robustness
+- Property-based tests useful for codec verification


### PR DESCRIPTION
Add 10 new documentation sections (24-33) covering AirPlay 1/RAOP support:
- 24: Overview and architecture comparison with AirPlay 2
- 25: RAOP mDNS service discovery
- 26: RSA challenge-response authentication
- 27: RTSP session management with SDP
- 28: RTP audio streaming with timing sync
- 29: AES-128-CTR audio encryption
- 30: DACP remote control protocol
- 31: DAAP/DMAP metadata encoding
- 32: Integration guide with unified client API
- 33: Testing strategy with mock server and CI/CD

Update main overview (00-overview.md) to reference new sections,
add AirPlay 1 dependency diagram, and include RAOP specification links.