### PR TITLE
Add AirPlay 1 Receiver Architecture & Documentation (Sections 34-45)

### DIFF
--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -534,3 +534,115 @@ async-std-runtime = ["async-std"]
 - [OpenAirPlay Specification](https://openairplay.github.io/airplay-spec/audio/index.html)
 - [Unofficial AirPlay Protocol Specification](https://nto.github.io/AirPlay.html)
 - [RAOP Protocol Analysis](https://git.zx2c4.com/Airtunes2/about/)
+
+---
+
+## AirPlay 1 Receiver Support
+
+The library includes comprehensive documentation for implementing an AirPlay 1 **receiver**, enabling the library to accept incoming audio streams from AirPlay senders (iTunes, iOS, macOS).
+
+### AirPlay 1 Receiver Section Dependencies
+
+```
+                         ┌──────────────────┐
+                         │ 34: Receiver     │
+                         │ Overview         │
+                         └────────┬─────────┘
+                                  │
+           ┌──────────────────────┼──────────────────────┐
+           │                      │                      │
+  ┌────────▼────────┐   ┌─────────▼────────┐   ┌────────▼────────┐
+  │ 35: Service     │   │ 36: RTSP Server  │   │ 42: Audio       │
+  │ Advertisement   │   │ (Sans-IO)        │   │ Output          │
+  └────────┬────────┘   └─────────┬────────┘   └────────┬────────┘
+           │                      │                     │
+           │            ┌─────────▼────────┐            │
+           │            │ 37: Session      │            │
+           │            │ Management       │            │
+           │            └─────────┬────────┘            │
+           │                      │                     │
+           │            ┌─────────▼────────┐            │
+           │            │ 38: SDP Parsing  │            │
+           │            │ & Stream Setup   │            │
+           │            └─────────┬────────┘            │
+           │                      │                     │
+           │            ┌─────────▼────────┐            │
+           │            │ 39: RTP Receiver │            │
+           │            │ Core             │            │
+           │            └─────────┬────────┘            │
+           │                      │                     │
+           │   ┌──────────────────┼──────────────────┐  │
+           │   │                  │                  │  │
+  ┌────────▼───▼────┐   ┌─────────▼────────┐  ┌─────▼──▼────────┐
+  │ 40: Timing      │   │ 41: Jitter       │  │                 │
+  │ Synchronization │   │ Buffer           │  │                 │
+  └────────┬────────┘   └─────────┬────────┘  │                 │
+           │                      │           │                 │
+           └──────────────────────┼───────────┘                 │
+                                  │                             │
+                         ┌────────▼────────┐                    │
+                         │ 43: Volume &    │                    │
+                         │ Metadata        │                    │
+                         └────────┬────────┘                    │
+                                  │                             │
+                         ┌────────▼────────┐                    │
+                         │ 44: Receiver    │◀───────────────────┘
+                         │ Integration     │
+                         └────────┬────────┘
+                                  │
+                         ┌────────▼────────┐
+                         │ 45: Receiver    │
+                         │ Testing         │
+                         └─────────────────┘
+```
+
+### AirPlay 1 Receiver Documentation Sections
+
+| Section | Title | Description |
+|---------|-------|-------------|
+| 34 | Receiver Overview | Architecture, feature flags, code reuse strategy |
+| 35 | RAOP Service Advertisement | mDNS publishing, TXT records for receiver discovery |
+| 36 | RTSP Server (Sans-IO) | Server-side RTSP parsing and response generation |
+| 37 | Session Management | Single-session enforcement, state machine, timeouts |
+| 38 | SDP Parsing & Stream Setup | ANNOUNCE handling, codec/encryption parameter extraction |
+| 39 | RTP Receiver Core | UDP audio reception, decryption, packet handling |
+| 40 | Timing Synchronization | NTP-like timing, clock offset computation |
+| 41 | Jitter Buffer & Packet Loss | Reordering, buffering, concealment strategies |
+| 42 | Audio Output Abstraction | Platform backends (CoreAudio, CPAL, ALSA) |
+| 43 | Volume & Metadata Handling | SET_PARAMETER parsing, DMAP metadata, artwork |
+| 44 | Receiver Integration | AirPlayReceiver API, event system, wiring |
+| 45 | Receiver Testing | Mock sender, protocol tests, network simulation |
+
+### Receiver Feature Flags
+
+The receiver uses feature flags to keep client-only builds lightweight:
+
+```toml
+[features]
+default = ["tokio-runtime", "client"]
+client = []                              # Client (sender) only
+receiver = ["audio-decode"]              # Receiver functionality
+audio-decode = ["dep:alac", "dep:symphonia"]
+audio-coreaudio = ["dep:coreaudio-rs"]   # macOS (priority)
+audio-cpal = ["dep:cpal"]                # Cross-platform fallback
+audio-alsa = ["dep:alsa"]                # Linux native
+receiver-full = ["receiver", "audio-coreaudio", "audio-cpal"]
+```
+
+### Receiver Components Reused from Client
+
+| Component | Location | Usage in Receiver |
+|-----------|----------|-------------------|
+| `RtspCodec` | `protocol/rtsp/` | Parse requests, encode responses |
+| `RtpPacket` | `protocol/rtp/` | Receive instead of send |
+| `RaopEncryption` | `protocol/raop/` | Decrypt incoming audio |
+| `AudioRingBuffer` | `audio/buffer.rs` | Buffer decoded audio for output |
+| `DmapParser` | `protocol/dacp/` | Parse incoming metadata |
+
+### Stream RF: Receiver Implementation
+
+1. Section 34 (Overview) → 35, 36, 42 (parallel)
+2. Section 36 → 37 → 38 → 39
+3. Section 39 → 40, 41 (parallel)
+4. Section 41, 40, 42, 43 → 44
+5. Section 44 → 45

--- a/docs/34-airplay1-receiver-overview.md
+++ b/docs/34-airplay1-receiver-overview.md
@@ -1,0 +1,449 @@
+# Section 34: AirPlay 1 Receiver Overview
+
+## Dependencies
+- **Section 02**: Core Types, Errors & Config (must be complete)
+- **Section 24**: AirPlay 1 Overview (recommended reading)
+- **Section 05**: RTSP Protocol (foundation for server implementation)
+- **Section 06**: RTP Protocol (foundation for receiver implementation)
+
+## Overview
+
+This section introduces the AirPlay 1 (RAOP) **receiver** implementation, enabling `airplay2-rs` to accept incoming audio streams from AirPlay senders (iTunes, iOS devices, macOS, third-party clients). The receiver complements the existing client implementation, sharing substantial infrastructure while inverting the data flow.
+
+### What is an AirPlay 1 Receiver?
+
+An AirPlay 1 receiver (also known as an AirTunes or RAOP receiver):
+- Advertises itself on the local network via mDNS/Bonjour
+- Accepts incoming RTSP connections from senders
+- Receives RTP audio packets over UDP
+- Decrypts, decodes, and plays audio through local hardware
+- Synchronizes playback timing with the sender
+
+### Design Philosophy
+
+The receiver implementation follows the same principles as the rest of the library:
+
+1. **Sans-IO Core**: Protocol logic separated from I/O operations
+2. **Trait-Based Abstractions**: Audio output via traits for platform independence
+3. **Feature Flags**: Optional compilation for lightweight client-only builds
+4. **Extensive Testing**: Mock senders, protocol conformance, network simulation
+5. **Code Reuse**: Maximum leverage of existing protocol implementations
+
+## Objectives
+
+- Implement a fully functional AirPlay 1 audio receiver
+- Support PCM, ALAC, and AAC audio codecs
+- Support RSA+AES-128 encryption (standard RAOP security)
+- Provide platform-independent audio output via traits
+- Enable optional password protection (deferred, but designed for)
+- Maintain compatibility with iTunes, iOS, macOS, and third-party senders
+- Integrate seamlessly with existing library architecture
+
+---
+
+## Architecture
+
+### Receiver vs Client: Inverted Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         CLIENT (Sender) Mode                             │
+│                                                                          │
+│   ┌──────────────┐    RTSP Request    ┌──────────────┐                  │
+│   │   AirPlay    │ ──────────────────▶│   Remote     │                  │
+│   │   Client     │    RTP Audio       │   Receiver   │                  │
+│   │   (us)       │ ══════════════════▶│   (device)   │                  │
+│   └──────────────┘                    └──────────────┘                  │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        RECEIVER (Server) Mode                            │
+│                                                                          │
+│   ┌──────────────┐    RTSP Request    ┌──────────────┐                  │
+│   │   Remote     │ ──────────────────▶│   AirPlay    │                  │
+│   │   Sender     │    RTP Audio       │   Receiver   │                  │
+│   │   (iTunes)   │ ══════════════════▶│   (us)       │                  │
+│   └──────────────┘                    └──────────────┘                  │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Receiver Architecture Layers
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                          Public API Layer                                │
+│   ┌─────────────────────────────────────────────────────────────────┐   │
+│   │                      AirPlayReceiver                             │   │
+│   │   - start() / stop()                                            │   │
+│   │   - on_audio(), on_metadata()                                   │   │
+│   │   - volume control, status queries                              │   │
+│   └─────────────────────────────────────────────────────────────────┘   │
+└────────────────────────────────────────┬────────────────────────────────┘
+                                         │
+┌────────────────────────────────────────▼────────────────────────────────┐
+│                         Session Layer                                    │
+│   ┌────────────────┐   ┌────────────────┐   ┌────────────────────────┐  │
+│   │    Session     │   │    Volume &    │   │   Metadata Handler     │  │
+│   │    Manager     │   │    Control     │   │   (DMAP/artwork)       │  │
+│   └───────┬────────┘   └────────────────┘   └────────────────────────┘  │
+└───────────┼─────────────────────────────────────────────────────────────┘
+            │
+┌───────────▼─────────────────────────────────────────────────────────────┐
+│                          Audio Layer                                     │
+│   ┌────────────────┐   ┌────────────────┐   ┌────────────────────────┐  │
+│   │  Jitter Buffer │   │   Decryption   │   │    Audio Decoder       │  │
+│   │  & Reordering  │   │   (AES-128)    │   │   (ALAC/AAC/PCM)       │  │
+│   └───────┬────────┘   └────────────────┘   └───────────┬────────────┘  │
+│           │                                             │                │
+│   ┌───────▼─────────────────────────────────────────────▼────────────┐  │
+│   │                      Audio Output Trait                          │  │
+│   │   - CoreAudio (macOS) / ALSA (Linux) / WASAPI (Windows)         │  │
+│   └──────────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────┘
+            │
+┌───────────▼─────────────────────────────────────────────────────────────┐
+│                        Protocol Layer (Sans-IO)                          │
+│   ┌────────────────┐   ┌────────────────┐   ┌────────────────────────┐  │
+│   │  RTSP Server   │   │  RTP Receiver  │   │   Timing Sync          │  │
+│   │  (sans-IO)     │   │  (sans-IO)     │   │   (NTP-like)           │  │
+│   └────────────────┘   └────────────────┘   └────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────┘
+            │
+┌───────────▼─────────────────────────────────────────────────────────────┐
+│                        Network Layer                                     │
+│   ┌────────────────┐   ┌────────────────┐   ┌────────────────────────┐  │
+│   │  TCP Listener  │   │  UDP Sockets   │   │   mDNS Advertiser      │  │
+│   │  (RTSP)        │   │  (Audio/Ctrl)  │   │   (_raop._tcp)         │  │
+│   └────────────────┘   └────────────────┘   └────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Code Reuse Strategy
+
+### Components Reused Directly
+
+| Component | Location | Usage in Receiver |
+|-----------|----------|-------------------|
+| `RtspCodec` | `protocol/rtsp/codec.rs` | Parse requests, encode responses |
+| `RtspRequest`, `RtspResponse` | `protocol/rtsp/` | Same structures, reversed roles |
+| `RtpPacket`, `RtpHeader` | `protocol/rtp/packet.rs` | Receive instead of send |
+| `TimingPacket` | `protocol/rtp/timing.rs` | Respond to timing requests |
+| `RaopEncryption` | `protocol/raop/encryption.rs` | Decrypt incoming audio |
+| `AudioRingBuffer` | `audio/buffer.rs` | Buffer decoded audio for output |
+| `DmapParser` | `protocol/dacp/` | Parse incoming metadata |
+
+### Components Extended
+
+| Component | Extension Needed |
+|-----------|-----------------|
+| `discovery/` | Add service advertisement (currently browse-only) |
+| `protocol/rtsp/` | Add `RtspServerCodec` for server-side parsing |
+| `protocol/sdp/` | Add SDP parser (currently only encoder) |
+| `audio/` | Add decoder wrappers (currently encoder-focused) |
+
+### New Components
+
+| Component | Purpose |
+|-----------|---------|
+| `receiver/` | New module for receiver-specific logic |
+| `audio/output.rs` | Audio output trait and implementations |
+| `receiver/session.rs` | Server-side session management |
+| `receiver/timing.rs` | NTP-like timing response logic |
+
+---
+
+## Feature Flags
+
+The receiver functionality is gated behind feature flags to keep client-only builds lightweight.
+
+### Cargo.toml Additions
+
+```toml
+[features]
+default = ["tokio-runtime", "client"]
+
+# Core functionality
+tokio-runtime = ["tokio", "tokio-util"]
+
+# Client (sender) functionality - existing code
+client = []
+
+# Receiver functionality - new code
+receiver = ["audio-decode"]
+
+# Audio decoding (required for receiver)
+audio-decode = ["dep:alac", "dep:symphonia"]
+
+# Audio output backends (pick one or more)
+audio-coreaudio = ["dep:coreaudio-rs"]     # macOS (priority)
+audio-cpal = ["dep:cpal"]                   # Cross-platform fallback
+audio-alsa = ["dep:alsa"]                   # Linux native
+
+# All receiver features for full build
+receiver-full = ["receiver", "audio-coreaudio", "audio-cpal"]
+
+# Password protection (deferred)
+receiver-auth = ["receiver"]
+```
+
+### Conditional Compilation
+
+```rust
+// In src/lib.rs
+#[cfg(feature = "client")]
+pub mod client;
+
+#[cfg(feature = "receiver")]
+pub mod receiver;
+
+// In src/receiver/mod.rs
+#[cfg(feature = "audio-coreaudio")]
+pub mod output_coreaudio;
+
+#[cfg(feature = "audio-alsa")]
+pub mod output_alsa;
+
+#[cfg(feature = "audio-cpal")]
+pub mod output_cpal;
+```
+
+---
+
+## Module Structure
+
+### Proposed Crate Structure (Receiver Additions)
+
+```
+src/
+├── lib.rs                      # Add receiver exports
+├── receiver/                   # NEW: Receiver module
+│   ├── mod.rs                  # Module exports
+│   ├── config.rs               # ReceiverConfig
+│   ├── server.rs               # AirPlayReceiver main struct
+│   ├── session.rs              # Session state machine
+│   ├── rtsp_handler.rs         # RTSP method handlers
+│   ├── rtp_receiver.rs         # UDP receive loops
+│   ├── timing.rs               # Timing sync responses
+│   └── events.rs               # Receiver events
+│
+├── discovery/
+│   ├── mod.rs
+│   ├── browser.rs              # Existing
+│   ├── parser.rs               # Existing
+│   └── advertiser.rs           # NEW: Service advertisement
+│
+├── audio/
+│   ├── mod.rs
+│   ├── buffer.rs               # Existing (reused)
+│   ├── format.rs               # Existing (reused)
+│   ├── jitter.rs               # NEW: Jitter buffer
+│   ├── output.rs               # NEW: Output trait
+│   ├── output_coreaudio.rs     # NEW: macOS backend
+│   ├── output_cpal.rs          # NEW: Cross-platform backend
+│   └── output_alsa.rs          # NEW: Linux backend
+│
+├── protocol/
+│   ├── rtsp/
+│   │   ├── mod.rs
+│   │   ├── codec.rs            # Existing
+│   │   ├── server_codec.rs     # NEW: Server-side parsing
+│   │   └── ...
+│   ├── sdp/
+│   │   ├── mod.rs
+│   │   ├── encoder.rs          # Existing
+│   │   └── parser.rs           # NEW: SDP parsing
+│   └── raop/
+│       ├── encryption.rs       # Existing (reused for decrypt)
+│       └── ...
+│
+└── testing/
+    ├── mock_server.rs          # Existing
+    └── mock_sender.rs          # NEW: Mock AirPlay sender
+```
+
+---
+
+## Receiver State Machine
+
+```
+                    ┌─────────────────┐
+                    │     Idle        │
+                    │  (advertising)  │
+                    └────────┬────────┘
+                             │ TCP connect
+                    ┌────────▼────────┐
+                    │   Connected     │
+                    │ (awaiting RTSP) │
+                    └────────┬────────┘
+                             │ ANNOUNCE
+                    ┌────────▼────────┐
+                    │   Announced     │
+                    │  (SDP parsed)   │
+                    └────────┬────────┘
+                             │ SETUP
+                    ┌────────▼────────┐
+                    │     Setup       │
+                    │ (ports ready)   │
+                    └────────┬────────┘
+                             │ RECORD
+                    ┌────────▼────────┐
+           FLUSH ──▶│    Streaming    │◀── Audio packets
+                    │  (playing)      │
+                    └────────┬────────┘
+                             │ TEARDOWN
+                    ┌────────▼────────┐
+                    │   Teardown      │
+                    │ (cleanup)       │
+                    └────────┬────────┘
+                             │
+                    ┌────────▼────────┐
+                    │      Idle       │
+                    └─────────────────┘
+```
+
+---
+
+## Section Dependencies (Receiver)
+
+```
+                         ┌──────────────────┐
+                         │ 34: Receiver     │
+                         │ Overview (this)  │
+                         └────────┬─────────┘
+                                  │
+           ┌──────────────────────┼──────────────────────┐
+           │                      │                      │
+  ┌────────▼────────┐   ┌─────────▼────────┐   ┌────────▼────────┐
+  │ 35: Service     │   │ 36: RTSP Server  │   │ 42: Audio       │
+  │ Advertisement   │   │ (Sans-IO)        │   │ Output          │
+  └────────┬────────┘   └─────────┬────────┘   └────────┬────────┘
+           │                      │                     │
+           │            ┌─────────▼────────┐            │
+           │            │ 37: Session      │            │
+           │            │ Management       │            │
+           │            └─────────┬────────┘            │
+           │                      │                     │
+           │            ┌─────────▼────────┐            │
+           │            │ 38: SDP Parsing  │            │
+           │            │ & Stream Setup   │            │
+           │            └─────────┬────────┘            │
+           │                      │                     │
+           │            ┌─────────▼────────┐            │
+           │            │ 39: RTP Receiver │            │
+           │            │ Core             │            │
+           │            └─────────┬────────┘            │
+           │                      │                     │
+           │   ┌──────────────────┼──────────────────┐  │
+           │   │                  │                  │  │
+  ┌────────▼───▼────┐   ┌─────────▼────────┐  ┌─────▼──▼────────┐
+  │ 40: Timing      │   │ 41: Jitter       │  │                 │
+  │ Synchronization │   │ Buffer           │  │                 │
+  └────────┬────────┘   └─────────┬────────┘  │                 │
+           │                      │           │                 │
+           └──────────────────────┼───────────┘                 │
+                                  │                             │
+                         ┌────────▼────────┐                    │
+                         │ 43: Volume &    │                    │
+                         │ Metadata        │                    │
+                         └────────┬────────┘                    │
+                                  │                             │
+                         ┌────────▼────────┐                    │
+                         │ 44: Receiver    │◀───────────────────┘
+                         │ Integration     │
+                         └────────┬────────┘
+                                  │
+                         ┌────────▼────────┐
+                         │ 45: Receiver    │
+                         │ Testing         │
+                         └─────────────────┘
+```
+
+---
+
+## Parallel Work Streams (Receiver)
+
+### Stream R1: Network & Discovery
+- Section 35 (Service Advertisement)
+- Can proceed independently
+
+### Stream R2: Protocol Core
+- Section 36 (RTSP Server) → 37 (Session) → 38 (SDP) → 39 (RTP Receiver)
+- Sequential dependency
+
+### Stream R3: Audio Pipeline
+- Section 42 (Audio Output) → 41 (Jitter Buffer) → 40 (Timing)
+- Can proceed in parallel with R2
+
+### Stream R4: Testing Infrastructure
+- Section 45 (Testing)
+- Can start early, expand as other sections complete
+
+### Convergence
+- Section 43 (Volume/Metadata) requires R2
+- Section 44 (Integration) requires R1, R2, R3
+- Section 45 (Testing) validates all
+
+---
+
+## Comparison: Receiver vs Reference Implementations
+
+| Feature | shairport-sync | This Implementation |
+|---------|----------------|---------------------|
+| Language | C | Rust |
+| AirPlay 1 | Yes | Yes (goal) |
+| AirPlay 2 | Yes | Client only (for now) |
+| Audio backends | ALSA, PulseAudio, etc. | Trait-based, pluggable |
+| Encryption | RSA + AES | RSA + AES (reuse existing) |
+| Password | Yes | Deferred |
+| Metadata | Yes | Yes |
+| Multi-room | Yes | Future consideration |
+
+---
+
+## Testing Philosophy
+
+Testing is **critical** for the receiver implementation. Each section includes:
+
+1. **Unit Tests**: Protocol parsing, state machines, codec correctness
+2. **Integration Tests**: Full RTSP/RTP exchanges with mock components
+3. **Conformance Tests**: Behavior matching against shairport-sync
+4. **Interoperability Tests**: Real sender compatibility (manual + documented)
+5. **Network Simulation**: Packet loss, jitter, reordering scenarios
+6. **Performance Tests**: Latency, throughput, buffer efficiency
+
+See **Section 45** for comprehensive testing infrastructure.
+
+---
+
+## Acceptance Criteria (Overview)
+
+- [ ] Architecture documented and approved
+- [ ] Feature flags designed and documented
+- [ ] Module structure defined
+- [ ] Dependency graph established
+- [ ] Reuse strategy identified for all components
+- [ ] Testing philosophy documented
+- [ ] All section documents (35-45) created
+
+---
+
+## Notes
+
+- **Priority**: macOS audio output (CoreAudio) is the priority, but design for all platforms
+- **Password Protection**: Design hooks now, implement later (receiver-auth feature)
+- **FairPlay**: Not supported (requires Apple licensing)
+- **AirPlay 2 Receiver**: Future consideration, beyond current scope
+- **Reference**: Compare behavior with [shairport-sync](https://github.com/mikebrady/shairport-sync)
+
+---
+
+## References
+
+- [Unofficial AirPlay Specification](https://nto.github.io/AirPlay.html)
+- [OpenAirPlay Audio Spec](https://openairplay.github.io/airplay-spec/audio/)
+- [shairport-sync](https://github.com/mikebrady/shairport-sync) - Reference implementation
+- [RAOP Protocol Analysis](https://git.zx2c4.com/Airtunes2/about/)

--- a/docs/35-raop-service-advertisement.md
+++ b/docs/35-raop-service-advertisement.md
@@ -1,0 +1,1008 @@
+# Section 35: RAOP Service Advertisement
+
+## Dependencies
+- **Section 02**: Core Types, Errors & Config (must be complete)
+- **Section 08**: mDNS Discovery (understanding of mdns-sd usage)
+- **Section 34**: Receiver Overview (architectural context)
+
+## Overview
+
+This section implements mDNS/Bonjour service advertisement for the AirPlay 1 receiver. While the existing `discovery/` module browses for services, the receiver must **advertise** itself so that AirPlay senders (iTunes, iOS, macOS) can discover and connect to it.
+
+The RAOP service uses the `_raop._tcp.local.` service type with a specific naming convention and TXT record format that describes receiver capabilities.
+
+## Objectives
+
+- Implement RAOP service advertisement using `mdns-sd` crate
+- Construct proper service name (`MAC@FriendlyName`)
+- Generate correct TXT record with all required fields
+- Support dynamic status updates (busy/available flags)
+- Handle service registration lifecycle (register, update, unregister)
+- Enable multiple network interface support
+
+---
+
+## Tasks
+
+### 35.1 Service Name Generation
+
+- [ ] **35.1.1** Implement MAC address retrieval for service name
+
+**File:** `src/discovery/advertiser.rs`
+
+```rust
+//! RAOP service advertisement for AirPlay 1 receiver
+
+use std::net::IpAddr;
+
+/// Retrieve a MAC address for service identification
+///
+/// The RAOP service name format is `MAC@FriendlyName` where MAC is
+/// a 12-character hex string (e.g., "5855CA1AE288").
+///
+/// Strategy:
+/// 1. Try to get the actual hardware MAC of the primary interface
+/// 2. Fall back to generating a stable pseudo-MAC from machine ID
+/// 3. Last resort: random MAC (not recommended, changes identity)
+pub fn get_device_mac() -> Result<[u8; 6], AdvertiserError> {
+    // Try platform-specific MAC retrieval
+    #[cfg(target_os = "macos")]
+    {
+        get_mac_macos()
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        get_mac_linux()
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        get_mac_windows()
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        // Generate stable pseudo-MAC
+        generate_stable_mac()
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn get_mac_macos() -> Result<[u8; 6], AdvertiserError> {
+    // Use IOKit or system_profiler to get en0 MAC
+    // Fallback: parse output of `ifconfig en0`
+    todo!("Implement macOS MAC retrieval")
+}
+
+#[cfg(target_os = "linux")]
+fn get_mac_linux() -> Result<[u8; 6], AdvertiserError> {
+    // Read from /sys/class/net/<interface>/address
+    // Prefer non-loopback, non-virtual interfaces
+    use std::fs;
+
+    let net_dir = "/sys/class/net";
+    for entry in fs::read_dir(net_dir).map_err(|e| AdvertiserError::MacRetrievalFailed(e.to_string()))? {
+        let entry = entry.map_err(|e| AdvertiserError::MacRetrievalFailed(e.to_string()))?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        // Skip loopback and virtual interfaces
+        if name_str == "lo" || name_str.starts_with("veth") || name_str.starts_with("docker") {
+            continue;
+        }
+
+        let addr_path = entry.path().join("address");
+        if let Ok(mac_str) = fs::read_to_string(&addr_path) {
+            let mac_str = mac_str.trim();
+            if mac_str != "00:00:00:00:00:00" {
+                return parse_mac_string(mac_str);
+            }
+        }
+    }
+
+    Err(AdvertiserError::MacRetrievalFailed("No suitable interface found".into()))
+}
+
+fn parse_mac_string(mac: &str) -> Result<[u8; 6], AdvertiserError> {
+    let parts: Vec<&str> = mac.split(':').collect();
+    if parts.len() != 6 {
+        return Err(AdvertiserError::MacRetrievalFailed(format!("Invalid MAC format: {}", mac)));
+    }
+
+    let mut bytes = [0u8; 6];
+    for (i, part) in parts.iter().enumerate() {
+        bytes[i] = u8::from_str_radix(part, 16)
+            .map_err(|_| AdvertiserError::MacRetrievalFailed(format!("Invalid hex: {}", part)))?;
+    }
+
+    Ok(bytes)
+}
+
+fn generate_stable_mac() -> Result<[u8; 6], AdvertiserError> {
+    // Generate from machine-id or hostname hash for stability across restarts
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let seed = match std::fs::read_to_string("/etc/machine-id") {
+        Ok(id) => id,
+        Err(_) => {
+            // Fallback to hostname
+            hostname::get()
+                .map(|h| h.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| "airplay-receiver".to_string())
+        }
+    };
+
+    let mut hasher = DefaultHasher::new();
+    seed.hash(&mut hasher);
+    let hash = hasher.finish();
+
+    // Use hash bytes as MAC, set locally-administered bit
+    let mut mac = [0u8; 6];
+    mac[0] = ((hash >> 40) as u8) | 0x02; // Set locally-administered bit
+    mac[1] = (hash >> 32) as u8;
+    mac[2] = (hash >> 24) as u8;
+    mac[3] = (hash >> 16) as u8;
+    mac[4] = (hash >> 8) as u8;
+    mac[5] = hash as u8;
+
+    Ok(mac)
+}
+
+/// Format MAC address for RAOP service name (uppercase, no colons)
+pub fn format_mac_for_service(mac: &[u8; 6]) -> String {
+    format!(
+        "{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}",
+        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+    )
+}
+```
+
+---
+
+### 35.2 TXT Record Builder
+
+- [ ] **35.2.1** Implement TXT record construction with all required fields
+
+**File:** `src/discovery/advertiser.rs` (continued)
+
+```rust
+use std::collections::HashMap;
+
+/// RAOP receiver capabilities for TXT record
+#[derive(Debug, Clone)]
+pub struct RaopCapabilities {
+    /// Supported audio codecs: 0=PCM, 1=ALAC, 2=AAC-LC, 3=AAC-ELD
+    pub codecs: Vec<u8>,
+    /// Supported encryption types: 0=none, 1=RSA+AES
+    pub encryption_types: Vec<u8>,
+    /// Supported metadata types: 0=text, 1=artwork, 2=progress
+    pub metadata_types: Vec<u8>,
+    /// Number of audio channels (typically 2 for stereo)
+    pub channels: u8,
+    /// Sample rate in Hz (typically 44100)
+    pub sample_rate: u32,
+    /// Sample size in bits (typically 16)
+    pub sample_size: u8,
+    /// Password required
+    pub password_required: bool,
+    /// Device model name
+    pub model: String,
+    /// Protocol version
+    pub protocol_version: u8,
+    /// Software version string
+    pub software_version: String,
+}
+
+impl Default for RaopCapabilities {
+    fn default() -> Self {
+        Self {
+            codecs: vec![0, 1, 2],           // PCM, ALAC, AAC-LC
+            encryption_types: vec![0, 1],    // None, RSA+AES
+            metadata_types: vec![0, 1, 2],   // All metadata types
+            channels: 2,
+            sample_rate: 44100,
+            sample_size: 16,
+            password_required: false,
+            model: "AirPlayRust".to_string(),
+            protocol_version: 1,
+            software_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+}
+
+/// Status flags for the receiver
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ReceiverStatusFlags {
+    /// Problem detected (e.g., audio device error)
+    pub problem: bool,
+    /// Receiver is PIN-protected
+    pub pin_required: bool,
+    /// Receiver is busy (streaming in progress)
+    pub busy: bool,
+    /// Supports legacy pairing
+    pub supports_legacy_pairing: bool,
+}
+
+impl ReceiverStatusFlags {
+    /// Convert to the `sf` TXT record value
+    pub fn to_flags(&self) -> u32 {
+        let mut flags = 0u32;
+
+        // Bit positions based on RAOP specification
+        if self.problem {
+            flags |= 0x01;
+        }
+        if self.pin_required {
+            flags |= 0x02;
+        }
+        if self.busy {
+            flags |= 0x04;
+        }
+        if self.supports_legacy_pairing {
+            flags |= 0x08;
+        }
+
+        flags
+    }
+}
+
+/// Build TXT record for RAOP service advertisement
+pub struct TxtRecordBuilder {
+    records: HashMap<String, String>,
+}
+
+impl TxtRecordBuilder {
+    pub fn new() -> Self {
+        Self {
+            records: HashMap::new(),
+        }
+    }
+
+    /// Build TXT record from capabilities and status
+    pub fn from_capabilities(
+        caps: &RaopCapabilities,
+        status: &ReceiverStatusFlags,
+    ) -> Self {
+        let mut builder = Self::new();
+
+        // Required fields
+        builder.add("txtvers", "1");
+
+        // Audio format
+        builder.add("ch", &caps.channels.to_string());
+        builder.add("sr", &caps.sample_rate.to_string());
+        builder.add("ss", &caps.sample_size.to_string());
+
+        // Codecs (comma-separated)
+        builder.add("cn", &Self::format_list(&caps.codecs));
+
+        // Encryption types
+        builder.add("et", &Self::format_list(&caps.encryption_types));
+
+        // Metadata types
+        builder.add("md", &Self::format_list(&caps.metadata_types));
+
+        // Transport (UDP only for now)
+        builder.add("tp", "UDP");
+
+        // Password
+        builder.add("pw", if caps.password_required { "true" } else { "false" });
+
+        // Device info
+        builder.add("am", &caps.model);
+        builder.add("vn", &caps.protocol_version.to_string());
+        builder.add("vs", &caps.software_version);
+
+        // Status flags
+        builder.add("sf", &format!("0x{:x}", status.to_flags()));
+
+        // Features (standard RAOP receiver features)
+        // This is a bitmask of supported features
+        builder.add("ft", "0x4A7FDFD5");
+
+        builder
+    }
+
+    /// Add a key-value pair
+    pub fn add(&mut self, key: &str, value: &str) -> &mut Self {
+        self.records.insert(key.to_string(), value.to_string());
+        self
+    }
+
+    /// Build into a vector of "key=value" strings
+    pub fn build(&self) -> Vec<String> {
+        self.records
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect()
+    }
+
+    /// Build into HashMap for mdns-sd
+    pub fn build_map(&self) -> HashMap<String, String> {
+        self.records.clone()
+    }
+
+    fn format_list(items: &[u8]) -> String {
+        items
+            .iter()
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+}
+
+impl Default for TxtRecordBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+```
+
+---
+
+### 35.3 Service Advertiser
+
+- [ ] **35.3.1** Implement the main service advertiser using mdns-sd
+
+**File:** `src/discovery/advertiser.rs` (continued)
+
+```rust
+use mdns_sd::{ServiceDaemon, ServiceInfo, Error as MdnsError};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Errors from service advertisement
+#[derive(Debug, thiserror::Error)]
+pub enum AdvertiserError {
+    #[error("Failed to retrieve MAC address: {0}")]
+    MacRetrievalFailed(String),
+
+    #[error("mDNS error: {0}")]
+    Mdns(#[from] MdnsError),
+
+    #[error("Service not registered")]
+    NotRegistered,
+
+    #[error("Service already registered")]
+    AlreadyRegistered,
+}
+
+/// Configuration for RAOP service advertisement
+#[derive(Debug, Clone)]
+pub struct AdvertiserConfig {
+    /// Friendly name shown to users (e.g., "Living Room Speaker")
+    pub name: String,
+    /// RTSP port to advertise
+    pub port: u16,
+    /// Receiver capabilities
+    pub capabilities: RaopCapabilities,
+    /// Optional: override MAC address
+    pub mac_override: Option<[u8; 6]>,
+}
+
+impl Default for AdvertiserConfig {
+    fn default() -> Self {
+        Self {
+            name: "AirPlay Receiver".to_string(),
+            port: 5000,
+            capabilities: RaopCapabilities::default(),
+            mac_override: None,
+        }
+    }
+}
+
+/// RAOP service advertiser
+///
+/// Handles mDNS advertisement lifecycle including registration,
+/// status updates, and graceful unregistration.
+pub struct RaopAdvertiser {
+    config: AdvertiserConfig,
+    daemon: ServiceDaemon,
+    service_fullname: Option<String>,
+    status: Arc<RwLock<ReceiverStatusFlags>>,
+    mac: [u8; 6],
+}
+
+impl RaopAdvertiser {
+    /// Create a new advertiser
+    pub fn new(config: AdvertiserConfig) -> Result<Self, AdvertiserError> {
+        let daemon = ServiceDaemon::new()?;
+
+        let mac = config.mac_override
+            .map(Ok)
+            .unwrap_or_else(get_device_mac)?;
+
+        Ok(Self {
+            config,
+            daemon,
+            service_fullname: None,
+            status: Arc::new(RwLock::new(ReceiverStatusFlags::default())),
+            mac,
+        })
+    }
+
+    /// Get the service name that will be advertised
+    pub fn service_name(&self) -> String {
+        format!("{}@{}", format_mac_for_service(&self.mac), self.config.name)
+    }
+
+    /// Register the service on the network
+    pub fn register(&mut self) -> Result<(), AdvertiserError> {
+        if self.service_fullname.is_some() {
+            return Err(AdvertiserError::AlreadyRegistered);
+        }
+
+        let service_type = "_raop._tcp.local.";
+        let service_name = self.service_name();
+
+        // Build TXT record
+        let status = *self.status.blocking_read();
+        let txt = TxtRecordBuilder::from_capabilities(&self.config.capabilities, &status);
+
+        // Create service info
+        // Note: mdns-sd ServiceInfo requires careful construction
+        let service_info = ServiceInfo::new(
+            service_type,
+            &service_name,
+            &self.config.name,  // hostname
+            (),                  // IP addresses (auto-detect)
+            self.config.port,
+            txt.build_map(),
+        ).map_err(MdnsError::from)?;
+
+        // Register with daemon
+        self.daemon.register(service_info.clone())?;
+
+        self.service_fullname = Some(service_info.get_fullname().to_string());
+
+        tracing::info!(
+            name = %service_name,
+            port = %self.config.port,
+            "RAOP service registered"
+        );
+
+        Ok(())
+    }
+
+    /// Unregister the service from the network
+    pub fn unregister(&mut self) -> Result<(), AdvertiserError> {
+        let fullname = self.service_fullname.take()
+            .ok_or(AdvertiserError::NotRegistered)?;
+
+        self.daemon.unregister(&fullname)?;
+
+        tracing::info!(name = %fullname, "RAOP service unregistered");
+
+        Ok(())
+    }
+
+    /// Update the status flags (e.g., mark as busy when streaming)
+    ///
+    /// This re-registers the service with updated TXT records.
+    pub fn update_status(&mut self, status: ReceiverStatusFlags) -> Result<(), AdvertiserError> {
+        {
+            let mut current = self.status.blocking_write();
+            *current = status;
+        }
+
+        // If registered, need to re-register to update TXT
+        if self.service_fullname.is_some() {
+            // Unregister then re-register with new TXT
+            self.unregister()?;
+            self.register()?;
+        }
+
+        Ok(())
+    }
+
+    /// Mark receiver as busy (streaming in progress)
+    pub fn set_busy(&mut self, busy: bool) -> Result<(), AdvertiserError> {
+        let current = *self.status.blocking_read();
+        self.update_status(ReceiverStatusFlags {
+            busy,
+            ..current
+        })
+    }
+
+    /// Get shared status handle for async status updates
+    pub fn status_handle(&self) -> Arc<RwLock<ReceiverStatusFlags>> {
+        self.status.clone()
+    }
+}
+
+impl Drop for RaopAdvertiser {
+    fn drop(&mut self) {
+        // Best-effort unregister on drop
+        if self.service_fullname.is_some() {
+            let _ = self.unregister();
+        }
+    }
+}
+```
+
+---
+
+### 35.4 Async Wrapper
+
+- [ ] **35.4.1** Implement async-friendly advertiser wrapper
+
+**File:** `src/discovery/advertiser.rs` (continued)
+
+```rust
+use tokio::sync::mpsc;
+
+/// Commands for async advertiser control
+#[derive(Debug)]
+pub enum AdvertiserCommand {
+    UpdateStatus(ReceiverStatusFlags),
+    Shutdown,
+}
+
+/// Async-friendly RAOP advertiser
+///
+/// Wraps the synchronous mdns-sd advertiser in a background task
+/// and provides async methods for control.
+pub struct AsyncRaopAdvertiser {
+    command_tx: mpsc::Sender<AdvertiserCommand>,
+    status: Arc<RwLock<ReceiverStatusFlags>>,
+    mac: [u8; 6],
+    service_name: String,
+}
+
+impl AsyncRaopAdvertiser {
+    /// Create and start the advertiser
+    pub async fn start(config: AdvertiserConfig) -> Result<Self, AdvertiserError> {
+        let (command_tx, mut command_rx) = mpsc::channel(16);
+
+        let mac = config.mac_override
+            .map(Ok)
+            .unwrap_or_else(get_device_mac)?;
+
+        let service_name = format!("{}@{}", format_mac_for_service(&mac), config.name);
+        let status = Arc::new(RwLock::new(ReceiverStatusFlags::default()));
+        let status_clone = status.clone();
+
+        // Spawn blocking task for mdns-sd
+        let config_clone = config.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut advertiser = match RaopAdvertiser::new(config_clone) {
+                Ok(a) => a,
+                Err(e) => {
+                    tracing::error!("Failed to create advertiser: {}", e);
+                    return;
+                }
+            };
+
+            if let Err(e) = advertiser.register() {
+                tracing::error!("Failed to register service: {}", e);
+                return;
+            }
+
+            // Process commands until shutdown
+            while let Some(cmd) = command_rx.blocking_recv() {
+                match cmd {
+                    AdvertiserCommand::UpdateStatus(new_status) => {
+                        if let Err(e) = advertiser.update_status(new_status) {
+                            tracing::warn!("Failed to update status: {}", e);
+                        }
+                    }
+                    AdvertiserCommand::Shutdown => {
+                        break;
+                    }
+                }
+            }
+
+            // Unregister on exit
+            let _ = advertiser.unregister();
+        });
+
+        Ok(Self {
+            command_tx,
+            status: status_clone,
+            mac,
+            service_name,
+        })
+    }
+
+    /// Update the receiver status
+    pub async fn update_status(&self, status: ReceiverStatusFlags) -> Result<(), AdvertiserError> {
+        {
+            let mut current = self.status.write().await;
+            *current = status;
+        }
+
+        self.command_tx
+            .send(AdvertiserCommand::UpdateStatus(status))
+            .await
+            .map_err(|_| AdvertiserError::NotRegistered)
+    }
+
+    /// Mark as busy
+    pub async fn set_busy(&self, busy: bool) -> Result<(), AdvertiserError> {
+        let current = *self.status.read().await;
+        self.update_status(ReceiverStatusFlags {
+            busy,
+            ..current
+        }).await
+    }
+
+    /// Get the service name being advertised
+    pub fn service_name(&self) -> &str {
+        &self.service_name
+    }
+
+    /// Get the MAC address
+    pub fn mac(&self) -> [u8; 6] {
+        self.mac
+    }
+
+    /// Shutdown the advertiser
+    pub async fn shutdown(self) {
+        let _ = self.command_tx.send(AdvertiserCommand::Shutdown).await;
+    }
+}
+```
+
+---
+
+## Unit Tests
+
+### 35.5 Unit Tests
+
+- [ ] **35.5.1** Implement comprehensive unit tests
+
+**File:** `src/discovery/advertiser.rs` (test module)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_mac_for_service() {
+        let mac = [0x58, 0x55, 0xCA, 0x1A, 0xE2, 0x88];
+        assert_eq!(format_mac_for_service(&mac), "5855CA1AE288");
+    }
+
+    #[test]
+    fn test_format_mac_with_zeros() {
+        let mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        assert_eq!(format_mac_for_service(&mac), "001122334455");
+    }
+
+    #[test]
+    fn test_parse_mac_string() {
+        let mac = parse_mac_string("58:55:ca:1a:e2:88").unwrap();
+        assert_eq!(mac, [0x58, 0x55, 0xca, 0x1a, 0xe2, 0x88]);
+    }
+
+    #[test]
+    fn test_parse_mac_string_invalid() {
+        assert!(parse_mac_string("invalid").is_err());
+        assert!(parse_mac_string("58:55:ca:1a:e2").is_err());  // Too short
+        assert!(parse_mac_string("58:55:ca:1a:e2:88:99").is_err());  // Too long
+        assert!(parse_mac_string("58:55:ZZ:1a:e2:88").is_err());  // Invalid hex
+    }
+
+    #[test]
+    fn test_stable_mac_generation() {
+        // Should generate the same MAC for same input
+        let mac1 = generate_stable_mac().unwrap();
+        let mac2 = generate_stable_mac().unwrap();
+        assert_eq!(mac1, mac2);
+
+        // Should have locally-administered bit set
+        assert!(mac1[0] & 0x02 != 0, "Locally-administered bit should be set");
+    }
+
+    #[test]
+    fn test_status_flags_empty() {
+        let flags = ReceiverStatusFlags::default();
+        assert_eq!(flags.to_flags(), 0);
+    }
+
+    #[test]
+    fn test_status_flags_busy() {
+        let flags = ReceiverStatusFlags {
+            busy: true,
+            ..Default::default()
+        };
+        assert_eq!(flags.to_flags(), 0x04);
+    }
+
+    #[test]
+    fn test_status_flags_combined() {
+        let flags = ReceiverStatusFlags {
+            problem: true,
+            pin_required: true,
+            busy: true,
+            supports_legacy_pairing: true,
+        };
+        assert_eq!(flags.to_flags(), 0x0F);
+    }
+
+    #[test]
+    fn test_txt_record_builder_default() {
+        let caps = RaopCapabilities::default();
+        let status = ReceiverStatusFlags::default();
+        let txt = TxtRecordBuilder::from_capabilities(&caps, &status);
+        let records = txt.build_map();
+
+        assert_eq!(records.get("txtvers"), Some(&"1".to_string()));
+        assert_eq!(records.get("ch"), Some(&"2".to_string()));
+        assert_eq!(records.get("sr"), Some(&"44100".to_string()));
+        assert_eq!(records.get("ss"), Some(&"16".to_string()));
+        assert_eq!(records.get("cn"), Some(&"0,1,2".to_string()));
+        assert_eq!(records.get("et"), Some(&"0,1".to_string()));
+        assert_eq!(records.get("tp"), Some(&"UDP".to_string()));
+        assert_eq!(records.get("pw"), Some(&"false".to_string()));
+    }
+
+    #[test]
+    fn test_txt_record_password_required() {
+        let caps = RaopCapabilities {
+            password_required: true,
+            ..Default::default()
+        };
+        let txt = TxtRecordBuilder::from_capabilities(&caps, &ReceiverStatusFlags::default());
+        let records = txt.build_map();
+
+        assert_eq!(records.get("pw"), Some(&"true".to_string()));
+    }
+
+    #[test]
+    fn test_txt_record_custom_codecs() {
+        let caps = RaopCapabilities {
+            codecs: vec![1],  // ALAC only
+            ..Default::default()
+        };
+        let txt = TxtRecordBuilder::from_capabilities(&caps, &ReceiverStatusFlags::default());
+        let records = txt.build_map();
+
+        assert_eq!(records.get("cn"), Some(&"1".to_string()));
+    }
+
+    #[test]
+    fn test_service_name_format() {
+        let config = AdvertiserConfig {
+            name: "Living Room".to_string(),
+            mac_override: Some([0x5B, 0x55, 0xCA, 0x1A, 0xE2, 0x88]),
+            ..Default::default()
+        };
+        let advertiser = RaopAdvertiser::new(config).unwrap();
+
+        assert_eq!(advertiser.service_name(), "5B55CA1AE288@Living Room");
+    }
+
+    #[test]
+    fn test_service_name_special_characters() {
+        let config = AdvertiserConfig {
+            name: "John's Speaker".to_string(),
+            mac_override: Some([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]),
+            ..Default::default()
+        };
+        let advertiser = RaopAdvertiser::new(config).unwrap();
+
+        assert_eq!(advertiser.service_name(), "AABBCCDDEEFF@John's Speaker");
+    }
+}
+```
+
+---
+
+## Integration Tests
+
+### 35.6 Integration Tests
+
+- [ ] **35.6.1** Test service visibility on network
+
+**File:** `tests/discovery/advertiser_tests.rs`
+
+```rust
+//! Integration tests for RAOP service advertisement
+//!
+//! These tests verify that advertised services can be discovered
+//! by the existing browser functionality.
+
+use airplay2::discovery::{
+    advertiser::{AdvertiserConfig, AsyncRaopAdvertiser, RaopCapabilities, ReceiverStatusFlags},
+    browser::ServiceBrowser,
+};
+use std::time::Duration;
+
+/// Test that an advertised service can be discovered
+#[tokio::test]
+async fn test_advertise_and_discover() {
+    // Start advertiser
+    let config = AdvertiserConfig {
+        name: "Test Receiver".to_string(),
+        port: 15000,  // Use high port to avoid conflicts
+        mac_override: Some([0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01]),
+        ..Default::default()
+    };
+
+    let advertiser = AsyncRaopAdvertiser::start(config).await.unwrap();
+
+    // Wait for advertisement to propagate
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Browse for services
+    let browser = ServiceBrowser::new().unwrap();
+    let services = browser.browse_raop(Duration::from_secs(5)).await.unwrap();
+
+    // Find our service
+    let found = services.iter().find(|s| s.name.contains("Test Receiver"));
+    assert!(found.is_some(), "Service should be discoverable");
+
+    let service = found.unwrap();
+    assert_eq!(service.port, 15000);
+
+    // Cleanup
+    advertiser.shutdown().await;
+}
+
+/// Test status update visibility
+#[tokio::test]
+async fn test_status_update_reflected_in_txt() {
+    let config = AdvertiserConfig {
+        name: "Status Test".to_string(),
+        port: 15001,
+        mac_override: Some([0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x02]),
+        ..Default::default()
+    };
+
+    let advertiser = AsyncRaopAdvertiser::start(config).await.unwrap();
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Update status to busy
+    advertiser.update_status(ReceiverStatusFlags {
+        busy: true,
+        ..Default::default()
+    }).await.unwrap();
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Browse and check TXT record
+    let browser = ServiceBrowser::new().unwrap();
+    let services = browser.browse_raop(Duration::from_secs(3)).await.unwrap();
+
+    let found = services.iter().find(|s| s.name.contains("Status Test"));
+    if let Some(service) = found {
+        let sf = service.txt.get("sf").and_then(|s| u32::from_str_radix(s.trim_start_matches("0x"), 16).ok());
+        assert_eq!(sf, Some(0x04), "Busy flag should be set");
+    }
+
+    advertiser.shutdown().await;
+}
+
+/// Test multiple advertisers with different names
+#[tokio::test]
+async fn test_multiple_advertisers() {
+    let configs = [
+        AdvertiserConfig {
+            name: "Kitchen".to_string(),
+            port: 15010,
+            mac_override: Some([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
+            ..Default::default()
+        },
+        AdvertiserConfig {
+            name: "Bedroom".to_string(),
+            port: 15011,
+            mac_override: Some([0x01, 0x02, 0x03, 0x04, 0x05, 0x07]),
+            ..Default::default()
+        },
+    ];
+
+    let mut advertisers = Vec::new();
+    for config in configs {
+        advertisers.push(AsyncRaopAdvertiser::start(config).await.unwrap());
+    }
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let browser = ServiceBrowser::new().unwrap();
+    let services = browser.browse_raop(Duration::from_secs(5)).await.unwrap();
+
+    assert!(services.iter().any(|s| s.name.contains("Kitchen")));
+    assert!(services.iter().any(|s| s.name.contains("Bedroom")));
+
+    for advertiser in advertisers {
+        advertiser.shutdown().await;
+    }
+}
+
+/// Test graceful shutdown removes service
+#[tokio::test]
+async fn test_shutdown_removes_service() {
+    let config = AdvertiserConfig {
+        name: "Temporary".to_string(),
+        port: 15020,
+        mac_override: Some([0xFE, 0xED, 0xFA, 0xCE, 0x00, 0x01]),
+        ..Default::default()
+    };
+
+    let advertiser = AsyncRaopAdvertiser::start(config).await.unwrap();
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Verify visible
+    let browser = ServiceBrowser::new().unwrap();
+    let services = browser.browse_raop(Duration::from_secs(3)).await.unwrap();
+    assert!(services.iter().any(|s| s.name.contains("Temporary")));
+
+    // Shutdown
+    advertiser.shutdown().await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Verify gone (may take a moment for mDNS to propagate)
+    let services = browser.browse_raop(Duration::from_secs(3)).await.unwrap();
+    // Note: Depending on mDNS cache, might still be visible briefly
+    // In practice, test for eventual consistency
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] MAC address retrieval works on Linux, macOS, Windows
+- [ ] Stable pseudo-MAC generation for platforms without accessible MAC
+- [ ] TXT record contains all required RAOP fields
+- [ ] Service advertised as `MAC@FriendlyName`
+- [ ] Service discoverable by standard mDNS browsers (dns-sd, avahi-browse)
+- [ ] Status updates (busy/available) reflected in TXT record
+- [ ] Graceful shutdown removes service from network
+- [ ] Multiple receivers can advertise on same machine (different ports)
+- [ ] All unit tests pass
+- [ ] Integration tests pass (advertise and discover)
+
+---
+
+## Verification Commands
+
+Use these commands to manually verify advertisement:
+
+### macOS
+```bash
+# List RAOP services
+dns-sd -B _raop._tcp local.
+
+# Get details of specific service
+dns-sd -L "AABBCCDDEEFF@My Speaker" _raop._tcp local.
+
+# Resolve to IP/port
+dns-sd -G v4 "AABBCCDDEEFF@My Speaker._raop._tcp.local."
+```
+
+### Linux
+```bash
+# Install avahi-utils if needed
+sudo apt install avahi-utils
+
+# Browse RAOP services
+avahi-browse -r _raop._tcp
+
+# Detailed view
+avahi-browse -r -p _raop._tcp
+```
+
+---
+
+## Notes
+
+- **mDNS library**: Using `mdns-sd` which provides both browsing and registration
+- **MAC address**: Real MAC preferred for device identity, but locally-administered pseudo-MAC acceptable
+- **TXT record updates**: Currently requires re-registration; mdns-sd may add update API in future
+- **Network interfaces**: mdns-sd handles multi-interface automatically
+- **Service name uniqueness**: If name conflicts, mDNS will add suffix (e.g., " (2)")
+- **Password**: `pw=false` hardcoded initially; Section 43 will add password support infrastructure
+
+---
+
+## References
+
+- [RFC 6762](https://tools.ietf.org/html/rfc6762) - Multicast DNS
+- [RFC 6763](https://tools.ietf.org/html/rfc6763) - DNS-Based Service Discovery
+- [RAOP TXT Record Format](https://openairplay.github.io/airplay-spec/service_discovery.html)
+- [mdns-sd crate documentation](https://docs.rs/mdns-sd/)

--- a/docs/36-rtsp-server-sans-io.md
+++ b/docs/36-rtsp-server-sans-io.md
@@ -1,0 +1,1422 @@
+# Section 36: RTSP Server (Sans-IO)
+
+## Dependencies
+- **Section 05**: RTSP Protocol (existing codec and types)
+- **Section 34**: Receiver Overview (architectural context)
+- **Section 02**: Core Types, Errors & Config
+
+## Overview
+
+This section implements the server-side RTSP handling for the AirPlay 1 receiver. The existing RTSP implementation (Section 05) provides client-side functionality; here we create a complementary server-side codec that:
+
+1. **Parses incoming RTSP requests** from AirPlay senders
+2. **Generates RTSP responses** with proper formatting
+3. **Follows sans-IO principles** - no I/O in the codec itself
+4. **Reuses existing types** - `RtspRequest`, `RtspResponse`, `Headers`, `Method`
+
+The key insight is that RTSP requests and responses have symmetric structures, so we can reuse most existing types while adding server-specific parsing and response generation.
+
+## Objectives
+
+- Implement `RtspServerCodec` for server-side request parsing
+- Create response builder for proper RTSP response formatting
+- Handle all RAOP-specific RTSP methods
+- Maintain CSeq tracking and session management
+- Support binary and text body payloads
+- Ensure complete test coverage with real-world RTSP captures
+
+---
+
+## Tasks
+
+### 36.1 Request Parser
+
+- [ ] **36.1.1** Implement server-side RTSP request parser
+
+**File:** `src/protocol/rtsp/server_codec.rs`
+
+```rust
+//! Server-side RTSP codec for parsing requests and generating responses
+//!
+//! This module complements the client-side codec by providing server-side
+//! parsing. Both share the same request/response types but differ in what
+//! they parse vs. generate.
+
+use super::{RtspRequest, RtspResponse, Method, Headers, StatusCode};
+use bytes::{Buf, BytesMut};
+use std::str;
+
+/// Errors during RTSP parsing
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("Incomplete data, need more bytes")]
+    Incomplete,
+
+    #[error("Invalid request line: {0}")]
+    InvalidRequestLine(String),
+
+    #[error("Invalid method: {0}")]
+    InvalidMethod(String),
+
+    #[error("Invalid header: {0}")]
+    InvalidHeader(String),
+
+    #[error("Invalid Content-Length: {0}")]
+    InvalidContentLength(String),
+
+    #[error("Body too large: {size} > {max}")]
+    BodyTooLarge { size: usize, max: usize },
+
+    #[error("Invalid UTF-8 in headers")]
+    InvalidUtf8,
+}
+
+/// Maximum allowed body size (16 MB should be plenty for any RTSP body)
+const MAX_BODY_SIZE: usize = 16 * 1024 * 1024;
+
+/// Maximum header section size (64 KB)
+const MAX_HEADER_SIZE: usize = 64 * 1024;
+
+/// Server-side RTSP codec
+///
+/// Parses incoming RTSP requests from a byte buffer and generates
+/// properly formatted RTSP responses.
+///
+/// # Sans-IO Design
+///
+/// This codec performs no I/O. It operates on byte buffers:
+/// - `feed()` adds bytes to the internal buffer
+/// - `decode()` attempts to parse a complete request
+/// - `encode_response()` generates response bytes
+///
+/// # Example
+///
+/// ```rust
+/// use airplay2::protocol::rtsp::RtspServerCodec;
+///
+/// let mut codec = RtspServerCodec::new();
+///
+/// // Feed incoming bytes
+/// codec.feed(b"OPTIONS * RTSP/1.0\r\nCSeq: 1\r\n\r\n");
+///
+/// // Try to decode
+/// if let Some(request) = codec.decode()? {
+///     println!("Method: {:?}", request.method);
+/// }
+/// ```
+pub struct RtspServerCodec {
+    buffer: BytesMut,
+}
+
+impl RtspServerCodec {
+    /// Create a new server codec
+    pub fn new() -> Self {
+        Self {
+            buffer: BytesMut::with_capacity(4096),
+        }
+    }
+
+    /// Feed bytes into the internal buffer
+    pub fn feed(&mut self, data: &[u8]) {
+        self.buffer.extend_from_slice(data);
+    }
+
+    /// Get current buffer length
+    pub fn buffer_len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Clear the buffer
+    pub fn clear(&mut self) {
+        self.buffer.clear();
+    }
+
+    /// Attempt to decode a complete RTSP request
+    ///
+    /// Returns:
+    /// - `Ok(Some(request))` if a complete request was parsed
+    /// - `Ok(None)` if more data is needed
+    /// - `Err(e)` if parsing failed
+    pub fn decode(&mut self) -> Result<Option<RtspRequest>, ParseError> {
+        // Find header/body separator
+        let header_end = match self.find_header_end() {
+            Some(pos) => pos,
+            None => {
+                // Check for header overflow
+                if self.buffer.len() > MAX_HEADER_SIZE {
+                    return Err(ParseError::InvalidHeader("Headers too large".into()));
+                }
+                return Ok(None);  // Need more data
+            }
+        };
+
+        // Parse headers (without consuming buffer yet)
+        let header_bytes = &self.buffer[..header_end];
+        let header_str = str::from_utf8(header_bytes)
+            .map_err(|_| ParseError::InvalidUtf8)?;
+
+        let (method, uri, headers) = self.parse_headers(header_str)?;
+
+        // Determine body length
+        let content_length = headers
+            .get("Content-Length")
+            .or_else(|| headers.get("content-length"))
+            .map(|s| s.parse::<usize>())
+            .transpose()
+            .map_err(|_| ParseError::InvalidContentLength("Not a number".into()))?
+            .unwrap_or(0);
+
+        if content_length > MAX_BODY_SIZE {
+            return Err(ParseError::BodyTooLarge {
+                size: content_length,
+                max: MAX_BODY_SIZE,
+            });
+        }
+
+        // Total message size: headers + \r\n\r\n + body
+        let total_size = header_end + 4 + content_length;
+
+        if self.buffer.len() < total_size {
+            return Ok(None);  // Need more data for body
+        }
+
+        // Now consume the buffer
+        let _ = self.buffer.split_to(header_end + 4);  // Headers + separator
+        let body = if content_length > 0 {
+            self.buffer.split_to(content_length).to_vec()
+        } else {
+            Vec::new()
+        };
+
+        Ok(Some(RtspRequest {
+            method,
+            uri,
+            headers,
+            body,
+        }))
+    }
+
+    /// Find the position of header/body separator (\r\n\r\n)
+    fn find_header_end(&self) -> Option<usize> {
+        let needle = b"\r\n\r\n";
+        self.buffer
+            .windows(needle.len())
+            .position(|window| window == needle)
+    }
+
+    /// Parse request line and headers
+    fn parse_headers(&self, header_str: &str) -> Result<(Method, String, Headers), ParseError> {
+        let mut lines = header_str.lines();
+
+        // Parse request line: "METHOD uri RTSP/1.0"
+        let request_line = lines.next()
+            .ok_or_else(|| ParseError::InvalidRequestLine("Empty request".into()))?;
+
+        let parts: Vec<&str> = request_line.split_whitespace().collect();
+        if parts.len() < 3 {
+            return Err(ParseError::InvalidRequestLine(request_line.to_string()));
+        }
+
+        let method = Method::from_str(parts[0])
+            .ok_or_else(|| ParseError::InvalidMethod(parts[0].to_string()))?;
+        let uri = parts[1].to_string();
+
+        // Validate protocol version
+        if !parts[2].starts_with("RTSP/") {
+            return Err(ParseError::InvalidRequestLine(
+                format!("Invalid protocol: {}", parts[2])
+            ));
+        }
+
+        // Parse headers
+        let mut headers = Headers::new();
+        for line in lines {
+            if line.is_empty() {
+                break;
+            }
+
+            if let Some(pos) = line.find(':') {
+                let name = line[..pos].trim().to_string();
+                let value = line[pos + 1..].trim().to_string();
+                headers.insert(name, value);
+            } else {
+                return Err(ParseError::InvalidHeader(line.to_string()));
+            }
+        }
+
+        Ok((method, uri, headers))
+    }
+}
+
+impl Default for RtspServerCodec {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+```
+
+---
+
+### 36.2 Response Builder
+
+- [ ] **36.2.1** Implement RTSP response encoder
+
+**File:** `src/protocol/rtsp/server_codec.rs` (continued)
+
+```rust
+/// Builder for RTSP responses
+///
+/// Provides a fluent interface for constructing RTSP responses with
+/// proper formatting for the wire protocol.
+#[derive(Debug, Clone)]
+pub struct ResponseBuilder {
+    status: StatusCode,
+    headers: Headers,
+    body: Option<Vec<u8>>,
+}
+
+impl ResponseBuilder {
+    /// Create a new response builder with the given status
+    pub fn new(status: StatusCode) -> Self {
+        Self {
+            status,
+            headers: Headers::new(),
+            body: None,
+        }
+    }
+
+    /// Create an OK (200) response
+    pub fn ok() -> Self {
+        Self::new(StatusCode::OK)
+    }
+
+    /// Create an error response
+    pub fn error(status: StatusCode) -> Self {
+        Self::new(status)
+    }
+
+    /// Set the CSeq header (required - should match request)
+    pub fn cseq(mut self, cseq: u32) -> Self {
+        self.headers.insert("CSeq".to_string(), cseq.to_string());
+        self
+    }
+
+    /// Set the Session header
+    pub fn session(mut self, session_id: &str) -> Self {
+        self.headers.insert("Session".to_string(), session_id.to_string());
+        self
+    }
+
+    /// Add a custom header
+    pub fn header(mut self, name: &str, value: &str) -> Self {
+        self.headers.insert(name.to_string(), value.to_string());
+        self
+    }
+
+    /// Set a text body (will set Content-Type to text/parameters)
+    pub fn text_body(mut self, body: &str) -> Self {
+        self.body = Some(body.as_bytes().to_vec());
+        self.headers.insert(
+            "Content-Type".to_string(),
+            "text/parameters".to_string()
+        );
+        self
+    }
+
+    /// Set a binary body
+    pub fn binary_body(mut self, body: Vec<u8>, content_type: &str) -> Self {
+        self.body = Some(body);
+        self.headers.insert("Content-Type".to_string(), content_type.to_string());
+        self
+    }
+
+    /// Set SDP body (for ANNOUNCE responses if needed)
+    pub fn sdp_body(mut self, sdp: &str) -> Self {
+        self.body = Some(sdp.as_bytes().to_vec());
+        self.headers.insert(
+            "Content-Type".to_string(),
+            "application/sdp".to_string()
+        );
+        self
+    }
+
+    /// Set the Audio-Latency header (used in RECORD response)
+    pub fn audio_latency(mut self, samples: u32) -> Self {
+        self.headers.insert("Audio-Latency".to_string(), samples.to_string());
+        self
+    }
+
+    /// Build into an RtspResponse
+    pub fn build(mut self) -> RtspResponse {
+        // Add Content-Length if body present
+        if let Some(ref body) = self.body {
+            self.headers.insert(
+                "Content-Length".to_string(),
+                body.len().to_string()
+            );
+        }
+
+        RtspResponse {
+            status: self.status,
+            headers: self.headers,
+            body: self.body.unwrap_or_default(),
+        }
+    }
+
+    /// Encode directly to bytes
+    pub fn encode(self) -> Vec<u8> {
+        let response = self.build();
+        encode_response(&response)
+    }
+}
+
+/// Encode an RTSP response to bytes
+pub fn encode_response(response: &RtspResponse) -> Vec<u8> {
+    let mut output = Vec::with_capacity(256 + response.body.len());
+
+    // Status line
+    let reason = status_reason(response.status);
+    output.extend_from_slice(
+        format!("RTSP/1.0 {} {}\r\n", response.status.0, reason).as_bytes()
+    );
+
+    // Headers
+    for (name, value) in response.headers.iter() {
+        output.extend_from_slice(format!("{}: {}\r\n", name, value).as_bytes());
+    }
+
+    // Separator
+    output.extend_from_slice(b"\r\n");
+
+    // Body
+    if !response.body.is_empty() {
+        output.extend_from_slice(&response.body);
+    }
+
+    output
+}
+
+/// Get reason phrase for status code
+fn status_reason(status: StatusCode) -> &'static str {
+    match status.0 {
+        200 => "OK",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        403 => "Forbidden",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        406 => "Not Acceptable",
+        451 => "Parameter Not Understood",
+        453 => "Not Enough Bandwidth",
+        454 => "Session Not Found",
+        455 => "Method Not Valid in This State",
+        457 => "Invalid Range",
+        459 => "Aggregate Operation Not Allowed",
+        460 => "Only Aggregate Operation Allowed",
+        461 => "Unsupported Transport",
+        500 => "Internal Server Error",
+        501 => "Not Implemented",
+        503 => "Service Unavailable",
+        _ => "Unknown",
+    }
+}
+
+/// Common status codes for RAOP
+impl StatusCode {
+    pub const OK: StatusCode = StatusCode(200);
+    pub const BAD_REQUEST: StatusCode = StatusCode(400);
+    pub const UNAUTHORIZED: StatusCode = StatusCode(401);
+    pub const FORBIDDEN: StatusCode = StatusCode(403);
+    pub const NOT_FOUND: StatusCode = StatusCode(404);
+    pub const METHOD_NOT_ALLOWED: StatusCode = StatusCode(405);
+    pub const NOT_ACCEPTABLE: StatusCode = StatusCode(406);
+    pub const SESSION_NOT_FOUND: StatusCode = StatusCode(454);
+    pub const METHOD_NOT_VALID: StatusCode = StatusCode(455);
+    pub const INTERNAL_ERROR: StatusCode = StatusCode(500);
+    pub const NOT_IMPLEMENTED: StatusCode = StatusCode(501);
+    pub const SERVICE_UNAVAILABLE: StatusCode = StatusCode(503);
+}
+```
+
+---
+
+### 36.3 Transport Header Parser
+
+- [ ] **36.3.1** Implement Transport header parsing for SETUP requests
+
+**File:** `src/protocol/rtsp/transport.rs`
+
+```rust
+//! RTSP Transport header parsing
+//!
+//! The Transport header in SETUP requests specifies how audio will be delivered.
+//! Format: `RTP/AVP/UDP;unicast;mode=record;control_port=6001;timing_port=6002`
+
+use std::collections::HashMap;
+
+/// Parsed Transport header
+#[derive(Debug, Clone, PartialEq)]
+pub struct TransportHeader {
+    /// Protocol (always "RTP/AVP" for RAOP)
+    pub protocol: String,
+    /// Lower protocol (UDP or TCP)
+    pub lower_transport: LowerTransport,
+    /// Unicast or multicast
+    pub cast: CastMode,
+    /// Mode (usually "record" for RAOP)
+    pub mode: Option<String>,
+    /// Client's control port
+    pub control_port: Option<u16>,
+    /// Client's timing port
+    pub timing_port: Option<u16>,
+    /// Interleaved channel (for TCP transport)
+    pub interleaved: Option<(u8, u8)>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LowerTransport {
+    Udp,
+    Tcp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CastMode {
+    Unicast,
+    Multicast,
+}
+
+impl TransportHeader {
+    /// Parse a Transport header value
+    pub fn parse(value: &str) -> Result<Self, TransportParseError> {
+        let mut parts = value.split(';');
+
+        // First part: protocol specification
+        let proto_spec = parts.next()
+            .ok_or(TransportParseError::MissingProtocol)?;
+
+        let (protocol, lower_transport) = Self::parse_protocol(proto_spec)?;
+
+        let mut transport = TransportHeader {
+            protocol,
+            lower_transport,
+            cast: CastMode::Unicast,  // Default
+            mode: None,
+            control_port: None,
+            timing_port: None,
+            interleaved: None,
+        };
+
+        // Parse remaining parameters
+        for part in parts {
+            let part = part.trim();
+
+            if part == "unicast" {
+                transport.cast = CastMode::Unicast;
+            } else if part == "multicast" {
+                transport.cast = CastMode::Multicast;
+            } else if let Some(value) = part.strip_prefix("mode=") {
+                transport.mode = Some(value.to_string());
+            } else if let Some(value) = part.strip_prefix("control_port=") {
+                transport.control_port = Some(
+                    value.parse().map_err(|_| TransportParseError::InvalidPort)?
+                );
+            } else if let Some(value) = part.strip_prefix("timing_port=") {
+                transport.timing_port = Some(
+                    value.parse().map_err(|_| TransportParseError::InvalidPort)?
+                );
+            } else if let Some(value) = part.strip_prefix("interleaved=") {
+                transport.interleaved = Some(Self::parse_interleaved(value)?);
+            }
+            // Ignore unknown parameters
+        }
+
+        Ok(transport)
+    }
+
+    fn parse_protocol(spec: &str) -> Result<(String, LowerTransport), TransportParseError> {
+        let parts: Vec<&str> = spec.split('/').collect();
+
+        match parts.as_slice() {
+            ["RTP", "AVP"] => Ok(("RTP/AVP".to_string(), LowerTransport::Udp)),
+            ["RTP", "AVP", "UDP"] => Ok(("RTP/AVP".to_string(), LowerTransport::Udp)),
+            ["RTP", "AVP", "TCP"] => Ok(("RTP/AVP".to_string(), LowerTransport::Tcp)),
+            _ => Err(TransportParseError::UnsupportedProtocol(spec.to_string())),
+        }
+    }
+
+    fn parse_interleaved(value: &str) -> Result<(u8, u8), TransportParseError> {
+        let parts: Vec<&str> = value.split('-').collect();
+        match parts.as_slice() {
+            [start, end] => {
+                let start: u8 = start.parse().map_err(|_| TransportParseError::InvalidPort)?;
+                let end: u8 = end.parse().map_err(|_| TransportParseError::InvalidPort)?;
+                Ok((start, end))
+            }
+            _ => Err(TransportParseError::InvalidInterleaved),
+        }
+    }
+
+    /// Generate Transport header for response
+    pub fn to_response_header(
+        &self,
+        server_port: u16,
+        control_port: u16,
+        timing_port: u16,
+    ) -> String {
+        let mut parts = vec![
+            format!("{}/{}", self.protocol,
+                match self.lower_transport {
+                    LowerTransport::Udp => "UDP",
+                    LowerTransport::Tcp => "TCP",
+                }
+            ),
+            self.cast.to_string(),
+        ];
+
+        if let Some(ref mode) = self.mode {
+            parts.push(format!("mode={}", mode));
+        }
+
+        parts.push(format!("server_port={}", server_port));
+        parts.push(format!("control_port={}", control_port));
+        parts.push(format!("timing_port={}", timing_port));
+
+        parts.join(";")
+    }
+}
+
+impl std::fmt::Display for CastMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CastMode::Unicast => write!(f, "unicast"),
+            CastMode::Multicast => write!(f, "multicast"),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TransportParseError {
+    #[error("Missing protocol specification")]
+    MissingProtocol,
+
+    #[error("Unsupported protocol: {0}")]
+    UnsupportedProtocol(String),
+
+    #[error("Invalid port number")]
+    InvalidPort,
+
+    #[error("Invalid interleaved channel specification")]
+    InvalidInterleaved,
+}
+```
+
+---
+
+### 36.4 Request Handlers
+
+- [ ] **36.4.1** Implement RTSP method handler infrastructure
+
+**File:** `src/receiver/rtsp_handler.rs`
+
+```rust
+//! RTSP request handlers for the receiver
+//!
+//! This module provides the logic for handling each RTSP method.
+//! Handlers are pure functions that take a request and session state,
+//! returning a response. No I/O is performed.
+
+use crate::protocol::rtsp::{
+    RtspRequest, Method, StatusCode,
+    server_codec::ResponseBuilder,
+    transport::TransportHeader,
+};
+use crate::receiver::session::{ReceiverSession, SessionState};
+
+/// Result of handling an RTSP request
+#[derive(Debug)]
+pub struct HandleResult {
+    /// Response to send back
+    pub response: Vec<u8>,
+    /// New session state (if changed)
+    pub new_state: Option<SessionState>,
+    /// Allocated ports (for SETUP)
+    pub allocated_ports: Option<AllocatedPorts>,
+    /// Should start streaming (for RECORD)
+    pub start_streaming: bool,
+    /// Should stop streaming (for TEARDOWN)
+    pub stop_streaming: bool,
+}
+
+/// Ports allocated during SETUP
+#[derive(Debug, Clone, Copy)]
+pub struct AllocatedPorts {
+    pub audio_port: u16,
+    pub control_port: u16,
+    pub timing_port: u16,
+}
+
+/// Handle an incoming RTSP request
+pub fn handle_request(
+    request: &RtspRequest,
+    session: &ReceiverSession,
+) -> HandleResult {
+    let cseq = request.headers.cseq().unwrap_or(0);
+
+    match request.method {
+        Method::Options => handle_options(cseq),
+        Method::Announce => handle_announce(request, cseq, session),
+        Method::Setup => handle_setup(request, cseq, session),
+        Method::Record => handle_record(request, cseq, session),
+        Method::Pause => handle_pause(cseq, session),
+        Method::Flush => handle_flush(request, cseq),
+        Method::Teardown => handle_teardown(cseq, session),
+        Method::GetParameter => handle_get_parameter(request, cseq, session),
+        Method::SetParameter => handle_set_parameter(request, cseq, session),
+        Method::Post => handle_post(request, cseq, session),
+        _ => handle_unknown(cseq),
+    }
+}
+
+/// Handle OPTIONS request
+fn handle_options(cseq: u32) -> HandleResult {
+    let methods = [
+        "ANNOUNCE", "SETUP", "RECORD", "PAUSE", "FLUSH",
+        "TEARDOWN", "OPTIONS", "GET_PARAMETER", "SET_PARAMETER", "POST"
+    ].join(", ");
+
+    let response = ResponseBuilder::ok()
+        .cseq(cseq)
+        .header("Public", &methods)
+        .encode();
+
+    HandleResult {
+        response,
+        new_state: None,
+        allocated_ports: None,
+        start_streaming: false,
+        stop_streaming: false,
+    }
+}
+
+/// Handle ANNOUNCE request (SDP body with stream parameters)
+fn handle_announce(
+    request: &RtspRequest,
+    cseq: u32,
+    session: &ReceiverSession,
+) -> HandleResult {
+    // Verify state
+    if session.state() != SessionState::Connected {
+        return error_result(StatusCode::METHOD_NOT_VALID, cseq);
+    }
+
+    // SDP parsing is handled by Section 38
+    // Here we just acknowledge receipt
+
+    let response = ResponseBuilder::ok()
+        .cseq(cseq)
+        .encode();
+
+    HandleResult {
+        response,
+        new_state: Some(SessionState::Announced),
+        allocated_ports: None,
+        start_streaming: false,
+        stop_streaming: false,
+    }
+}
+
+/// Handle SETUP request
+fn handle_setup(
+    request: &RtspRequest,
+    cseq: u32,
+    session: &ReceiverSession,
+) -> HandleResult {
+    // Parse Transport header
+    let transport_str = match request.headers.get("Transport") {
+        Some(t) => t,
+        None => return error_result(StatusCode::BAD_REQUEST, cseq),
+    };
+
+    let client_transport = match TransportHeader::parse(transport_str) {
+        Ok(t) => t,
+        Err(_) => return error_result(StatusCode::BAD_REQUEST, cseq),
+    };
+
+    // Ports will be allocated by the session manager
+    // Here we return placeholder that will be filled in by caller
+    let ports = AllocatedPorts {
+        audio_port: 0,  // Placeholder
+        control_port: 0,
+        timing_port: 0,
+    };
+
+    // Generate session ID
+    let session_id = generate_session_id();
+
+    // Build response Transport header
+    let response_transport = client_transport.to_response_header(
+        ports.audio_port,
+        ports.control_port,
+        ports.timing_port,
+    );
+
+    let response = ResponseBuilder::ok()
+        .cseq(cseq)
+        .session(&session_id)
+        .header("Transport", &response_transport)
+        .encode();
+
+    HandleResult {
+        response,
+        new_state: Some(SessionState::Setup),
+        allocated_ports: Some(ports),
+        start_streaming: false,
+        stop_streaming: false,
+    }
+}
+
+/// Handle RECORD request (start streaming)
+fn handle_record(
+    request: &RtspRequest,
+    cseq: u32,
+    session: &ReceiverSession,
+) -> HandleResult {
+    if session.state() != SessionState::Setup {
+        return error_result(StatusCode::METHOD_NOT_VALID, cseq);
+    }
+
+    // Parse RTP-Info header for initial sequence/timestamp
+    // Format: seq=<seq>;rtptime=<timestamp>
+    let _rtp_info = request.headers.get("RTP-Info");
+
+    // Report our audio latency (in samples at 44.1kHz)
+    // 2 seconds = 88200 samples
+    let latency_samples: u32 = 88200;
+
+    let response = ResponseBuilder::ok()
+        .cseq(cseq)
+        .audio_latency(latency_samples)
+        .encode();
+
+    HandleResult {
+        response,
+        new_state: Some(SessionState::Streaming),
+        allocated_ports: None,
+        start_streaming: true,
+        stop_streaming: false,
+    }
+}
+
+/// Handle PAUSE request
+fn handle_pause(cseq: u32, session: &ReceiverSession) -> HandleResult {
+    let response = ResponseBuilder::ok()
+        .cseq(cseq)
+        .encode();
+
+    HandleResult {
+        response,
+        new_state: Some(SessionState::Paused),
+        allocated_ports: None,
+        start_streaming: false,
+        stop_streaming: false,  // Keep session alive, just pause output
+    }
+}
+
+/// Handle FLUSH request (clear buffer)
+fn handle_flush(request: &RtspRequest, cseq: u32) -> HandleResult {
+    // Parse RTP-Info for flush point
+    // Format: rtptime=<timestamp>
+    let _rtp_info = request.headers.get("RTP-Info");
+
+    let response = ResponseBuilder::ok()
+        .cseq(cseq)
+        .encode();
+
+    HandleResult {
+        response,
+        new_state: None,
+        allocated_ports: None,
+        start_streaming: false,
+        stop_streaming: false,
+    }
+}
+
+/// Handle TEARDOWN request
+fn handle_teardown(cseq: u32, session: &ReceiverSession) -> HandleResult {
+    let response = ResponseBuilder::ok()
+        .cseq(cseq)
+        .encode();
+
+    HandleResult {
+        response,
+        new_state: Some(SessionState::Teardown),
+        allocated_ports: None,
+        start_streaming: false,
+        stop_streaming: true,
+    }
+}
+
+/// Handle GET_PARAMETER (keep-alive, status queries)
+fn handle_get_parameter(
+    request: &RtspRequest,
+    cseq: u32,
+    session: &ReceiverSession,
+) -> HandleResult {
+    // Body may contain parameter names to query
+    // Empty body = keep-alive ping
+
+    let body_str = String::from_utf8_lossy(&request.body);
+
+    let response_body = if body_str.contains("volume") {
+        format!("volume: {:.6}\r\n", session.volume())
+    } else {
+        String::new()
+    };
+
+    let response = if response_body.is_empty() {
+        ResponseBuilder::ok().cseq(cseq).encode()
+    } else {
+        ResponseBuilder::ok()
+            .cseq(cseq)
+            .text_body(&response_body)
+            .encode()
+    };
+
+    HandleResult {
+        response,
+        new_state: None,
+        allocated_ports: None,
+        start_streaming: false,
+        stop_streaming: false,
+    }
+}
+
+/// Handle SET_PARAMETER (volume, metadata, etc.)
+fn handle_set_parameter(
+    request: &RtspRequest,
+    cseq: u32,
+    session: &ReceiverSession,
+) -> HandleResult {
+    // Content-Type determines what's being set
+    let content_type = request.headers.get("Content-Type")
+        .map(|s| s.as_str())
+        .unwrap_or("");
+
+    // Delegate to appropriate handler based on content type
+    // Section 43 handles the detailed parsing
+
+    let response = ResponseBuilder::ok()
+        .cseq(cseq)
+        .encode();
+
+    HandleResult {
+        response,
+        new_state: None,
+        allocated_ports: None,
+        start_streaming: false,
+        stop_streaming: false,
+    }
+}
+
+/// Handle POST (pairing, auth)
+fn handle_post(
+    request: &RtspRequest,
+    cseq: u32,
+    session: &ReceiverSession,
+) -> HandleResult {
+    // POST is used for pairing endpoints like /pair-setup, /pair-verify
+    // For now, return not implemented
+
+    let response = ResponseBuilder::error(StatusCode::NOT_IMPLEMENTED)
+        .cseq(cseq)
+        .encode();
+
+    HandleResult {
+        response,
+        new_state: None,
+        allocated_ports: None,
+        start_streaming: false,
+        stop_streaming: false,
+    }
+}
+
+/// Handle unknown method
+fn handle_unknown(cseq: u32) -> HandleResult {
+    error_result(StatusCode::METHOD_NOT_ALLOWED, cseq)
+}
+
+/// Generate an error result
+fn error_result(status: StatusCode, cseq: u32) -> HandleResult {
+    let response = ResponseBuilder::error(status)
+        .cseq(cseq)
+        .encode();
+
+    HandleResult {
+        response,
+        new_state: None,
+        allocated_ports: None,
+        start_streaming: false,
+        stop_streaming: false,
+    }
+}
+
+/// Generate a random session ID
+fn generate_session_id() -> String {
+    use rand::Rng;
+    let id: u64 = rand::thread_rng().gen();
+    format!("{:016X}", id)
+}
+```
+
+---
+
+## Unit Tests
+
+### 36.5 Unit Tests
+
+- [ ] **36.5.1** Comprehensive codec tests
+
+**File:** `src/protocol/rtsp/server_codec.rs` (test module)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_options_request() {
+        let mut codec = RtspServerCodec::new();
+        codec.feed(b"OPTIONS * RTSP/1.0\r\nCSeq: 1\r\n\r\n");
+
+        let request = codec.decode().unwrap().unwrap();
+        assert_eq!(request.method, Method::Options);
+        assert_eq!(request.uri, "*");
+        assert_eq!(request.headers.cseq(), Some(1));
+    }
+
+    #[test]
+    fn test_parse_announce_with_sdp() {
+        let sdp = "v=0\r\no=- 0 0 IN IP4 192.168.1.100\r\ns=AirTunes\r\n";
+        let request_str = format!(
+            "ANNOUNCE rtsp://192.168.1.1/1234 RTSP/1.0\r\n\
+             CSeq: 2\r\n\
+             Content-Type: application/sdp\r\n\
+             Content-Length: {}\r\n\
+             \r\n\
+             {}",
+            sdp.len(),
+            sdp
+        );
+
+        let mut codec = RtspServerCodec::new();
+        codec.feed(request_str.as_bytes());
+
+        let request = codec.decode().unwrap().unwrap();
+        assert_eq!(request.method, Method::Announce);
+        assert_eq!(request.headers.get("Content-Type"), Some(&"application/sdp".to_string()));
+        assert_eq!(String::from_utf8_lossy(&request.body), sdp);
+    }
+
+    #[test]
+    fn test_parse_setup_request() {
+        let request_str =
+            "SETUP rtsp://192.168.1.1/1234 RTSP/1.0\r\n\
+             CSeq: 3\r\n\
+             Transport: RTP/AVP/UDP;unicast;mode=record;control_port=6001;timing_port=6002\r\n\
+             \r\n";
+
+        let mut codec = RtspServerCodec::new();
+        codec.feed(request_str.as_bytes());
+
+        let request = codec.decode().unwrap().unwrap();
+        assert_eq!(request.method, Method::Setup);
+
+        let transport = TransportHeader::parse(
+            request.headers.get("Transport").unwrap()
+        ).unwrap();
+
+        assert_eq!(transport.control_port, Some(6001));
+        assert_eq!(transport.timing_port, Some(6002));
+    }
+
+    #[test]
+    fn test_parse_incomplete_request() {
+        let mut codec = RtspServerCodec::new();
+        codec.feed(b"OPTIONS * RTSP/1.0\r\n");
+
+        // Should return None (incomplete)
+        assert!(codec.decode().unwrap().is_none());
+
+        // Add rest of headers
+        codec.feed(b"CSeq: 1\r\n\r\n");
+
+        // Now should parse
+        let request = codec.decode().unwrap().unwrap();
+        assert_eq!(request.method, Method::Options);
+    }
+
+    #[test]
+    fn test_parse_incomplete_body() {
+        let mut codec = RtspServerCodec::new();
+        codec.feed(
+            b"SET_PARAMETER rtsp://192.168.1.1/1234 RTSP/1.0\r\n\
+              CSeq: 5\r\n\
+              Content-Length: 20\r\n\
+              \r\n\
+              volume: -1"  // Only 10 bytes, need 20
+        );
+
+        // Should return None (incomplete body)
+        assert!(codec.decode().unwrap().is_none());
+
+        // Add rest of body
+        codec.feed(b"5.000000\r\n");
+
+        let request = codec.decode().unwrap().unwrap();
+        assert_eq!(String::from_utf8_lossy(&request.body), "volume: -15.000000\r\n");
+    }
+
+    #[test]
+    fn test_parse_multiple_requests() {
+        let mut codec = RtspServerCodec::new();
+        codec.feed(
+            b"OPTIONS * RTSP/1.0\r\nCSeq: 1\r\n\r\n\
+              OPTIONS * RTSP/1.0\r\nCSeq: 2\r\n\r\n"
+        );
+
+        let req1 = codec.decode().unwrap().unwrap();
+        assert_eq!(req1.headers.cseq(), Some(1));
+
+        let req2 = codec.decode().unwrap().unwrap();
+        assert_eq!(req2.headers.cseq(), Some(2));
+
+        // No more requests
+        assert!(codec.decode().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_response_builder() {
+        let response = ResponseBuilder::ok()
+            .cseq(5)
+            .session("ABC123")
+            .header("Custom-Header", "value")
+            .encode();
+
+        let response_str = String::from_utf8(response).unwrap();
+        assert!(response_str.starts_with("RTSP/1.0 200 OK\r\n"));
+        assert!(response_str.contains("CSeq: 5\r\n"));
+        assert!(response_str.contains("Session: ABC123\r\n"));
+        assert!(response_str.contains("Custom-Header: value\r\n"));
+        assert!(response_str.ends_with("\r\n\r\n"));
+    }
+
+    #[test]
+    fn test_response_with_body() {
+        let body = "volume: -15.000000\r\n";
+        let response = ResponseBuilder::ok()
+            .cseq(10)
+            .text_body(body)
+            .encode();
+
+        let response_str = String::from_utf8(response).unwrap();
+        assert!(response_str.contains(&format!("Content-Length: {}\r\n", body.len())));
+        assert!(response_str.contains("Content-Type: text/parameters\r\n"));
+        assert!(response_str.ends_with(body));
+    }
+
+    #[test]
+    fn test_error_response() {
+        let response = ResponseBuilder::error(StatusCode::NOT_FOUND)
+            .cseq(99)
+            .encode();
+
+        let response_str = String::from_utf8(response).unwrap();
+        assert!(response_str.starts_with("RTSP/1.0 404 Not Found\r\n"));
+    }
+}
+
+#[cfg(test)]
+mod transport_tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_basic_transport() {
+        let transport = TransportHeader::parse(
+            "RTP/AVP/UDP;unicast;mode=record"
+        ).unwrap();
+
+        assert_eq!(transport.protocol, "RTP/AVP");
+        assert_eq!(transport.lower_transport, LowerTransport::Udp);
+        assert_eq!(transport.cast, CastMode::Unicast);
+        assert_eq!(transport.mode, Some("record".to_string()));
+    }
+
+    #[test]
+    fn test_parse_transport_with_ports() {
+        let transport = TransportHeader::parse(
+            "RTP/AVP/UDP;unicast;mode=record;control_port=6001;timing_port=6002"
+        ).unwrap();
+
+        assert_eq!(transport.control_port, Some(6001));
+        assert_eq!(transport.timing_port, Some(6002));
+    }
+
+    #[test]
+    fn test_parse_tcp_transport() {
+        let transport = TransportHeader::parse(
+            "RTP/AVP/TCP;unicast;interleaved=0-1"
+        ).unwrap();
+
+        assert_eq!(transport.lower_transport, LowerTransport::Tcp);
+        assert_eq!(transport.interleaved, Some((0, 1)));
+    }
+
+    #[test]
+    fn test_response_header_generation() {
+        let transport = TransportHeader::parse(
+            "RTP/AVP/UDP;unicast;mode=record"
+        ).unwrap();
+
+        let response = transport.to_response_header(6000, 6001, 6002);
+        assert!(response.contains("server_port=6000"));
+        assert!(response.contains("control_port=6001"));
+        assert!(response.contains("timing_port=6002"));
+    }
+}
+```
+
+---
+
+## Integration Tests
+
+### 36.6 Integration Tests
+
+- [ ] **36.6.1** Full RTSP conversation tests
+
+**File:** `tests/protocol/rtsp_server_tests.rs`
+
+```rust
+//! Integration tests for RTSP server codec
+//!
+//! These tests simulate complete RTSP conversations between
+//! a mock sender and our server codec.
+
+use airplay2::protocol::rtsp::{RtspServerCodec, Method};
+use airplay2::receiver::rtsp_handler::{handle_request, HandleResult};
+use airplay2::receiver::session::{ReceiverSession, SessionState};
+
+/// Simulate a complete RAOP session negotiation
+#[test]
+fn test_complete_session_negotiation() {
+    let mut codec = RtspServerCodec::new();
+    let mut session = ReceiverSession::new();
+
+    // Step 1: OPTIONS
+    codec.feed(b"OPTIONS * RTSP/1.0\r\nCSeq: 1\r\n\r\n");
+    let request = codec.decode().unwrap().unwrap();
+    let result = handle_request(&request, &session);
+
+    let response_str = String::from_utf8(result.response).unwrap();
+    assert!(response_str.contains("200 OK"));
+    assert!(response_str.contains("Public:"));
+    assert!(response_str.contains("ANNOUNCE"));
+
+    // Step 2: ANNOUNCE with SDP
+    let sdp = "v=0\r\n\
+               o=iTunes 1234 0 IN IP4 192.168.1.100\r\n\
+               s=iTunes\r\n\
+               c=IN IP4 192.168.1.1\r\n\
+               t=0 0\r\n\
+               m=audio 0 RTP/AVP 96\r\n\
+               a=rtpmap:96 AppleLossless\r\n\
+               a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100\r\n";
+
+    let announce = format!(
+        "ANNOUNCE rtsp://192.168.1.1/1234 RTSP/1.0\r\n\
+         CSeq: 2\r\n\
+         Content-Type: application/sdp\r\n\
+         Content-Length: {}\r\n\
+         \r\n{}",
+        sdp.len(),
+        sdp
+    );
+
+    codec.clear();
+    codec.feed(announce.as_bytes());
+    session.set_state(SessionState::Connected);
+
+    let request = codec.decode().unwrap().unwrap();
+    let result = handle_request(&request, &session);
+
+    assert!(String::from_utf8(result.response).unwrap().contains("200 OK"));
+    assert_eq!(result.new_state, Some(SessionState::Announced));
+
+    // Step 3: SETUP
+    session.set_state(SessionState::Announced);
+    codec.clear();
+    codec.feed(
+        b"SETUP rtsp://192.168.1.1/1234 RTSP/1.0\r\n\
+          CSeq: 3\r\n\
+          Transport: RTP/AVP/UDP;unicast;mode=record;control_port=6001;timing_port=6002\r\n\
+          \r\n"
+    );
+
+    let request = codec.decode().unwrap().unwrap();
+    let result = handle_request(&request, &session);
+
+    let response_str = String::from_utf8(result.response).unwrap();
+    assert!(response_str.contains("200 OK"));
+    assert!(response_str.contains("Session:"));
+    assert!(response_str.contains("Transport:"));
+    assert_eq!(result.new_state, Some(SessionState::Setup));
+    assert!(result.allocated_ports.is_some());
+
+    // Step 4: RECORD
+    session.set_state(SessionState::Setup);
+    codec.clear();
+    codec.feed(
+        b"RECORD rtsp://192.168.1.1/1234 RTSP/1.0\r\n\
+          CSeq: 4\r\n\
+          Range: npt=0-\r\n\
+          RTP-Info: seq=1;rtptime=0\r\n\
+          \r\n"
+    );
+
+    let request = codec.decode().unwrap().unwrap();
+    let result = handle_request(&request, &session);
+
+    let response_str = String::from_utf8(result.response).unwrap();
+    assert!(response_str.contains("200 OK"));
+    assert!(response_str.contains("Audio-Latency:"));
+    assert!(result.start_streaming);
+
+    // Step 5: TEARDOWN
+    session.set_state(SessionState::Streaming);
+    codec.clear();
+    codec.feed(
+        b"TEARDOWN rtsp://192.168.1.1/1234 RTSP/1.0\r\n\
+          CSeq: 5\r\n\
+          \r\n"
+    );
+
+    let request = codec.decode().unwrap().unwrap();
+    let result = handle_request(&request, &session);
+
+    assert!(String::from_utf8(result.response).unwrap().contains("200 OK"));
+    assert!(result.stop_streaming);
+}
+
+/// Test volume control via SET_PARAMETER
+#[test]
+fn test_volume_control() {
+    let mut codec = RtspServerCodec::new();
+    let session = ReceiverSession::new();
+
+    let volume_cmd = "SET_PARAMETER rtsp://192.168.1.1/1234 RTSP/1.0\r\n\
+                      CSeq: 10\r\n\
+                      Content-Type: text/parameters\r\n\
+                      Content-Length: 20\r\n\
+                      \r\n\
+                      volume: -15.000000\r\n";
+
+    codec.feed(volume_cmd.as_bytes());
+    let request = codec.decode().unwrap().unwrap();
+
+    assert_eq!(request.method, Method::SetParameter);
+    let result = handle_request(&request, &session);
+
+    assert!(String::from_utf8(result.response).unwrap().contains("200 OK"));
+}
+
+/// Test keep-alive via empty GET_PARAMETER
+#[test]
+fn test_keepalive() {
+    let mut codec = RtspServerCodec::new();
+    let session = ReceiverSession::new();
+
+    codec.feed(
+        b"GET_PARAMETER rtsp://192.168.1.1/1234 RTSP/1.0\r\n\
+          CSeq: 20\r\n\
+          \r\n"
+    );
+
+    let request = codec.decode().unwrap().unwrap();
+    let result = handle_request(&request, &session);
+
+    assert!(String::from_utf8(result.response).unwrap().contains("200 OK"));
+}
+
+/// Test FLUSH handling
+#[test]
+fn test_flush() {
+    let mut codec = RtspServerCodec::new();
+    let session = ReceiverSession::new();
+
+    codec.feed(
+        b"FLUSH rtsp://192.168.1.1/1234 RTSP/1.0\r\n\
+          CSeq: 30\r\n\
+          RTP-Info: rtptime=12345\r\n\
+          \r\n"
+    );
+
+    let request = codec.decode().unwrap().unwrap();
+    let result = handle_request(&request, &session);
+
+    assert!(String::from_utf8(result.response).unwrap().contains("200 OK"));
+}
+
+/// Test error handling for invalid state transitions
+#[test]
+fn test_invalid_state_transition() {
+    let mut codec = RtspServerCodec::new();
+    let session = ReceiverSession::new();
+    // Session is in initial state, not Setup
+
+    codec.feed(
+        b"RECORD rtsp://192.168.1.1/1234 RTSP/1.0\r\n\
+          CSeq: 1\r\n\
+          \r\n"
+    );
+
+    let request = codec.decode().unwrap().unwrap();
+    let result = handle_request(&request, &session);
+
+    // Should get 455 Method Not Valid in This State
+    assert!(String::from_utf8(result.response).unwrap().contains("455"));
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] RTSP requests parsed correctly (all methods)
+- [ ] Incomplete requests return `Ok(None)` not error
+- [ ] Binary and text bodies handled correctly
+- [ ] Content-Length validated and enforced
+- [ ] Response builder generates valid RTSP responses
+- [ ] Transport header parsed and generated correctly
+- [ ] CSeq properly echoed in responses
+- [ ] Session ID generated and tracked
+- [ ] State machine enforces valid transitions
+- [ ] All RAOP-required methods implemented
+- [ ] All unit tests pass
+- [ ] Integration tests pass
+
+---
+
+## Notes
+
+- **Reuse**: The client's `RtspRequest` and `RtspResponse` types are reused; only parsing direction differs
+- **Sans-IO**: No async/await or networking in this module; that's handled by the connection layer
+- **Error codes**: RTSP uses status codes similar to HTTP; we support the RAOP-relevant subset
+- **Body handling**: Most RAOP bodies are small (SDP, parameters), but metadata can be larger
+- **Future**: POST handling for pairing will be expanded when implementing password protection
+
+---
+
+## References
+
+- [RFC 2326](https://tools.ietf.org/html/rfc2326) - Real Time Streaming Protocol (RTSP)
+- [Unofficial AirPlay Spec - RTSP](https://nto.github.io/AirPlay.html#audio-rtsp)
+- [shairport-sync RTSP handling](https://github.com/mikebrady/shairport-sync/blob/master/rtsp.c)

--- a/docs/37-receiver-session-management.md
+++ b/docs/37-receiver-session-management.md
@@ -1,0 +1,1019 @@
+# Section 37: Receiver Session Management
+
+## Dependencies
+- **Section 36**: RTSP Server (Sans-IO) (RTSP handling)
+- **Section 34**: Receiver Overview (architecture)
+- **Section 02**: Core Types, Errors & Config
+
+## Overview
+
+This section implements session management for the AirPlay 1 receiver. A "session" represents an active connection from an AirPlay sender, encompassing:
+
+- TCP connection for RTSP control
+- UDP sockets for audio, control, and timing
+- Session state machine
+- Stream parameters (codec, encryption keys)
+- Playback state (volume, metadata)
+
+The receiver enforces **single-session semantics**: only one sender can stream at a time. New connections either queue, reject, or preempt the existing session based on configuration.
+
+## Objectives
+
+- Implement session state machine with all RAOP states
+- Manage UDP socket lifecycle (allocation, binding, cleanup)
+- Store stream parameters from ANNOUNCE/SETUP
+- Track session timeout and keep-alive
+- Support session preemption policies
+- Provide async session manager for connection handling
+
+---
+
+## Tasks
+
+### 37.1 Session State Machine
+
+- [ ] **37.1.1** Define session states and transitions
+
+**File:** `src/receiver/session.rs`
+
+```rust
+//! Receiver session management
+//!
+//! Manages the lifecycle of an AirPlay streaming session from
+//! connection through teardown.
+
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+use tokio::sync::watch;
+
+/// Session states following RAOP protocol flow
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionState {
+    /// Initial state after TCP connection
+    Connected,
+    /// ANNOUNCE received, stream parameters known
+    Announced,
+    /// SETUP complete, UDP ports allocated
+    Setup,
+    /// RECORD received, actively streaming
+    Streaming,
+    /// PAUSE received, stream paused but session alive
+    Paused,
+    /// TEARDOWN received or connection lost
+    Teardown,
+    /// Session ended, ready for cleanup
+    Closed,
+}
+
+impl SessionState {
+    /// Check if transition to new state is valid
+    pub fn can_transition_to(&self, new_state: SessionState) -> bool {
+        use SessionState::*;
+
+        match (self, new_state) {
+            // Normal forward flow
+            (Connected, Announced) => true,
+            (Announced, Setup) => true,
+            (Setup, Streaming) => true,
+            (Streaming, Paused) => true,
+            (Paused, Streaming) => true,
+
+            // Teardown from any active state
+            (Connected | Announced | Setup | Streaming | Paused, Teardown) => true,
+            (Teardown, Closed) => true,
+
+            // Allow re-announce (some senders do this)
+            (Announced, Announced) => true,
+            (Setup, Announced) => true,
+
+            // Allow re-setup
+            (Setup, Setup) => true,
+
+            _ => false,
+        }
+    }
+
+    /// Is this an active streaming state?
+    pub fn is_active(&self) -> bool {
+        matches!(self, SessionState::Streaming | SessionState::Paused)
+    }
+
+    /// Is the session still valid (not closed)?
+    pub fn is_valid(&self) -> bool {
+        !matches!(self, SessionState::Teardown | SessionState::Closed)
+    }
+}
+
+/// Stream parameters parsed from ANNOUNCE SDP
+#[derive(Debug, Clone)]
+pub struct StreamParameters {
+    /// Audio codec
+    pub codec: AudioCodec,
+    /// Sample rate (typically 44100)
+    pub sample_rate: u32,
+    /// Bits per sample (typically 16)
+    pub bits_per_sample: u8,
+    /// Number of channels (typically 2)
+    pub channels: u8,
+    /// Samples per RTP packet (typically 352)
+    pub frames_per_packet: u32,
+    /// AES key (decrypted from RSA, if encryption used)
+    pub aes_key: Option<[u8; 16]>,
+    /// AES IV (if encryption used)
+    pub aes_iv: Option<[u8; 16]>,
+    /// Minimum latency requested by sender (in samples)
+    pub min_latency: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioCodec {
+    Pcm,      // L16
+    Alac,     // Apple Lossless
+    AacLc,    // AAC Low Complexity
+    AacEld,   // AAC Enhanced Low Delay
+}
+
+impl Default for StreamParameters {
+    fn default() -> Self {
+        Self {
+            codec: AudioCodec::Alac,
+            sample_rate: 44100,
+            bits_per_sample: 16,
+            channels: 2,
+            frames_per_packet: 352,
+            aes_key: None,
+            aes_iv: None,
+            min_latency: None,
+        }
+    }
+}
+
+/// UDP socket addresses for a session
+#[derive(Debug, Clone)]
+pub struct SessionSockets {
+    /// Our audio receive port
+    pub audio_port: u16,
+    /// Our control port (sync packets)
+    pub control_port: u16,
+    /// Our timing port (NTP-like)
+    pub timing_port: u16,
+    /// Client's control port (for sending retransmit requests)
+    pub client_control_port: Option<u16>,
+    /// Client's timing port
+    pub client_timing_port: Option<u16>,
+    /// Client's address
+    pub client_addr: Option<SocketAddr>,
+}
+
+/// A receiver session
+#[derive(Debug)]
+pub struct ReceiverSession {
+    /// Unique session identifier
+    id: String,
+    /// Current state
+    state: SessionState,
+    /// Client address
+    client_addr: SocketAddr,
+    /// Stream parameters (set after ANNOUNCE)
+    stream_params: Option<StreamParameters>,
+    /// Socket configuration (set after SETUP)
+    sockets: Option<SessionSockets>,
+    /// Current volume (-144.0 to 0.0 dB)
+    volume: f32,
+    /// Last activity timestamp
+    last_activity: Instant,
+    /// Session creation time
+    created_at: Instant,
+    /// RTSP session ID sent to client
+    rtsp_session_id: Option<String>,
+    /// Initial RTP sequence number
+    initial_seq: Option<u16>,
+    /// Initial RTP timestamp
+    initial_rtptime: Option<u32>,
+}
+
+impl ReceiverSession {
+    /// Create a new session
+    pub fn new(client_addr: SocketAddr) -> Self {
+        Self {
+            id: generate_session_id(),
+            state: SessionState::Connected,
+            client_addr,
+            stream_params: None,
+            sockets: None,
+            volume: 0.0,  // Full volume
+            last_activity: Instant::now(),
+            created_at: Instant::now(),
+            rtsp_session_id: None,
+            initial_seq: None,
+            initial_rtptime: None,
+        }
+    }
+
+    /// Get session ID
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Get current state
+    pub fn state(&self) -> SessionState {
+        self.state
+    }
+
+    /// Set state (validates transition)
+    pub fn set_state(&mut self, new_state: SessionState) -> Result<(), SessionError> {
+        if !self.state.can_transition_to(new_state) {
+            return Err(SessionError::InvalidTransition {
+                from: self.state,
+                to: new_state,
+            });
+        }
+        self.state = new_state;
+        self.touch();
+        Ok(())
+    }
+
+    /// Get client address
+    pub fn client_addr(&self) -> SocketAddr {
+        self.client_addr
+    }
+
+    /// Get volume in dB
+    pub fn volume(&self) -> f32 {
+        self.volume
+    }
+
+    /// Set volume in dB (-144.0 to 0.0)
+    pub fn set_volume(&mut self, volume: f32) {
+        self.volume = volume.clamp(-144.0, 0.0);
+        self.touch();
+    }
+
+    /// Set stream parameters (from ANNOUNCE)
+    pub fn set_stream_params(&mut self, params: StreamParameters) {
+        self.stream_params = Some(params);
+        self.touch();
+    }
+
+    /// Get stream parameters
+    pub fn stream_params(&self) -> Option<&StreamParameters> {
+        self.stream_params.as_ref()
+    }
+
+    /// Set socket configuration (from SETUP)
+    pub fn set_sockets(&mut self, sockets: SessionSockets) {
+        self.sockets = Some(sockets);
+        self.touch();
+    }
+
+    /// Get socket configuration
+    pub fn sockets(&self) -> Option<&SessionSockets> {
+        self.sockets.as_ref()
+    }
+
+    /// Set RTSP session ID
+    pub fn set_rtsp_session_id(&mut self, id: String) {
+        self.rtsp_session_id = Some(id);
+    }
+
+    /// Get RTSP session ID
+    pub fn rtsp_session_id(&self) -> Option<&str> {
+        self.rtsp_session_id.as_deref()
+    }
+
+    /// Set initial RTP info (from RECORD)
+    pub fn set_rtp_info(&mut self, seq: u16, rtptime: u32) {
+        self.initial_seq = Some(seq);
+        self.initial_rtptime = Some(rtptime);
+        self.touch();
+    }
+
+    /// Update last activity timestamp
+    pub fn touch(&mut self) {
+        self.last_activity = Instant::now();
+    }
+
+    /// Get time since last activity
+    pub fn idle_time(&self) -> Duration {
+        self.last_activity.elapsed()
+    }
+
+    /// Get session age
+    pub fn age(&self) -> Duration {
+        self.created_at.elapsed()
+    }
+
+    /// Check if session has timed out
+    pub fn is_timed_out(&self, timeout: Duration) -> bool {
+        self.idle_time() > timeout
+    }
+}
+
+/// Session errors
+#[derive(Debug, thiserror::Error)]
+pub enum SessionError {
+    #[error("Invalid state transition from {from:?} to {to:?}")]
+    InvalidTransition {
+        from: SessionState,
+        to: SessionState,
+    },
+
+    #[error("Session not found: {0}")]
+    NotFound(String),
+
+    #[error("Session busy: another session is active")]
+    Busy,
+
+    #[error("Session timed out")]
+    Timeout,
+}
+
+fn generate_session_id() -> String {
+    use rand::Rng;
+    let id: u64 = rand::thread_rng().gen();
+    format!("{:016X}", id)
+}
+```
+
+---
+
+### 37.2 Session Manager
+
+- [ ] **37.2.1** Implement session manager for handling multiple connections
+
+**File:** `src/receiver/session_manager.rs`
+
+```rust
+//! Session manager for the receiver
+//!
+//! Manages session lifecycle, enforces single-session policy,
+//! and handles session preemption.
+
+use super::session::{ReceiverSession, SessionState, SessionError, SessionSockets};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::UdpSocket;
+use tokio::sync::{Mutex, RwLock, broadcast};
+
+/// Session preemption policy
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreemptionPolicy {
+    /// Reject new connections while session is active
+    Reject,
+    /// Allow new connection to preempt existing session
+    AllowPreempt,
+    /// Queue new connection until current session ends
+    Queue,
+}
+
+/// Session manager configuration
+#[derive(Debug, Clone)]
+pub struct SessionManagerConfig {
+    /// Session idle timeout
+    pub idle_timeout: Duration,
+    /// Maximum session duration (0 = unlimited)
+    pub max_duration: Duration,
+    /// Preemption policy
+    pub preemption_policy: PreemptionPolicy,
+    /// Base port for UDP sockets
+    pub udp_base_port: u16,
+    /// Port range size
+    pub udp_port_range: u16,
+}
+
+impl Default for SessionManagerConfig {
+    fn default() -> Self {
+        Self {
+            idle_timeout: Duration::from_secs(60),
+            max_duration: Duration::ZERO,  // Unlimited
+            preemption_policy: PreemptionPolicy::AllowPreempt,
+            udp_base_port: 6000,
+            udp_port_range: 100,
+        }
+    }
+}
+
+/// Events from session manager
+#[derive(Debug, Clone)]
+pub enum SessionEvent {
+    /// New session started
+    SessionStarted { session_id: String, client: SocketAddr },
+    /// Session state changed
+    StateChanged { session_id: String, new_state: SessionState },
+    /// Session ended
+    SessionEnded { session_id: String, reason: String },
+    /// Volume changed
+    VolumeChanged { session_id: String, volume: f32 },
+}
+
+/// Manages receiver sessions
+pub struct SessionManager {
+    config: SessionManagerConfig,
+    /// Current active session (only one allowed)
+    active_session: Arc<RwLock<Option<ReceiverSession>>>,
+    /// Allocated UDP sockets for current session
+    sockets: Arc<Mutex<Option<AllocatedSockets>>>,
+    /// Port allocator
+    port_allocator: Arc<Mutex<PortAllocator>>,
+    /// Event broadcaster
+    event_tx: broadcast::Sender<SessionEvent>,
+}
+
+/// Allocated UDP sockets for a session
+pub struct AllocatedSockets {
+    pub audio: UdpSocket,
+    pub control: UdpSocket,
+    pub timing: UdpSocket,
+}
+
+impl AllocatedSockets {
+    pub fn ports(&self) -> (u16, u16, u16) {
+        (
+            self.audio.local_addr().map(|a| a.port()).unwrap_or(0),
+            self.control.local_addr().map(|a| a.port()).unwrap_or(0),
+            self.timing.local_addr().map(|a| a.port()).unwrap_or(0),
+        )
+    }
+}
+
+/// Simple port allocator
+struct PortAllocator {
+    base: u16,
+    range: u16,
+    next: u16,
+}
+
+impl PortAllocator {
+    fn new(base: u16, range: u16) -> Self {
+        Self { base, range, next: 0 }
+    }
+
+    /// Allocate next available port trio
+    fn allocate_trio(&mut self) -> (u16, u16, u16) {
+        let offset = self.next;
+        self.next = (self.next + 3) % self.range;
+
+        (
+            self.base + offset,
+            self.base + offset + 1,
+            self.base + offset + 2,
+        )
+    }
+}
+
+impl SessionManager {
+    /// Create a new session manager
+    pub fn new(config: SessionManagerConfig) -> Self {
+        let (event_tx, _) = broadcast::channel(64);
+
+        Self {
+            port_allocator: Arc::new(Mutex::new(PortAllocator::new(
+                config.udp_base_port,
+                config.udp_port_range,
+            ))),
+            config,
+            active_session: Arc::new(RwLock::new(None)),
+            sockets: Arc::new(Mutex::new(None)),
+            event_tx,
+        }
+    }
+
+    /// Subscribe to session events
+    pub fn subscribe(&self) -> broadcast::Receiver<SessionEvent> {
+        self.event_tx.subscribe()
+    }
+
+    /// Check if a session is currently active
+    pub async fn has_active_session(&self) -> bool {
+        self.active_session.read().await.is_some()
+    }
+
+    /// Get current session info (if any)
+    pub async fn current_session_id(&self) -> Option<String> {
+        self.active_session.read().await
+            .as_ref()
+            .map(|s| s.id().to_string())
+    }
+
+    /// Start a new session
+    pub async fn start_session(
+        &self,
+        client_addr: SocketAddr,
+    ) -> Result<String, SessionError> {
+        let mut active = self.active_session.write().await;
+
+        // Check if session already exists
+        if let Some(ref existing) = *active {
+            match self.config.preemption_policy {
+                PreemptionPolicy::Reject => {
+                    return Err(SessionError::Busy);
+                }
+                PreemptionPolicy::AllowPreempt => {
+                    // End existing session
+                    let old_id = existing.id().to_string();
+                    self.cleanup_sockets().await;
+
+                    let _ = self.event_tx.send(SessionEvent::SessionEnded {
+                        session_id: old_id,
+                        reason: "Preempted by new connection".to_string(),
+                    });
+                }
+                PreemptionPolicy::Queue => {
+                    // For now, treat as reject (queue not implemented)
+                    return Err(SessionError::Busy);
+                }
+            }
+        }
+
+        // Create new session
+        let session = ReceiverSession::new(client_addr);
+        let session_id = session.id().to_string();
+
+        let _ = self.event_tx.send(SessionEvent::SessionStarted {
+            session_id: session_id.clone(),
+            client: client_addr,
+        });
+
+        *active = Some(session);
+        Ok(session_id)
+    }
+
+    /// Allocate UDP sockets for the session
+    pub async fn allocate_sockets(&self) -> Result<(u16, u16, u16), std::io::Error> {
+        let (audio_port, control_port, timing_port) = {
+            let mut allocator = self.port_allocator.lock().await;
+            allocator.allocate_trio()
+        };
+
+        // Bind sockets
+        let audio = UdpSocket::bind(format!("0.0.0.0:{}", audio_port)).await?;
+        let control = UdpSocket::bind(format!("0.0.0.0:{}", control_port)).await?;
+        let timing = UdpSocket::bind(format!("0.0.0.0:{}", timing_port)).await?;
+
+        let ports = (
+            audio.local_addr()?.port(),
+            control.local_addr()?.port(),
+            timing.local_addr()?.port(),
+        );
+
+        let mut sockets = self.sockets.lock().await;
+        *sockets = Some(AllocatedSockets { audio, control, timing });
+
+        Ok(ports)
+    }
+
+    /// Get reference to allocated sockets
+    pub async fn get_sockets(&self) -> Option<Arc<Mutex<Option<AllocatedSockets>>>> {
+        // Return clone of Arc for shared access
+        Some(self.sockets.clone())
+    }
+
+    /// Update session state
+    pub async fn update_state(&self, new_state: SessionState) -> Result<(), SessionError> {
+        let mut active = self.active_session.write().await;
+
+        let session = active.as_mut()
+            .ok_or_else(|| SessionError::NotFound("No active session".into()))?;
+
+        session.set_state(new_state)?;
+
+        let session_id = session.id().to_string();
+
+        let _ = self.event_tx.send(SessionEvent::StateChanged {
+            session_id,
+            new_state,
+        });
+
+        Ok(())
+    }
+
+    /// Update session volume
+    pub async fn set_volume(&self, volume: f32) {
+        let mut active = self.active_session.write().await;
+
+        if let Some(ref mut session) = *active {
+            session.set_volume(volume);
+
+            let _ = self.event_tx.send(SessionEvent::VolumeChanged {
+                session_id: session.id().to_string(),
+                volume,
+            });
+        }
+    }
+
+    /// End the current session
+    pub async fn end_session(&self, reason: &str) {
+        let mut active = self.active_session.write().await;
+
+        if let Some(session) = active.take() {
+            self.cleanup_sockets().await;
+
+            let _ = self.event_tx.send(SessionEvent::SessionEnded {
+                session_id: session.id().to_string(),
+                reason: reason.to_string(),
+            });
+        }
+    }
+
+    /// Cleanup UDP sockets
+    async fn cleanup_sockets(&self) {
+        let mut sockets = self.sockets.lock().await;
+        *sockets = None;
+        // Sockets are dropped, ports released
+    }
+
+    /// Check for session timeout
+    pub async fn check_timeout(&self) -> bool {
+        let active = self.active_session.read().await;
+
+        if let Some(ref session) = *active {
+            if session.is_timed_out(self.config.idle_timeout) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Touch session to reset idle timeout
+    pub async fn touch_session(&self) {
+        let mut active = self.active_session.write().await;
+
+        if let Some(ref mut session) = *active {
+            session.touch();
+        }
+    }
+
+    /// Run with mutable access to session
+    pub async fn with_session<F, R>(&self, f: F) -> Result<R, SessionError>
+    where
+        F: FnOnce(&mut ReceiverSession) -> R,
+    {
+        let mut active = self.active_session.write().await;
+        let session = active.as_mut()
+            .ok_or_else(|| SessionError::NotFound("No active session".into()))?;
+        Ok(f(session))
+    }
+}
+```
+
+---
+
+### 37.3 Timeout Monitor
+
+- [ ] **37.3.1** Implement background timeout monitoring
+
+**File:** `src/receiver/session_manager.rs` (continued)
+
+```rust
+use tokio::time::interval;
+
+impl SessionManager {
+    /// Start background timeout monitor
+    ///
+    /// Returns a handle that can be used to stop the monitor.
+    pub fn start_timeout_monitor(self: &Arc<Self>) -> tokio::task::JoinHandle<()> {
+        let manager = self.clone();
+        let check_interval = self.config.idle_timeout / 4;
+
+        tokio::spawn(async move {
+            let mut ticker = interval(check_interval);
+
+            loop {
+                ticker.tick().await;
+
+                let should_timeout = manager.check_timeout().await;
+
+                if should_timeout {
+                    tracing::info!("Session timed out due to inactivity");
+                    manager.end_session("Idle timeout").await;
+                }
+
+                // Also check max duration if configured
+                if manager.config.max_duration > Duration::ZERO {
+                    let active = manager.active_session.read().await;
+                    if let Some(ref session) = *active {
+                        if session.age() > manager.config.max_duration {
+                            drop(active);  // Release read lock before write
+                            tracing::info!("Session exceeded maximum duration");
+                            manager.end_session("Maximum duration exceeded").await;
+                        }
+                    }
+                }
+            }
+        })
+    }
+}
+```
+
+---
+
+## Unit Tests
+
+### 37.4 Unit Tests
+
+- [ ] **37.4.1** Session state machine tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    fn test_addr() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 12345)
+    }
+
+    #[test]
+    fn test_valid_state_transitions() {
+        use SessionState::*;
+
+        assert!(Connected.can_transition_to(Announced));
+        assert!(Announced.can_transition_to(Setup));
+        assert!(Setup.can_transition_to(Streaming));
+        assert!(Streaming.can_transition_to(Paused));
+        assert!(Paused.can_transition_to(Streaming));
+        assert!(Streaming.can_transition_to(Teardown));
+    }
+
+    #[test]
+    fn test_invalid_state_transitions() {
+        use SessionState::*;
+
+        assert!(!Connected.can_transition_to(Streaming));
+        assert!(!Setup.can_transition_to(Connected));
+        assert!(!Closed.can_transition_to(Connected));
+    }
+
+    #[test]
+    fn test_teardown_from_any_state() {
+        use SessionState::*;
+
+        for state in [Connected, Announced, Setup, Streaming, Paused] {
+            assert!(state.can_transition_to(Teardown),
+                    "{:?} should transition to Teardown", state);
+        }
+    }
+
+    #[test]
+    fn test_session_state_change() {
+        let mut session = ReceiverSession::new(test_addr());
+
+        assert_eq!(session.state(), SessionState::Connected);
+
+        session.set_state(SessionState::Announced).unwrap();
+        assert_eq!(session.state(), SessionState::Announced);
+
+        // Invalid transition should fail
+        let result = session.set_state(SessionState::Streaming);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_session_volume() {
+        let mut session = ReceiverSession::new(test_addr());
+
+        assert_eq!(session.volume(), 0.0);
+
+        session.set_volume(-15.0);
+        assert_eq!(session.volume(), -15.0);
+
+        // Clamp to valid range
+        session.set_volume(-200.0);
+        assert_eq!(session.volume(), -144.0);
+
+        session.set_volume(10.0);
+        assert_eq!(session.volume(), 0.0);
+    }
+
+    #[test]
+    fn test_session_timeout() {
+        let session = ReceiverSession::new(test_addr());
+
+        // Immediately after creation, should not be timed out
+        assert!(!session.is_timed_out(Duration::from_secs(1)));
+
+        // With zero timeout, should be timed out
+        assert!(session.is_timed_out(Duration::ZERO));
+    }
+
+    #[test]
+    fn test_is_active_states() {
+        assert!(SessionState::Streaming.is_active());
+        assert!(SessionState::Paused.is_active());
+        assert!(!SessionState::Connected.is_active());
+        assert!(!SessionState::Teardown.is_active());
+    }
+
+    #[tokio::test]
+    async fn test_session_manager_single_session() {
+        let manager = SessionManager::new(SessionManagerConfig::default());
+
+        let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 1000);
+        let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2)), 1001);
+
+        // Start first session
+        let session1 = manager.start_session(addr1).await.unwrap();
+        assert!(manager.has_active_session().await);
+
+        // With AllowPreempt policy, second session preempts first
+        let session2 = manager.start_session(addr2).await.unwrap();
+        assert_ne!(session1, session2);
+
+        // End session
+        manager.end_session("test").await;
+        assert!(!manager.has_active_session().await);
+    }
+
+    #[tokio::test]
+    async fn test_session_manager_reject_policy() {
+        let config = SessionManagerConfig {
+            preemption_policy: PreemptionPolicy::Reject,
+            ..Default::default()
+        };
+        let manager = SessionManager::new(config);
+
+        let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 1000);
+        let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2)), 1001);
+
+        manager.start_session(addr1).await.unwrap();
+
+        // Second session should be rejected
+        let result = manager.start_session(addr2).await;
+        assert!(matches!(result, Err(SessionError::Busy)));
+    }
+
+    #[tokio::test]
+    async fn test_socket_allocation() {
+        let manager = SessionManager::new(SessionManagerConfig::default());
+
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 1000);
+        manager.start_session(addr).await.unwrap();
+
+        let (audio, control, timing) = manager.allocate_sockets().await.unwrap();
+
+        // Ports should be allocated
+        assert!(audio > 0);
+        assert!(control > 0);
+        assert!(timing > 0);
+
+        // Ports should be sequential (based on allocator)
+        assert_eq!(control, audio + 1);
+        assert_eq!(timing, audio + 2);
+    }
+}
+```
+
+---
+
+## Integration Tests
+
+### 37.5 Integration Tests
+
+- [ ] **37.5.1** Full session lifecycle test
+
+**File:** `tests/receiver/session_tests.rs`
+
+```rust
+use airplay2::receiver::session_manager::{
+    SessionManager, SessionManagerConfig, SessionEvent, PreemptionPolicy
+};
+use airplay2::receiver::session::SessionState;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::Duration;
+
+#[tokio::test]
+async fn test_complete_session_lifecycle() {
+    let manager = SessionManager::new(SessionManagerConfig::default());
+    let mut events = manager.subscribe();
+
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 5000);
+
+    // Start session
+    let session_id = manager.start_session(addr).await.unwrap();
+
+    // Verify start event
+    let event = events.recv().await.unwrap();
+    assert!(matches!(event, SessionEvent::SessionStarted { .. }));
+
+    // Allocate sockets
+    let (audio, control, timing) = manager.allocate_sockets().await.unwrap();
+    assert!(audio > 0 && control > 0 && timing > 0);
+
+    // Progress through states
+    manager.update_state(SessionState::Announced).await.unwrap();
+    let event = events.recv().await.unwrap();
+    assert!(matches!(event, SessionEvent::StateChanged { new_state: SessionState::Announced, .. }));
+
+    manager.update_state(SessionState::Setup).await.unwrap();
+    manager.update_state(SessionState::Streaming).await.unwrap();
+
+    // Set volume
+    manager.set_volume(-20.0).await;
+    let event = events.recv().await.unwrap();
+    let event = events.recv().await.unwrap();
+    let event = events.recv().await.unwrap();
+    assert!(matches!(event, SessionEvent::VolumeChanged { volume, .. } if (volume - -20.0).abs() < 0.01));
+
+    // End session
+    manager.end_session("Test complete").await;
+    let event = events.recv().await.unwrap();
+    assert!(matches!(event, SessionEvent::SessionEnded { .. }));
+
+    assert!(!manager.has_active_session().await);
+}
+
+#[tokio::test]
+async fn test_session_preemption() {
+    let manager = SessionManager::new(SessionManagerConfig {
+        preemption_policy: PreemptionPolicy::AllowPreempt,
+        ..Default::default()
+    });
+
+    let mut events = manager.subscribe();
+
+    let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 1000);
+    let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2)), 1001);
+
+    // Start first session
+    manager.start_session(addr1).await.unwrap();
+    let _ = events.recv().await;  // SessionStarted
+
+    // Preempt with second session
+    manager.start_session(addr2).await.unwrap();
+
+    // Should get SessionEnded for first, then SessionStarted for second
+    let event = events.recv().await.unwrap();
+    assert!(matches!(event, SessionEvent::SessionEnded { reason, .. }
+        if reason.contains("Preempted")));
+
+    let event = events.recv().await.unwrap();
+    assert!(matches!(event, SessionEvent::SessionStarted { client, .. }
+        if client == addr2));
+}
+
+#[tokio::test]
+async fn test_session_timeout() {
+    let config = SessionManagerConfig {
+        idle_timeout: Duration::from_millis(100),
+        ..Default::default()
+    };
+
+    let manager = std::sync::Arc::new(SessionManager::new(config));
+    let mut events = manager.subscribe();
+
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 1000);
+    manager.start_session(addr).await.unwrap();
+    let _ = events.recv().await;  // SessionStarted
+
+    // Start timeout monitor
+    let _monitor = manager.start_timeout_monitor();
+
+    // Wait for timeout
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Should receive timeout event
+    let event = tokio::time::timeout(
+        Duration::from_millis(100),
+        events.recv()
+    ).await.unwrap().unwrap();
+
+    assert!(matches!(event, SessionEvent::SessionEnded { reason, .. }
+        if reason.contains("timeout")));
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Session state machine validates all transitions
+- [ ] Invalid transitions return appropriate errors
+- [ ] Single-session enforcement works with all policies
+- [ ] UDP socket allocation succeeds and returns valid ports
+- [ ] Session events broadcast correctly
+- [ ] Timeout monitoring detects idle sessions
+- [ ] Session preemption works correctly
+- [ ] Volume changes tracked per-session
+- [ ] All unit tests pass
+- [ ] Integration tests pass
+
+---
+
+## Notes
+
+- **Single session**: AirPlay 1 typically allows only one sender; this is enforced at session level
+- **Preemption**: AllowPreempt is friendliest for home use; Reject better for professional setups
+- **Socket lifecycle**: Sockets bound on SETUP, released on TEARDOWN or timeout
+- **Thread safety**: Uses RwLock for session state, Mutex for sockets
+- **Events**: Broadcast channel allows multiple subscribers (UI, logging, etc.)
+- **Future**: Queue policy could be implemented for multi-sender scenarios
+
+---
+
+## References
+
+- [RTSP Session Handling](https://tools.ietf.org/html/rfc2326#section-3.4)
+- [shairport-sync session management](https://github.com/mikebrady/shairport-sync)

--- a/docs/38-sdp-parsing-stream-setup.md
+++ b/docs/38-sdp-parsing-stream-setup.md
@@ -1,0 +1,735 @@
+# Section 38: SDP Parsing & Stream Setup
+
+## Dependencies
+- **Section 36**: RTSP Server (Sans-IO) (ANNOUNCE handling)
+- **Section 37**: Session Management (StreamParameters storage)
+- **Section 04**: Crypto Primitives (RSA decryption for AES key)
+
+## Overview
+
+This section implements SDP (Session Description Protocol) parsing for the receiver. When an AirPlay sender connects, it sends an ANNOUNCE request containing an SDP body that describes the audio stream:
+
+- Codec type (PCM, ALAC, AAC)
+- Audio format parameters (sample rate, channels, bits)
+- Encryption keys (RSA-encrypted AES key and IV)
+- Latency requirements
+
+The receiver must parse this SDP to configure the audio pipeline correctly.
+
+## Objectives
+
+- Parse SDP bodies from ANNOUNCE requests
+- Extract codec and format parameters from `a=fmtp:` lines
+- Decrypt AES key from `a=rsaaeskey:` using RSA private key
+- Decode AES IV from `a=aesiv:`
+- Map SDP parameters to internal StreamParameters
+- Handle multiple codec types (ALAC, AAC, PCM)
+
+---
+
+## Tasks
+
+### 38.1 SDP Parser
+
+- [ ] **38.1.1** Implement SDP line parser
+
+**File:** `src/protocol/sdp/parser.rs`
+
+```rust
+//! SDP parser for RAOP ANNOUNCE bodies
+//!
+//! Parses Session Description Protocol content to extract
+//! audio stream parameters.
+
+use std::collections::HashMap;
+
+/// Parsed SDP session
+#[derive(Debug, Clone)]
+pub struct SdpSession {
+    /// Session version (v=)
+    pub version: u8,
+    /// Origin (o=)
+    pub origin: Option<SdpOrigin>,
+    /// Session name (s=)
+    pub session_name: String,
+    /// Connection info (c=)
+    pub connection: Option<SdpConnection>,
+    /// Time description (t=)
+    pub timing: Option<(u64, u64)>,
+    /// Media descriptions (m=)
+    pub media: Vec<SdpMedia>,
+    /// Session-level attributes (a=)
+    pub attributes: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SdpOrigin {
+    pub username: String,
+    pub session_id: String,
+    pub session_version: String,
+    pub net_type: String,
+    pub addr_type: String,
+    pub address: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SdpConnection {
+    pub net_type: String,
+    pub addr_type: String,
+    pub address: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SdpMedia {
+    pub media_type: String,
+    pub port: u16,
+    pub protocol: String,
+    pub formats: Vec<String>,
+    pub attributes: HashMap<String, String>,
+}
+
+/// SDP parsing errors
+#[derive(Debug, thiserror::Error)]
+pub enum SdpParseError {
+    #[error("Invalid SDP line: {0}")]
+    InvalidLine(String),
+
+    #[error("Missing required field: {0}")]
+    MissingField(String),
+
+    #[error("Invalid version: {0}")]
+    InvalidVersion(String),
+
+    #[error("Invalid origin line: {0}")]
+    InvalidOrigin(String),
+
+    #[error("Invalid media line: {0}")]
+    InvalidMedia(String),
+
+    #[error("Invalid fmtp: {0}")]
+    InvalidFmtp(String),
+}
+
+impl SdpSession {
+    /// Parse SDP from string
+    pub fn parse(sdp: &str) -> Result<Self, SdpParseError> {
+        let mut version = 0;
+        let mut origin = None;
+        let mut session_name = String::new();
+        let mut connection = None;
+        let mut timing = None;
+        let mut media = Vec::new();
+        let mut session_attributes = HashMap::new();
+        let mut current_media: Option<SdpMedia> = None;
+
+        for line in sdp.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            if line.len() < 2 || line.chars().nth(1) != Some('=') {
+                continue;  // Skip invalid lines
+            }
+
+            let line_type = line.chars().next().unwrap();
+            let value = &line[2..];
+
+            match line_type {
+                'v' => {
+                    version = value.parse()
+                        .map_err(|_| SdpParseError::InvalidVersion(value.to_string()))?;
+                }
+                'o' => {
+                    origin = Some(Self::parse_origin(value)?);
+                }
+                's' => {
+                    session_name = value.to_string();
+                }
+                'c' => {
+                    connection = Some(Self::parse_connection(value)?);
+                }
+                't' => {
+                    let parts: Vec<&str> = value.split_whitespace().collect();
+                    if parts.len() >= 2 {
+                        let start = parts[0].parse().unwrap_or(0);
+                        let stop = parts[1].parse().unwrap_or(0);
+                        timing = Some((start, stop));
+                    }
+                }
+                'm' => {
+                    // Save previous media block
+                    if let Some(m) = current_media.take() {
+                        media.push(m);
+                    }
+                    current_media = Some(Self::parse_media(value)?);
+                }
+                'a' => {
+                    let (name, attr_value) = Self::parse_attribute(value);
+
+                    if let Some(ref mut m) = current_media {
+                        m.attributes.insert(name, attr_value);
+                    } else {
+                        session_attributes.insert(name, attr_value);
+                    }
+                }
+                _ => {
+                    // Ignore unknown line types
+                }
+            }
+        }
+
+        // Save last media block
+        if let Some(m) = current_media {
+            media.push(m);
+        }
+
+        Ok(SdpSession {
+            version,
+            origin,
+            session_name,
+            connection,
+            timing,
+            media,
+            attributes: session_attributes,
+        })
+    }
+
+    fn parse_origin(value: &str) -> Result<SdpOrigin, SdpParseError> {
+        let parts: Vec<&str> = value.split_whitespace().collect();
+        if parts.len() < 6 {
+            return Err(SdpParseError::InvalidOrigin(value.to_string()));
+        }
+
+        Ok(SdpOrigin {
+            username: parts[0].to_string(),
+            session_id: parts[1].to_string(),
+            session_version: parts[2].to_string(),
+            net_type: parts[3].to_string(),
+            addr_type: parts[4].to_string(),
+            address: parts[5].to_string(),
+        })
+    }
+
+    fn parse_connection(value: &str) -> Result<SdpConnection, SdpParseError> {
+        let parts: Vec<&str> = value.split_whitespace().collect();
+        if parts.len() < 3 {
+            return Err(SdpParseError::InvalidLine(value.to_string()));
+        }
+
+        Ok(SdpConnection {
+            net_type: parts[0].to_string(),
+            addr_type: parts[1].to_string(),
+            address: parts[2].to_string(),
+        })
+    }
+
+    fn parse_media(value: &str) -> Result<SdpMedia, SdpParseError> {
+        let parts: Vec<&str> = value.split_whitespace().collect();
+        if parts.len() < 4 {
+            return Err(SdpParseError::InvalidMedia(value.to_string()));
+        }
+
+        Ok(SdpMedia {
+            media_type: parts[0].to_string(),
+            port: parts[1].parse().unwrap_or(0),
+            protocol: parts[2].to_string(),
+            formats: parts[3..].iter().map(|s| s.to_string()).collect(),
+            attributes: HashMap::new(),
+        })
+    }
+
+    fn parse_attribute(value: &str) -> (String, String) {
+        if let Some(pos) = value.find(':') {
+            (value[..pos].to_string(), value[pos + 1..].to_string())
+        } else {
+            (value.to_string(), String::new())
+        }
+    }
+
+    /// Get first audio media description
+    pub fn audio_media(&self) -> Option<&SdpMedia> {
+        self.media.iter().find(|m| m.media_type == "audio")
+    }
+}
+```
+
+---
+
+### 38.2 RAOP-Specific Parameter Extraction
+
+- [ ] **38.2.1** Extract ALAC/AAC format parameters
+
+**File:** `src/protocol/sdp/raop.rs`
+
+```rust
+//! RAOP-specific SDP parsing
+//!
+//! Extracts audio format parameters from RAOP ANNOUNCE SDP.
+
+use super::parser::{SdpSession, SdpMedia, SdpParseError};
+use crate::receiver::session::{StreamParameters, AudioCodec};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+
+/// ALAC format parameters from fmtp line
+#[derive(Debug, Clone)]
+pub struct AlacParameters {
+    /// Frames per packet
+    pub frames_per_packet: u32,
+    /// Compatible version
+    pub compatible_version: u8,
+    /// Bits per sample
+    pub bit_depth: u8,
+    /// Rice history mult
+    pub pb: u8,
+    /// Rice initial history
+    pub mb: u8,
+    /// Rice limit
+    pub kb: u8,
+    /// Number of channels
+    pub channels: u8,
+    /// Max run
+    pub max_run: u16,
+    /// Max frame bytes
+    pub max_frame_bytes: u32,
+    /// Average bit rate
+    pub avg_bit_rate: u32,
+    /// Sample rate
+    pub sample_rate: u32,
+}
+
+impl AlacParameters {
+    /// Parse from fmtp attribute value
+    /// Format: "96 352 0 16 40 10 14 2 255 0 0 44100"
+    pub fn parse(fmtp: &str) -> Result<Self, SdpParseError> {
+        let parts: Vec<&str> = fmtp.split_whitespace().collect();
+
+        // Skip payload type (first element)
+        if parts.len() < 12 {
+            return Err(SdpParseError::InvalidFmtp(format!(
+                "ALAC fmtp needs 12 fields, got {}: {}",
+                parts.len(),
+                fmtp
+            )));
+        }
+
+        // Start from index 1 (skip payload type)
+        let offset = if parts[0].parse::<u32>().is_ok() { 1 } else { 0 };
+
+        Ok(AlacParameters {
+            frames_per_packet: parts.get(offset).and_then(|s| s.parse().ok()).unwrap_or(352),
+            compatible_version: parts.get(offset + 1).and_then(|s| s.parse().ok()).unwrap_or(0),
+            bit_depth: parts.get(offset + 2).and_then(|s| s.parse().ok()).unwrap_or(16),
+            pb: parts.get(offset + 3).and_then(|s| s.parse().ok()).unwrap_or(40),
+            mb: parts.get(offset + 4).and_then(|s| s.parse().ok()).unwrap_or(10),
+            kb: parts.get(offset + 5).and_then(|s| s.parse().ok()).unwrap_or(14),
+            channels: parts.get(offset + 6).and_then(|s| s.parse().ok()).unwrap_or(2),
+            max_run: parts.get(offset + 7).and_then(|s| s.parse().ok()).unwrap_or(255),
+            max_frame_bytes: parts.get(offset + 8).and_then(|s| s.parse().ok()).unwrap_or(0),
+            avg_bit_rate: parts.get(offset + 9).and_then(|s| s.parse().ok()).unwrap_or(0),
+            sample_rate: parts.get(offset + 10).and_then(|s| s.parse().ok()).unwrap_or(44100),
+        })
+    }
+}
+
+/// AAC format parameters
+#[derive(Debug, Clone)]
+pub struct AacParameters {
+    /// Sample rate
+    pub sample_rate: u32,
+    /// Channels
+    pub channels: u8,
+    /// AAC profile
+    pub profile: AacProfile,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AacProfile {
+    LowComplexity,
+    EnhancedLowDelay,
+}
+
+/// Encryption parameters from SDP
+#[derive(Debug, Clone)]
+pub struct EncryptionParams {
+    /// RSA-encrypted AES key (base64-decoded)
+    pub encrypted_aes_key: Vec<u8>,
+    /// AES IV (base64-decoded)
+    pub aes_iv: [u8; 16],
+}
+
+/// Parse encryption parameters from SDP attributes
+pub fn parse_encryption(media: &SdpMedia) -> Result<Option<EncryptionParams>, SdpParseError> {
+    let encrypted_key = match media.attributes.get("rsaaeskey") {
+        Some(key) => key,
+        None => return Ok(None),  // No encryption
+    };
+
+    let iv_str = media.attributes.get("aesiv")
+        .ok_or_else(|| SdpParseError::MissingField("aesiv".to_string()))?;
+
+    // Decode base64
+    let encrypted_aes_key = BASE64.decode(encrypted_key.trim())
+        .map_err(|_| SdpParseError::InvalidLine("Invalid base64 in rsaaeskey".to_string()))?;
+
+    let iv_bytes = BASE64.decode(iv_str.trim())
+        .map_err(|_| SdpParseError::InvalidLine("Invalid base64 in aesiv".to_string()))?;
+
+    if iv_bytes.len() != 16 {
+        return Err(SdpParseError::InvalidLine(
+            format!("AES IV must be 16 bytes, got {}", iv_bytes.len())
+        ));
+    }
+
+    let mut aes_iv = [0u8; 16];
+    aes_iv.copy_from_slice(&iv_bytes);
+
+    Ok(Some(EncryptionParams {
+        encrypted_aes_key,
+        aes_iv,
+    }))
+}
+
+/// Detect codec from rtpmap attribute
+pub fn detect_codec(media: &SdpMedia) -> Option<AudioCodec> {
+    let rtpmap = media.attributes.get("rtpmap")?;
+
+    if rtpmap.contains("AppleLossless") {
+        Some(AudioCodec::Alac)
+    } else if rtpmap.contains("mpeg4-generic") || rtpmap.contains("MP4A-LATM") {
+        // Check for AAC-ELD vs AAC-LC
+        if rtpmap.contains("ELD") {
+            Some(AudioCodec::AacEld)
+        } else {
+            Some(AudioCodec::AacLc)
+        }
+    } else if rtpmap.contains("L16") {
+        Some(AudioCodec::Pcm)
+    } else {
+        None
+    }
+}
+
+/// Extract stream parameters from SDP session
+pub fn extract_stream_parameters(
+    sdp: &SdpSession,
+    rsa_private_key: Option<&[u8]>,
+) -> Result<StreamParameters, SdpParseError> {
+    let media = sdp.audio_media()
+        .ok_or_else(|| SdpParseError::MissingField("audio media".to_string()))?;
+
+    let codec = detect_codec(media)
+        .ok_or_else(|| SdpParseError::MissingField("rtpmap".to_string()))?;
+
+    let (sample_rate, bits_per_sample, channels, frames_per_packet) = match codec {
+        AudioCodec::Alac => {
+            let fmtp = media.attributes.get("fmtp")
+                .ok_or_else(|| SdpParseError::MissingField("fmtp".to_string()))?;
+            let alac = AlacParameters::parse(fmtp)?;
+            (alac.sample_rate, alac.bit_depth, alac.channels, alac.frames_per_packet)
+        }
+        AudioCodec::Pcm => {
+            // L16 defaults
+            (44100, 16, 2, 352)
+        }
+        AudioCodec::AacLc | AudioCodec::AacEld => {
+            // AAC defaults
+            (44100, 16, 2, 352)
+        }
+    };
+
+    // Parse encryption if present
+    let encryption = parse_encryption(media)?;
+
+    let (aes_key, aes_iv) = if let Some(enc) = encryption {
+        // Decrypt AES key using RSA
+        let key = if let Some(rsa_key) = rsa_private_key {
+            Some(decrypt_aes_key(&enc.encrypted_aes_key, rsa_key)?)
+        } else {
+            None
+        };
+        (key, Some(enc.aes_iv))
+    } else {
+        (None, None)
+    };
+
+    // Parse min-latency if present
+    let min_latency = media.attributes.get("min-latency")
+        .and_then(|s| s.parse().ok());
+
+    Ok(StreamParameters {
+        codec,
+        sample_rate,
+        bits_per_sample,
+        channels,
+        frames_per_packet,
+        aes_key,
+        aes_iv,
+        min_latency,
+    })
+}
+
+/// Decrypt AES key using RSA private key
+fn decrypt_aes_key(
+    encrypted: &[u8],
+    rsa_private_key: &[u8],
+) -> Result<[u8; 16], SdpParseError> {
+    use rsa::{RsaPrivateKey, Pkcs1v15Encrypt};
+    use rsa::pkcs8::DecodePrivateKey;
+
+    // Parse RSA private key
+    let private_key = RsaPrivateKey::from_pkcs8_der(rsa_private_key)
+        .map_err(|e| SdpParseError::InvalidLine(format!("Invalid RSA key: {}", e)))?;
+
+    // Decrypt using PKCS#1 v1.5
+    let decrypted = private_key.decrypt(Pkcs1v15Encrypt, encrypted)
+        .map_err(|e| SdpParseError::InvalidLine(format!("RSA decrypt failed: {}", e)))?;
+
+    if decrypted.len() != 16 {
+        return Err(SdpParseError::InvalidLine(
+            format!("Decrypted AES key must be 16 bytes, got {}", decrypted.len())
+        ));
+    }
+
+    let mut key = [0u8; 16];
+    key.copy_from_slice(&decrypted);
+    Ok(key)
+}
+```
+
+---
+
+### 38.3 Integration with Session
+
+- [ ] **38.3.1** Wire SDP parsing into ANNOUNCE handler
+
+**File:** `src/receiver/announce_handler.rs`
+
+```rust
+//! ANNOUNCE request handler
+//!
+//! Processes ANNOUNCE requests and configures session stream parameters.
+
+use crate::protocol::sdp::{parser::SdpSession, raop::extract_stream_parameters};
+use crate::receiver::session::{ReceiverSession, StreamParameters};
+use crate::protocol::rtsp::RtspRequest;
+
+/// Errors from ANNOUNCE handling
+#[derive(Debug, thiserror::Error)]
+pub enum AnnounceError {
+    #[error("Empty body in ANNOUNCE")]
+    EmptyBody,
+
+    #[error("Body is not valid UTF-8")]
+    InvalidUtf8,
+
+    #[error("SDP parse error: {0}")]
+    SdpParse(#[from] crate::protocol::sdp::parser::SdpParseError),
+
+    #[error("Unsupported codec")]
+    UnsupportedCodec,
+}
+
+/// Process an ANNOUNCE request
+pub fn process_announce(
+    request: &RtspRequest,
+    rsa_private_key: Option<&[u8]>,
+) -> Result<StreamParameters, AnnounceError> {
+    if request.body.is_empty() {
+        return Err(AnnounceError::EmptyBody);
+    }
+
+    let sdp_str = std::str::from_utf8(&request.body)
+        .map_err(|_| AnnounceError::InvalidUtf8)?;
+
+    let sdp = SdpSession::parse(sdp_str)?;
+
+    let params = extract_stream_parameters(&sdp, rsa_private_key)?;
+
+    Ok(params)
+}
+
+/// Apply stream parameters to session
+pub fn apply_to_session(
+    session: &mut ReceiverSession,
+    params: StreamParameters,
+) {
+    session.set_stream_params(params);
+}
+```
+
+---
+
+## Unit Tests
+
+### 38.4 Unit Tests
+
+- [ ] **38.4.1** SDP parsing tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_SDP: &str = r#"v=0
+o=iTunes 3413821438 0 IN IP4 192.168.1.100
+s=iTunes
+c=IN IP4 192.168.1.1
+t=0 0
+m=audio 0 RTP/AVP 96
+a=rtpmap:96 AppleLossless
+a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100
+a=rsaaeskey:VGhpcyBpcyBhIHRlc3Qga2V5IHRoYXQgaXMgdXNlZCBmb3IgdGVzdGluZw==
+a=aesiv:MDEyMzQ1Njc4OWFiY2RlZg==
+a=min-latency:11025
+"#;
+
+    const SIMPLE_SDP: &str = r#"v=0
+o=- 0 0 IN IP4 127.0.0.1
+s=AirTunes
+t=0 0
+m=audio 0 RTP/AVP 96
+a=rtpmap:96 AppleLossless
+a=fmtp:96 352 0 16 40 10 14 2 255 0 0 44100
+"#;
+
+    #[test]
+    fn test_parse_basic_sdp() {
+        let sdp = SdpSession::parse(SIMPLE_SDP).unwrap();
+
+        assert_eq!(sdp.version, 0);
+        assert_eq!(sdp.session_name, "AirTunes");
+        assert_eq!(sdp.media.len(), 1);
+
+        let audio = sdp.audio_media().unwrap();
+        assert_eq!(audio.media_type, "audio");
+        assert!(audio.attributes.contains_key("rtpmap"));
+    }
+
+    #[test]
+    fn test_parse_full_sdp() {
+        let sdp = SdpSession::parse(SAMPLE_SDP).unwrap();
+
+        assert!(sdp.origin.is_some());
+        let origin = sdp.origin.as_ref().unwrap();
+        assert_eq!(origin.username, "iTunes");
+
+        let audio = sdp.audio_media().unwrap();
+        assert!(audio.attributes.contains_key("rsaaeskey"));
+        assert!(audio.attributes.contains_key("aesiv"));
+        assert!(audio.attributes.contains_key("min-latency"));
+    }
+
+    #[test]
+    fn test_detect_codec_alac() {
+        let sdp = SdpSession::parse(SIMPLE_SDP).unwrap();
+        let audio = sdp.audio_media().unwrap();
+
+        let codec = detect_codec(audio).unwrap();
+        assert_eq!(codec, AudioCodec::Alac);
+    }
+
+    #[test]
+    fn test_parse_alac_parameters() {
+        let fmtp = "96 352 0 16 40 10 14 2 255 0 0 44100";
+        let params = AlacParameters::parse(fmtp).unwrap();
+
+        assert_eq!(params.frames_per_packet, 352);
+        assert_eq!(params.bit_depth, 16);
+        assert_eq!(params.channels, 2);
+        assert_eq!(params.sample_rate, 44100);
+    }
+
+    #[test]
+    fn test_parse_encryption_params() {
+        let sdp = SdpSession::parse(SAMPLE_SDP).unwrap();
+        let audio = sdp.audio_media().unwrap();
+
+        let enc = parse_encryption(audio).unwrap();
+        assert!(enc.is_some());
+
+        let enc = enc.unwrap();
+        assert!(!enc.encrypted_aes_key.is_empty());
+        assert_eq!(enc.aes_iv.len(), 16);
+    }
+
+    #[test]
+    fn test_no_encryption() {
+        let sdp = SdpSession::parse(SIMPLE_SDP).unwrap();
+        let audio = sdp.audio_media().unwrap();
+
+        let enc = parse_encryption(audio).unwrap();
+        assert!(enc.is_none());
+    }
+
+    #[test]
+    fn test_extract_stream_params_unencrypted() {
+        let sdp = SdpSession::parse(SIMPLE_SDP).unwrap();
+
+        let params = extract_stream_parameters(&sdp, None).unwrap();
+
+        assert_eq!(params.codec, AudioCodec::Alac);
+        assert_eq!(params.sample_rate, 44100);
+        assert_eq!(params.bits_per_sample, 16);
+        assert_eq!(params.channels, 2);
+        assert_eq!(params.frames_per_packet, 352);
+        assert!(params.aes_key.is_none());
+    }
+
+    #[test]
+    fn test_pcm_codec() {
+        let sdp_str = r#"v=0
+o=- 0 0 IN IP4 127.0.0.1
+s=Test
+t=0 0
+m=audio 0 RTP/AVP 96
+a=rtpmap:96 L16/44100/2
+"#;
+        let sdp = SdpSession::parse(sdp_str).unwrap();
+        let audio = sdp.audio_media().unwrap();
+
+        let codec = detect_codec(audio).unwrap();
+        assert_eq!(codec, AudioCodec::Pcm);
+    }
+
+    #[test]
+    fn test_min_latency_extraction() {
+        let sdp = SdpSession::parse(SAMPLE_SDP).unwrap();
+        let params = extract_stream_parameters(&sdp, None).unwrap();
+
+        assert_eq!(params.min_latency, Some(11025));
+    }
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Parse SDP v0 sessions correctly
+- [ ] Extract audio media section
+- [ ] Parse rtpmap for codec detection (ALAC, AAC, PCM)
+- [ ] Parse fmtp for ALAC parameters
+- [ ] Decode base64 rsaaeskey and aesiv
+- [ ] Decrypt AES key with RSA private key (when provided)
+- [ ] Handle missing encryption (unencrypted streams)
+- [ ] Extract min-latency attribute
+- [ ] Map to StreamParameters correctly
+- [ ] All unit tests pass
+
+---
+
+## Notes
+
+- **RSA Key**: The receiver needs a compatible RSA private key; for testing, a self-generated key works
+- **Apple's Key**: Real AirPlay devices use Apple's private key; open-source implementations use extracted keys
+- **Codec Support**: Focus on ALAC first (most common), then PCM, then AAC
+- **Robustness**: Real-world SDPs may have variations; be permissive in parsing
+
+---
+
+## References
+
+- [RFC 4566](https://tools.ietf.org/html/rfc4566) - SDP: Session Description Protocol
+- [RAOP SDP Format](https://nto.github.io/AirPlay.html#audio-sdp)
+- [ALAC Specification](https://macosforge.github.io/alac/)

--- a/docs/39-rtp-receiver-core.md
+++ b/docs/39-rtp-receiver-core.md
@@ -1,0 +1,961 @@
+# Section 39: RTP Receiver Core
+
+## Dependencies
+- **Section 06**: RTP Protocol (packet structures)
+- **Section 37**: Session Management (socket allocation)
+- **Section 38**: SDP Parsing (stream parameters)
+- **Section 29**: RAOP Encryption (AES decryption)
+
+## Overview
+
+This section implements the RTP receiver core, which handles incoming UDP audio packets from the AirPlay sender. The receiver operates three UDP sockets:
+
+1. **Audio Port**: Receives encrypted/encoded audio data packets
+2. **Control Port**: Receives sync packets and handles retransmit requests
+3. **Timing Port**: Handles NTP-like timing synchronization (Section 40)
+
+The receiver must:
+- Parse RTP headers and extract sequence numbers, timestamps
+- Decrypt audio payloads (AES-128-CBC)
+- Pass packets to the jitter buffer for reordering
+- Handle packet loss detection
+
+## Objectives
+
+- Implement async UDP receive loops for all three ports
+- Parse RTP packet headers efficiently
+- Decrypt AES-128-CBC encrypted payloads
+- Extract and validate sequence numbers for ordering
+- Detect packet loss via sequence gaps
+- Integrate with jitter buffer (Section 41)
+
+---
+
+## Tasks
+
+### 39.1 RTP Packet Reception
+
+- [ ] **39.1.1** Implement RTP packet receiver
+
+**File:** `src/receiver/rtp_receiver.rs`
+
+```rust
+//! RTP packet receiver for audio data
+//!
+//! Handles incoming RTP packets on the audio UDP port,
+//! decrypts them, and forwards to the jitter buffer.
+
+use crate::protocol::rtp::{RtpPacket, RtpHeader};
+use crate::receiver::session::StreamParameters;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+
+/// Maximum UDP packet size
+const MAX_PACKET_SIZE: usize = 2048;
+
+/// RTP audio packet payload type
+const PAYLOAD_TYPE_AUDIO: u8 = 0x60;
+
+/// Received and decrypted audio packet
+#[derive(Debug, Clone)]
+pub struct AudioPacket {
+    /// RTP sequence number
+    pub sequence: u16,
+    /// RTP timestamp
+    pub timestamp: u32,
+    /// SSRC
+    pub ssrc: u32,
+    /// Decrypted audio data
+    pub audio_data: Vec<u8>,
+    /// Reception time (for jitter calculation)
+    pub received_at: std::time::Instant,
+}
+
+/// Errors from RTP reception
+#[derive(Debug, thiserror::Error)]
+pub enum RtpReceiveError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Invalid RTP packet")]
+    InvalidPacket,
+
+    #[error("Wrong payload type: {0}")]
+    WrongPayloadType(u8),
+
+    #[error("Decryption failed: {0}")]
+    DecryptionFailed(String),
+
+    #[error("Channel closed")]
+    ChannelClosed,
+}
+
+/// RTP audio receiver
+pub struct RtpAudioReceiver {
+    socket: Arc<UdpSocket>,
+    stream_params: StreamParameters,
+    packet_tx: mpsc::Sender<AudioPacket>,
+    decryptor: Option<AudioDecryptor>,
+}
+
+impl RtpAudioReceiver {
+    /// Create a new RTP audio receiver
+    pub fn new(
+        socket: Arc<UdpSocket>,
+        stream_params: StreamParameters,
+        packet_tx: mpsc::Sender<AudioPacket>,
+    ) -> Self {
+        let decryptor = if let (Some(key), Some(iv)) = (stream_params.aes_key, stream_params.aes_iv) {
+            Some(AudioDecryptor::new(key, iv))
+        } else {
+            None
+        };
+
+        Self {
+            socket,
+            stream_params,
+            packet_tx,
+            decryptor,
+        }
+    }
+
+    /// Run the receive loop
+    pub async fn run(self) -> Result<(), RtpReceiveError> {
+        let mut buf = [0u8; MAX_PACKET_SIZE];
+
+        loop {
+            let (len, _src) = self.socket.recv_from(&mut buf).await?;
+
+            if len < 12 {
+                // Too short for RTP header
+                continue;
+            }
+
+            match self.process_packet(&buf[..len]).await {
+                Ok(()) => {}
+                Err(RtpReceiveError::ChannelClosed) => {
+                    tracing::debug!("Audio channel closed, stopping receiver");
+                    break;
+                }
+                Err(e) => {
+                    tracing::warn!("RTP packet error: {}", e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Process a single RTP packet
+    async fn process_packet(&self, data: &[u8]) -> Result<(), RtpReceiveError> {
+        // Parse RTP header
+        let header = RtpHeader::parse(data)
+            .ok_or(RtpReceiveError::InvalidPacket)?;
+
+        // Check payload type
+        if header.payload_type != PAYLOAD_TYPE_AUDIO {
+            return Err(RtpReceiveError::WrongPayloadType(header.payload_type));
+        }
+
+        // Extract payload (after 12-byte header)
+        let payload = &data[12..];
+
+        // Decrypt if encryption is enabled
+        let audio_data = if let Some(ref decryptor) = self.decryptor {
+            decryptor.decrypt(payload)?
+        } else {
+            payload.to_vec()
+        };
+
+        // Create audio packet
+        let packet = AudioPacket {
+            sequence: header.sequence,
+            timestamp: header.timestamp,
+            ssrc: header.ssrc,
+            audio_data,
+            received_at: std::time::Instant::now(),
+        };
+
+        // Send to jitter buffer
+        self.packet_tx.send(packet).await
+            .map_err(|_| RtpReceiveError::ChannelClosed)?;
+
+        Ok(())
+    }
+}
+
+/// RTP header parser
+impl RtpHeader {
+    /// Parse RTP header from bytes
+    pub fn parse(data: &[u8]) -> Option<Self> {
+        if data.len() < 12 {
+            return None;
+        }
+
+        let byte0 = data[0];
+        let byte1 = data[1];
+
+        let version = (byte0 >> 6) & 0x03;
+        if version != 2 {
+            return None;  // RTP version must be 2
+        }
+
+        let padding = (byte0 >> 5) & 0x01 != 0;
+        let extension = (byte0 >> 4) & 0x01 != 0;
+        let csrc_count = byte0 & 0x0F;
+        let marker = (byte1 >> 7) & 0x01 != 0;
+        let payload_type = byte1 & 0x7F;
+
+        let sequence = u16::from_be_bytes([data[2], data[3]]);
+        let timestamp = u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
+        let ssrc = u32::from_be_bytes([data[8], data[9], data[10], data[11]]);
+
+        Some(RtpHeader {
+            version,
+            padding,
+            extension,
+            csrc_count,
+            marker,
+            payload_type,
+            sequence,
+            timestamp,
+            ssrc,
+        })
+    }
+}
+```
+
+---
+
+### 39.2 Audio Decryptor
+
+- [ ] **39.2.1** Implement AES-128-CBC decryption for audio
+
+**File:** `src/receiver/rtp_receiver.rs` (continued)
+
+```rust
+use aes::Aes128;
+use aes::cipher::{BlockDecrypt, KeyInit, generic_array::GenericArray};
+
+/// Audio payload decryptor (AES-128-CBC)
+pub struct AudioDecryptor {
+    key: [u8; 16],
+    iv: [u8; 16],
+}
+
+impl AudioDecryptor {
+    pub fn new(key: [u8; 16], iv: [u8; 16]) -> Self {
+        Self { key, iv }
+    }
+
+    /// Decrypt audio payload
+    ///
+    /// RAOP uses AES-128-CBC with the IV from SDP.
+    /// Each packet uses the same IV (not chained between packets).
+    pub fn decrypt(&self, encrypted: &[u8]) -> Result<Vec<u8>, RtpReceiveError> {
+        if encrypted.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // AES-CBC works on 16-byte blocks
+        // RAOP only encrypts complete blocks, leaving remainder unencrypted
+        let block_size = 16;
+        let encrypted_len = (encrypted.len() / block_size) * block_size;
+
+        if encrypted_len == 0 {
+            // Less than one block, no encryption
+            return Ok(encrypted.to_vec());
+        }
+
+        let cipher = Aes128::new(GenericArray::from_slice(&self.key));
+
+        let mut decrypted = Vec::with_capacity(encrypted.len());
+
+        // Decrypt in CBC mode
+        let mut prev_block = self.iv;
+
+        for chunk in encrypted[..encrypted_len].chunks(block_size) {
+            let mut block = GenericArray::clone_from_slice(chunk);
+
+            // Save ciphertext for next XOR
+            let ciphertext: [u8; 16] = chunk.try_into().unwrap();
+
+            // Decrypt block
+            cipher.decrypt_block(&mut block);
+
+            // XOR with previous ciphertext (or IV for first block)
+            for (b, p) in block.iter_mut().zip(prev_block.iter()) {
+                *b ^= *p;
+            }
+
+            decrypted.extend_from_slice(&block);
+            prev_block = ciphertext;
+        }
+
+        // Append unencrypted remainder
+        if encrypted_len < encrypted.len() {
+            decrypted.extend_from_slice(&encrypted[encrypted_len..]);
+        }
+
+        Ok(decrypted)
+    }
+}
+```
+
+---
+
+### 39.3 Control Port Handler
+
+- [ ] **39.3.1** Implement control port receiver for sync packets
+
+**File:** `src/receiver/control_receiver.rs`
+
+```rust
+//! Control port receiver
+//!
+//! Handles sync packets and retransmission requests on the control UDP port.
+
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+
+/// Control packet types
+const PACKET_TYPE_SYNC: u8 = 0x54;
+const PACKET_TYPE_RETRANSMIT_REQUEST: u8 = 0x55;
+
+/// Sync packet from sender
+#[derive(Debug, Clone)]
+pub struct SyncPacket {
+    /// Extension bit
+    pub extension: bool,
+    /// RTP timestamp at next packet
+    pub rtp_timestamp: u32,
+    /// NTP timestamp (when sent)
+    pub ntp_timestamp: u64,
+    /// RTP timestamp at NTP time
+    pub rtp_timestamp_at_ntp: u32,
+}
+
+/// Retransmit request (we receive these; respond on control port)
+#[derive(Debug, Clone)]
+pub struct RetransmitRequest {
+    /// First sequence number to retransmit
+    pub first_seq: u16,
+    /// Number of packets to retransmit
+    pub count: u16,
+}
+
+/// Events from control port
+#[derive(Debug, Clone)]
+pub enum ControlEvent {
+    Sync(SyncPacket),
+    RetransmitRequest(RetransmitRequest),
+}
+
+/// Control port receiver
+pub struct ControlReceiver {
+    socket: Arc<UdpSocket>,
+    event_tx: mpsc::Sender<ControlEvent>,
+}
+
+impl ControlReceiver {
+    pub fn new(socket: Arc<UdpSocket>, event_tx: mpsc::Sender<ControlEvent>) -> Self {
+        Self { socket, event_tx }
+    }
+
+    /// Run the receive loop
+    pub async fn run(self) -> Result<(), std::io::Error> {
+        let mut buf = [0u8; 256];
+
+        loop {
+            let (len, src) = self.socket.recv_from(&mut buf).await?;
+
+            if len < 8 {
+                continue;
+            }
+
+            if let Some(event) = self.parse_packet(&buf[..len]) {
+                if self.event_tx.send(event).await.is_err() {
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn parse_packet(&self, data: &[u8]) -> Option<ControlEvent> {
+        if data.len() < 8 {
+            return None;
+        }
+
+        let packet_type = data[1] & 0x7F;
+
+        match packet_type {
+            PACKET_TYPE_SYNC => self.parse_sync(data),
+            PACKET_TYPE_RETRANSMIT_REQUEST => self.parse_retransmit(data),
+            _ => None,
+        }
+    }
+
+    fn parse_sync(&self, data: &[u8]) -> Option<ControlEvent> {
+        // Sync packet format:
+        // Byte 0: 0x80 | extension bit
+        // Byte 1: 0x54 (marker + type)
+        // Bytes 2-3: sequence (ignored)
+        // Bytes 4-7: RTP timestamp (next packet)
+        // Bytes 8-15: NTP timestamp
+        // Bytes 16-19: RTP timestamp at NTP time
+
+        if data.len() < 20 {
+            return None;
+        }
+
+        let extension = (data[0] & 0x10) != 0;
+        let rtp_timestamp = u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
+        let ntp_timestamp = u64::from_be_bytes([
+            data[8], data[9], data[10], data[11],
+            data[12], data[13], data[14], data[15],
+        ]);
+        let rtp_timestamp_at_ntp = u32::from_be_bytes([data[16], data[17], data[18], data[19]]);
+
+        Some(ControlEvent::Sync(SyncPacket {
+            extension,
+            rtp_timestamp,
+            ntp_timestamp,
+            rtp_timestamp_at_ntp,
+        }))
+    }
+
+    fn parse_retransmit(&self, data: &[u8]) -> Option<ControlEvent> {
+        // Retransmit request format:
+        // Bytes 0-1: Header
+        // Bytes 2-3: Sequence of missing packet
+        // Bytes 4-5: Count
+
+        if data.len() < 8 {
+            return None;
+        }
+
+        let first_seq = u16::from_be_bytes([data[4], data[5]]);
+        let count = u16::from_be_bytes([data[6], data[7]]);
+
+        Some(ControlEvent::RetransmitRequest(RetransmitRequest {
+            first_seq,
+            count,
+        }))
+    }
+}
+```
+
+---
+
+### 39.4 Packet Loss Detection
+
+- [ ] **39.4.1** Implement sequence number tracking and gap detection
+
+**File:** `src/receiver/sequence_tracker.rs`
+
+```rust
+//! RTP sequence number tracking and packet loss detection
+
+use std::collections::VecDeque;
+
+/// Tracks RTP sequence numbers to detect gaps
+pub struct SequenceTracker {
+    /// Last received sequence number
+    last_seq: Option<u16>,
+    /// Expected next sequence number
+    expected_seq: Option<u16>,
+    /// Recent gap history for statistics
+    recent_gaps: VecDeque<GapInfo>,
+    /// Maximum history size
+    max_history: usize,
+    /// Total packets received
+    packets_received: u64,
+    /// Total gaps detected
+    total_gaps: u64,
+    /// Total packets lost
+    total_lost: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct GapInfo {
+    /// First missing sequence
+    pub start: u16,
+    /// Count of missing packets
+    pub count: u16,
+    /// When gap was detected
+    pub detected_at: std::time::Instant,
+}
+
+impl SequenceTracker {
+    pub fn new() -> Self {
+        Self {
+            last_seq: None,
+            expected_seq: None,
+            recent_gaps: VecDeque::with_capacity(100),
+            max_history: 100,
+            packets_received: 0,
+            total_gaps: 0,
+            total_lost: 0,
+        }
+    }
+
+    /// Record a received packet, returning any detected gap
+    pub fn record(&mut self, seq: u16) -> Option<GapInfo> {
+        self.packets_received += 1;
+
+        let gap = if let Some(expected) = self.expected_seq {
+            let gap_size = self.sequence_gap(expected, seq);
+
+            if gap_size > 0 && gap_size < 1000 {
+                // Gap detected (but not wrap-around)
+                self.total_gaps += 1;
+                self.total_lost += gap_size as u64;
+
+                let gap_info = GapInfo {
+                    start: expected,
+                    count: gap_size,
+                    detected_at: std::time::Instant::now(),
+                };
+
+                if self.recent_gaps.len() >= self.max_history {
+                    self.recent_gaps.pop_front();
+                }
+                self.recent_gaps.push_back(gap_info.clone());
+
+                Some(gap_info)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        self.last_seq = Some(seq);
+        self.expected_seq = Some(seq.wrapping_add(1));
+
+        gap
+    }
+
+    /// Calculate gap between expected and actual sequence numbers
+    /// Handles 16-bit wraparound correctly
+    fn sequence_gap(&self, expected: u16, actual: u16) -> u16 {
+        actual.wrapping_sub(expected)
+    }
+
+    /// Check if a sequence number is expected (not duplicate, not too old)
+    pub fn is_expected(&self, seq: u16) -> bool {
+        if let Some(expected) = self.expected_seq {
+            let diff = seq.wrapping_sub(expected);
+            // Accept if within reasonable window (ahead or slightly behind)
+            diff < 1000 || diff > 65000
+        } else {
+            true  // First packet
+        }
+    }
+
+    /// Get packet loss ratio (0.0 to 1.0)
+    pub fn loss_ratio(&self) -> f64 {
+        if self.packets_received == 0 {
+            return 0.0;
+        }
+        let total = self.packets_received + self.total_lost;
+        self.total_lost as f64 / total as f64
+    }
+
+    /// Get statistics
+    pub fn stats(&self) -> SequenceStats {
+        SequenceStats {
+            packets_received: self.packets_received,
+            total_gaps: self.total_gaps,
+            total_lost: self.total_lost,
+            loss_ratio: self.loss_ratio(),
+        }
+    }
+
+    /// Reset the tracker
+    pub fn reset(&mut self) {
+        self.last_seq = None;
+        self.expected_seq = None;
+        self.recent_gaps.clear();
+        self.packets_received = 0;
+        self.total_gaps = 0;
+        self.total_lost = 0;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SequenceStats {
+    pub packets_received: u64,
+    pub total_gaps: u64,
+    pub total_lost: u64,
+    pub loss_ratio: f64,
+}
+
+impl Default for SequenceTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sequential_packets() {
+        let mut tracker = SequenceTracker::new();
+
+        assert!(tracker.record(100).is_none());
+        assert!(tracker.record(101).is_none());
+        assert!(tracker.record(102).is_none());
+
+        assert_eq!(tracker.packets_received, 3);
+        assert_eq!(tracker.total_lost, 0);
+    }
+
+    #[test]
+    fn test_gap_detection() {
+        let mut tracker = SequenceTracker::new();
+
+        tracker.record(100);
+        let gap = tracker.record(105);  // Skipped 101-104
+
+        assert!(gap.is_some());
+        let gap = gap.unwrap();
+        assert_eq!(gap.start, 101);
+        assert_eq!(gap.count, 4);
+    }
+
+    #[test]
+    fn test_wraparound() {
+        let mut tracker = SequenceTracker::new();
+
+        tracker.record(65534);
+        tracker.record(65535);
+        let gap = tracker.record(0);  // Wrap to 0
+
+        assert!(gap.is_none());
+        assert_eq!(tracker.total_lost, 0);
+    }
+
+    #[test]
+    fn test_loss_ratio() {
+        let mut tracker = SequenceTracker::new();
+
+        tracker.record(100);
+        tracker.record(105);  // Lost 4 packets
+
+        assert!((tracker.loss_ratio() - 0.666).abs() < 0.01);
+    }
+}
+```
+
+---
+
+### 39.5 Combined Receiver Manager
+
+- [ ] **39.5.1** Implement unified receiver management
+
+**File:** `src/receiver/receiver_manager.rs`
+
+```rust
+//! Combined RTP receiver manager
+//!
+//! Manages all three UDP receive loops and coordinates
+//! packet flow to the audio pipeline.
+
+use super::rtp_receiver::{RtpAudioReceiver, AudioPacket, RtpReceiveError};
+use super::control_receiver::{ControlReceiver, ControlEvent};
+use super::sequence_tracker::SequenceTracker;
+use crate::receiver::session::StreamParameters;
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+use tokio::sync::{mpsc, RwLock};
+use tokio::task::JoinHandle;
+
+/// Receiver manager configuration
+#[derive(Debug, Clone)]
+pub struct ReceiverConfig {
+    /// Audio packet channel buffer size
+    pub audio_buffer_size: usize,
+    /// Control event channel buffer size
+    pub control_buffer_size: usize,
+}
+
+impl Default for ReceiverConfig {
+    fn default() -> Self {
+        Self {
+            audio_buffer_size: 512,
+            control_buffer_size: 64,
+        }
+    }
+}
+
+/// Manages all RTP receive operations
+pub struct ReceiverManager {
+    config: ReceiverConfig,
+    audio_rx: mpsc::Receiver<AudioPacket>,
+    control_rx: mpsc::Receiver<ControlEvent>,
+    sequence_tracker: Arc<RwLock<SequenceTracker>>,
+    handles: Vec<JoinHandle<()>>,
+}
+
+impl ReceiverManager {
+    /// Start receivers on provided sockets
+    pub fn start(
+        audio_socket: Arc<UdpSocket>,
+        control_socket: Arc<UdpSocket>,
+        stream_params: StreamParameters,
+        config: ReceiverConfig,
+    ) -> Self {
+        let (audio_tx, audio_rx) = mpsc::channel(config.audio_buffer_size);
+        let (control_tx, control_rx) = mpsc::channel(config.control_buffer_size);
+        let sequence_tracker = Arc::new(RwLock::new(SequenceTracker::new()));
+
+        // Start audio receiver
+        let audio_receiver = RtpAudioReceiver::new(
+            audio_socket,
+            stream_params,
+            audio_tx,
+        );
+
+        let audio_handle = tokio::spawn(async move {
+            if let Err(e) = audio_receiver.run().await {
+                tracing::error!("Audio receiver error: {}", e);
+            }
+        });
+
+        // Start control receiver
+        let control_receiver = ControlReceiver::new(control_socket, control_tx);
+
+        let control_handle = tokio::spawn(async move {
+            if let Err(e) = control_receiver.run().await {
+                tracing::error!("Control receiver error: {}", e);
+            }
+        });
+
+        Self {
+            config,
+            audio_rx,
+            control_rx,
+            sequence_tracker,
+            handles: vec![audio_handle, control_handle],
+        }
+    }
+
+    /// Receive next audio packet
+    pub async fn recv_audio(&mut self) -> Option<AudioPacket> {
+        let packet = self.audio_rx.recv().await?;
+
+        // Track sequence
+        let mut tracker = self.sequence_tracker.write().await;
+        if let Some(gap) = tracker.record(packet.sequence) {
+            tracing::debug!(
+                "Packet loss detected: {} packets starting at seq {}",
+                gap.count,
+                gap.start
+            );
+        }
+
+        Some(packet)
+    }
+
+    /// Receive next control event
+    pub async fn recv_control(&mut self) -> Option<ControlEvent> {
+        self.control_rx.recv().await
+    }
+
+    /// Get sequence tracker for statistics
+    pub fn sequence_tracker(&self) -> Arc<RwLock<SequenceTracker>> {
+        self.sequence_tracker.clone()
+    }
+
+    /// Stop all receivers
+    pub async fn stop(self) {
+        for handle in self.handles {
+            handle.abort();
+        }
+    }
+}
+```
+
+---
+
+## Unit Tests
+
+### 39.6 Unit Tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rtp_header_parse() {
+        // Valid RTP packet header
+        let data = [
+            0x80, 0x60,  // V=2, P=0, X=0, CC=0, M=0, PT=96
+            0x00, 0x01,  // Sequence = 1
+            0x00, 0x00, 0x00, 0x0A,  // Timestamp = 10
+            0x12, 0x34, 0x56, 0x78,  // SSRC
+            0x00, 0x00,  // Payload start
+        ];
+
+        let header = RtpHeader::parse(&data).unwrap();
+
+        assert_eq!(header.version, 2);
+        assert_eq!(header.payload_type, 0x60);
+        assert_eq!(header.sequence, 1);
+        assert_eq!(header.timestamp, 10);
+        assert_eq!(header.ssrc, 0x12345678);
+    }
+
+    #[test]
+    fn test_rtp_header_invalid_version() {
+        let data = [
+            0x40, 0x60,  // V=1 (invalid)
+            0x00, 0x01,
+            0x00, 0x00, 0x00, 0x0A,
+            0x12, 0x34, 0x56, 0x78,
+        ];
+
+        assert!(RtpHeader::parse(&data).is_none());
+    }
+
+    #[test]
+    fn test_audio_decryptor() {
+        let key = [0x01; 16];
+        let iv = [0x02; 16];
+        let decryptor = AudioDecryptor::new(key, iv);
+
+        // Test with less than one block (unencrypted)
+        let short_data = [0x03; 10];
+        let result = decryptor.decrypt(&short_data).unwrap();
+        assert_eq!(result, short_data);
+    }
+
+    #[test]
+    fn test_sync_packet_parse() {
+        let data = [
+            0x90, 0xD4,  // Header with sync type
+            0x00, 0x01,  // Sequence
+            0x00, 0x00, 0x01, 0x00,  // RTP timestamp
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,  // NTP timestamp
+            0x00, 0x00, 0x00, 0xFF,  // RTP at NTP
+        ];
+
+        let receiver = ControlReceiver::new(
+            Arc::new(tokio::net::UdpSocket::bind("0.0.0.0:0").unwrap()),
+            mpsc::channel(1).0,
+        );
+
+        // Use internal parse for testing
+        let event = receiver.parse_sync(&data);
+        assert!(event.is_some());
+
+        if let Some(ControlEvent::Sync(sync)) = event {
+            assert_eq!(sync.rtp_timestamp, 256);
+            assert_eq!(sync.ntp_timestamp, 1);
+            assert_eq!(sync.rtp_timestamp_at_ntp, 255);
+        }
+    }
+}
+```
+
+---
+
+## Integration Tests
+
+### 39.7 Integration Tests
+
+**File:** `tests/receiver/rtp_receiver_tests.rs`
+
+```rust
+use tokio::net::UdpSocket;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn test_audio_packet_reception() {
+    // Create receiver socket
+    let receiver_socket = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
+    let receiver_addr = receiver_socket.local_addr().unwrap();
+
+    // Create sender socket
+    let sender_socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+
+    // Setup receiver
+    let (tx, mut rx) = mpsc::channel(16);
+    let params = StreamParameters::default();
+    let audio_receiver = RtpAudioReceiver::new(receiver_socket, params, tx);
+
+    // Start receiver
+    let handle = tokio::spawn(async move {
+        audio_receiver.run().await
+    });
+
+    // Send a valid RTP packet
+    let rtp_packet = build_test_rtp_packet(1, 0, &[0xAB; 100]);
+    sender_socket.send_to(&rtp_packet, receiver_addr).await.unwrap();
+
+    // Receive and verify
+    let received = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        rx.recv()
+    ).await.unwrap().unwrap();
+
+    assert_eq!(received.sequence, 1);
+    assert_eq!(received.timestamp, 0);
+
+    handle.abort();
+}
+
+fn build_test_rtp_packet(seq: u16, timestamp: u32, payload: &[u8]) -> Vec<u8> {
+    let mut packet = vec![
+        0x80, 0x60,  // V=2, PT=96
+        (seq >> 8) as u8, seq as u8,
+        (timestamp >> 24) as u8, (timestamp >> 16) as u8,
+        (timestamp >> 8) as u8, timestamp as u8,
+        0x12, 0x34, 0x56, 0x78,  // SSRC
+    ];
+    packet.extend_from_slice(payload);
+    packet
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Parse RTP headers correctly (version, PT, seq, timestamp, SSRC)
+- [ ] Decrypt AES-128-CBC payloads correctly
+- [ ] Handle unencrypted streams
+- [ ] Receive packets on audio UDP port
+- [ ] Receive sync packets on control port
+- [ ] Detect packet loss via sequence gaps
+- [ ] Calculate accurate loss statistics
+- [ ] Handle 16-bit sequence wraparound
+- [ ] All unit tests pass
+- [ ] Integration tests pass
+
+---
+
+## Notes
+
+- **Payload type**: RAOP uses 0x60 (96) for audio; other types are control/timing
+- **Decryption**: AES-CBC with same IV per packet (not chained)
+- **Sequence tracking**: 16-bit wrapping handled correctly
+- **Buffer sizes**: Tune based on network conditions and latency requirements
+- **Future**: Retransmit requests could be sent for lost packets
+
+---
+
+## References
+
+- [RFC 3550](https://tools.ietf.org/html/rfc3550) - RTP: A Transport Protocol for Real-Time Applications
+- [RAOP RTP Format](https://nto.github.io/AirPlay.html#audio-rtp)

--- a/docs/40-timing-synchronization.md
+++ b/docs/40-timing-synchronization.md
@@ -1,0 +1,564 @@
+# Section 40: Timing Synchronization
+
+## Dependencies
+- **Section 39**: RTP Receiver Core (timing port handling)
+- **Section 37**: Session Management (socket allocation)
+- **Section 06**: RTP Protocol (timing packet structures)
+
+## Overview
+
+This section implements NTP-like timing synchronization for the AirPlay receiver. Accurate timing is critical for:
+
+1. **Buffer management**: Knowing when to start playback
+2. **Sync packets**: Correlating RTP timestamps to wall-clock time
+3. **Multi-room sync**: If extended to support grouped playback
+4. **Latency measurement**: Understanding sender-receiver delay
+
+The timing protocol exchanges packets on the timing UDP port, allowing both sender and receiver to compute clock offsets and network delay.
+
+## Objectives
+
+- Implement timing request/response handler
+- Compute clock offset from NTP-like exchange
+- Map RTP timestamps to local playback time
+- Track and compensate for clock drift
+- Provide accurate "now playing" timestamps
+
+---
+
+## Tasks
+
+### 40.1 Timing Packet Handler
+
+- [ ] **40.1.1** Implement timing request/response on timing port
+
+**File:** `src/receiver/timing.rs`
+
+```rust
+//! Timing synchronization for RAOP receiver
+//!
+//! Implements NTP-like timing exchange to synchronize clocks
+//! between sender and receiver.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tokio::net::UdpSocket;
+use tokio::sync::RwLock;
+
+/// Timing packet types
+const TIMING_REQUEST: u8 = 0x52;
+const TIMING_RESPONSE: u8 = 0x53;
+
+/// NTP epoch offset from Unix epoch (seconds from 1900 to 1970)
+const NTP_EPOCH_OFFSET: u64 = 2208988800;
+
+/// Timing packet structure
+#[derive(Debug, Clone, Copy)]
+pub struct TimingPacket {
+    /// Packet type (0x52 request, 0x53 response)
+    pub packet_type: u8,
+    /// Reference timestamp (when we received request, or when sender sent)
+    pub reference_time: NtpTimestamp,
+    /// Receive timestamp (when we received the packet)
+    pub receive_time: NtpTimestamp,
+    /// Send timestamp (when we send response)
+    pub send_time: NtpTimestamp,
+}
+
+/// NTP timestamp (64-bit: 32 seconds + 32 fraction)
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NtpTimestamp {
+    pub seconds: u32,
+    pub fraction: u32,
+}
+
+impl NtpTimestamp {
+    /// Create from current system time
+    pub fn now() -> Self {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO);
+
+        let seconds = now.as_secs() + NTP_EPOCH_OFFSET;
+        let nanos = now.subsec_nanos();
+        // Convert nanoseconds to NTP fraction (2^32 / 10^9)
+        let fraction = ((nanos as u64 * 0x100000000u64) / 1_000_000_000) as u32;
+
+        Self {
+            seconds: seconds as u32,
+            fraction,
+        }
+    }
+
+    /// Create from 64-bit NTP timestamp
+    pub fn from_u64(value: u64) -> Self {
+        Self {
+            seconds: (value >> 32) as u32,
+            fraction: value as u32,
+        }
+    }
+
+    /// Convert to 64-bit NTP timestamp
+    pub fn to_u64(&self) -> u64 {
+        ((self.seconds as u64) << 32) | (self.fraction as u64)
+    }
+
+    /// Convert to Duration since NTP epoch
+    pub fn to_duration(&self) -> Duration {
+        let secs = self.seconds as u64;
+        let nanos = ((self.fraction as u64 * 1_000_000_000) / 0x100000000u64) as u32;
+        Duration::new(secs, nanos)
+    }
+
+    /// Difference in microseconds
+    pub fn diff_micros(&self, other: &Self) -> i64 {
+        let self_micros = (self.seconds as i64 * 1_000_000) +
+            ((self.fraction as i64 * 1_000_000) >> 32);
+        let other_micros = (other.seconds as i64 * 1_000_000) +
+            ((other.fraction as i64 * 1_000_000) >> 32);
+        self_micros - other_micros
+    }
+}
+
+/// Clock synchronization state
+#[derive(Debug)]
+pub struct ClockSync {
+    /// Computed offset (local - remote) in microseconds
+    offset_micros: i64,
+    /// Round-trip delay in microseconds
+    delay_micros: u64,
+    /// Number of sync exchanges
+    exchange_count: u32,
+    /// Last sync time
+    last_sync: Instant,
+    /// Moving average of offset
+    offset_avg: f64,
+    /// Drift rate (microseconds per second)
+    drift_rate: f64,
+}
+
+impl ClockSync {
+    pub fn new() -> Self {
+        Self {
+            offset_micros: 0,
+            delay_micros: 0,
+            exchange_count: 0,
+            last_sync: Instant::now(),
+            offset_avg: 0.0,
+            drift_rate: 0.0,
+        }
+    }
+
+    /// Update sync from timing exchange
+    ///
+    /// NTP-like offset calculation:
+    /// offset = ((t2 - t1) + (t3 - t4)) / 2
+    /// delay = (t4 - t1) - (t3 - t2)
+    ///
+    /// Where:
+    /// t1 = sender's transmit time
+    /// t2 = our receive time
+    /// t3 = our transmit time
+    /// t4 = sender's receive time (from next sync or estimated)
+    pub fn update(
+        &mut self,
+        sender_transmit: NtpTimestamp,   // t1
+        our_receive: NtpTimestamp,       // t2
+        our_transmit: NtpTimestamp,      // t3
+    ) {
+        // Simplified: estimate offset as (t2 - t1) - delay/2
+        // Without t4, we can only estimate based on previous delay
+
+        let receive_diff = our_receive.diff_micros(&sender_transmit);
+
+        // Update moving average
+        let alpha = if self.exchange_count < 10 { 0.5 } else { 0.1 };
+        self.offset_avg = (1.0 - alpha) * self.offset_avg + alpha * (receive_diff as f64);
+        self.offset_micros = self.offset_avg as i64;
+
+        // Estimate delay (simplified)
+        let transmit_diff = our_transmit.diff_micros(&our_receive);
+        self.delay_micros = transmit_diff.unsigned_abs();
+
+        self.exchange_count += 1;
+        self.last_sync = Instant::now();
+    }
+
+    /// Get current offset in microseconds
+    pub fn offset_micros(&self) -> i64 {
+        self.offset_micros
+    }
+
+    /// Get estimated delay in microseconds
+    pub fn delay_micros(&self) -> u64 {
+        self.delay_micros
+    }
+
+    /// Check if sync is stale
+    pub fn is_stale(&self, max_age: Duration) -> bool {
+        self.last_sync.elapsed() > max_age
+    }
+}
+
+impl Default for ClockSync {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Timing port handler
+pub struct TimingHandler {
+    socket: Arc<UdpSocket>,
+    clock_sync: Arc<RwLock<ClockSync>>,
+    sender_addr: Option<SocketAddr>,
+}
+
+impl TimingHandler {
+    pub fn new(socket: Arc<UdpSocket>) -> Self {
+        Self {
+            socket,
+            clock_sync: Arc::new(RwLock::new(ClockSync::new())),
+            sender_addr: None,
+        }
+    }
+
+    /// Run timing handler loop
+    pub async fn run(mut self) -> Result<(), std::io::Error> {
+        let mut buf = [0u8; 64];
+
+        loop {
+            let (len, src) = self.socket.recv_from(&mut buf).await?;
+
+            if len < 32 {
+                continue;
+            }
+
+            // Remember sender address
+            self.sender_addr = Some(src);
+
+            // Parse and respond to timing request
+            if let Some(response) = self.handle_timing_packet(&buf[..len]).await {
+                self.socket.send_to(&response, src).await?;
+            }
+        }
+    }
+
+    async fn handle_timing_packet(&self, data: &[u8]) -> Option<Vec<u8>> {
+        if data.len() < 32 {
+            return None;
+        }
+
+        let packet_type = data[1] & 0x7F;
+
+        if packet_type != TIMING_REQUEST {
+            return None;
+        }
+
+        // Parse timing request
+        // Format:
+        // Bytes 0-1: Header (0x80 0x52)
+        // Bytes 2-3: Sequence
+        // Bytes 4-7: Zero
+        // Bytes 8-15: Reference timestamp (zero in request)
+        // Bytes 16-23: Receive timestamp (zero in request)
+        // Bytes 24-31: Transmit timestamp (sender's send time)
+
+        let sender_transmit = NtpTimestamp::from_u64(
+            u64::from_be_bytes([
+                data[24], data[25], data[26], data[27],
+                data[28], data[29], data[30], data[31],
+            ])
+        );
+
+        let our_receive = NtpTimestamp::now();
+
+        // Build response
+        let our_transmit = NtpTimestamp::now();
+
+        // Update clock sync
+        {
+            let mut sync = self.clock_sync.write().await;
+            sync.update(sender_transmit, our_receive, our_transmit);
+        }
+
+        // Build timing response
+        let mut response = vec![0u8; 32];
+        response[0] = 0x80;
+        response[1] = TIMING_RESPONSE | 0x80;  // Response type with marker
+        response[2] = data[2];  // Echo sequence
+        response[3] = data[3];
+
+        // Reference time = sender's transmit time
+        let ref_bytes = sender_transmit.to_u64().to_be_bytes();
+        response[8..16].copy_from_slice(&ref_bytes);
+
+        // Receive time = when we received request
+        let recv_bytes = our_receive.to_u64().to_be_bytes();
+        response[16..24].copy_from_slice(&recv_bytes);
+
+        // Transmit time = now
+        let send_bytes = our_transmit.to_u64().to_be_bytes();
+        response[24..32].copy_from_slice(&send_bytes);
+
+        Some(response)
+    }
+
+    /// Get clock sync handle
+    pub fn clock_sync(&self) -> Arc<RwLock<ClockSync>> {
+        self.clock_sync.clone()
+    }
+}
+```
+
+---
+
+### 40.2 RTP to Wall-Clock Mapping
+
+- [ ] **40.2.1** Map RTP timestamps to playback time
+
+**File:** `src/receiver/playback_timing.rs`
+
+```rust
+//! RTP timestamp to playback time mapping
+
+use super::timing::{ClockSync, NtpTimestamp};
+use super::control_receiver::SyncPacket;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+/// Maps RTP timestamps to wall-clock time for playback scheduling
+pub struct PlaybackTiming {
+    /// Sample rate (typically 44100)
+    sample_rate: u32,
+    /// Reference RTP timestamp (from sync packet)
+    ref_rtp_timestamp: Option<u32>,
+    /// Reference NTP timestamp (from sync packet)
+    ref_ntp_timestamp: Option<NtpTimestamp>,
+    /// Reference local time
+    ref_local_time: Option<Instant>,
+    /// Clock sync for offset
+    clock_sync: Arc<RwLock<ClockSync>>,
+    /// Target latency in samples
+    target_latency_samples: u32,
+}
+
+impl PlaybackTiming {
+    pub fn new(sample_rate: u32, clock_sync: Arc<RwLock<ClockSync>>) -> Self {
+        Self {
+            sample_rate,
+            ref_rtp_timestamp: None,
+            ref_ntp_timestamp: None,
+            ref_local_time: None,
+            clock_sync,
+            // Default 2 second latency
+            target_latency_samples: sample_rate * 2,
+        }
+    }
+
+    /// Update reference from sync packet
+    pub fn update_from_sync(&mut self, sync: &SyncPacket) {
+        self.ref_rtp_timestamp = Some(sync.rtp_timestamp_at_ntp);
+        self.ref_ntp_timestamp = Some(NtpTimestamp::from_u64(sync.ntp_timestamp));
+        self.ref_local_time = Some(Instant::now());
+
+        tracing::debug!(
+            "Sync update: RTP {} at NTP {}",
+            sync.rtp_timestamp_at_ntp,
+            sync.ntp_timestamp
+        );
+    }
+
+    /// Set target latency
+    pub fn set_target_latency(&mut self, samples: u32) {
+        self.target_latency_samples = samples;
+    }
+
+    /// Get target latency in duration
+    pub fn target_latency(&self) -> Duration {
+        Duration::from_secs_f64(
+            self.target_latency_samples as f64 / self.sample_rate as f64
+        )
+    }
+
+    /// Calculate when an RTP timestamp should be played
+    ///
+    /// Returns the Instant at which the audio with this RTP timestamp
+    /// should be sent to the audio device.
+    pub async fn playback_time(&self, rtp_timestamp: u32) -> Option<Instant> {
+        let ref_rtp = self.ref_rtp_timestamp?;
+        let ref_local = self.ref_local_time?;
+
+        // Calculate samples since reference
+        let samples_diff = rtp_timestamp.wrapping_sub(ref_rtp) as i64;
+
+        // Convert to duration
+        let time_diff = Duration::from_secs_f64(
+            samples_diff as f64 / self.sample_rate as f64
+        );
+
+        // Add target latency
+        let latency = self.target_latency();
+
+        // Calculate playback time
+        let playback_time = if samples_diff >= 0 {
+            ref_local + time_diff + latency
+        } else {
+            // Past timestamp
+            ref_local.checked_sub(Duration::from_secs_f64(
+                (-samples_diff) as f64 / self.sample_rate as f64
+            ))? + latency
+        };
+
+        Some(playback_time)
+    }
+
+    /// Check if an RTP timestamp is ready for playback
+    pub async fn is_ready_for_playback(&self, rtp_timestamp: u32) -> bool {
+        if let Some(playback_time) = self.playback_time(rtp_timestamp).await {
+            Instant::now() >= playback_time
+        } else {
+            // No sync yet, use simple delay
+            false
+        }
+    }
+
+    /// Get delay until playback time
+    pub async fn delay_until_playback(&self, rtp_timestamp: u32) -> Option<Duration> {
+        let playback_time = self.playback_time(rtp_timestamp).await?;
+        let now = Instant::now();
+
+        if now >= playback_time {
+            Some(Duration::ZERO)
+        } else {
+            Some(playback_time - now)
+        }
+    }
+
+    /// Convert RTP timestamp difference to duration
+    pub fn rtp_to_duration(&self, rtp_samples: u32) -> Duration {
+        Duration::from_secs_f64(rtp_samples as f64 / self.sample_rate as f64)
+    }
+}
+```
+
+---
+
+## Unit Tests
+
+### 40.3 Unit Tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ntp_timestamp_now() {
+        let ts = NtpTimestamp::now();
+
+        // Should be after year 2020 in NTP time
+        // 2020 in NTP = 3786825600 (seconds since 1900)
+        assert!(ts.seconds > 3786825600);
+    }
+
+    #[test]
+    fn test_ntp_timestamp_roundtrip() {
+        let original = NtpTimestamp {
+            seconds: 12345678,
+            fraction: 0xABCDEF00,
+        };
+
+        let u64_val = original.to_u64();
+        let restored = NtpTimestamp::from_u64(u64_val);
+
+        assert_eq!(original.seconds, restored.seconds);
+        assert_eq!(original.fraction, restored.fraction);
+    }
+
+    #[test]
+    fn test_ntp_diff_micros() {
+        let t1 = NtpTimestamp { seconds: 1000, fraction: 0 };
+        let t2 = NtpTimestamp { seconds: 1001, fraction: 0 };
+
+        let diff = t2.diff_micros(&t1);
+        assert_eq!(diff, 1_000_000);  // 1 second = 1,000,000 microseconds
+    }
+
+    #[test]
+    fn test_clock_sync_update() {
+        let mut sync = ClockSync::new();
+
+        let sender = NtpTimestamp { seconds: 1000, fraction: 0 };
+        let receive = NtpTimestamp { seconds: 1000, fraction: 0x80000000 };  // +0.5s
+        let transmit = NtpTimestamp { seconds: 1000, fraction: 0x80000001 };
+
+        sync.update(sender, receive, transmit);
+
+        assert!(sync.exchange_count == 1);
+        assert!(sync.offset_micros() != 0 || sync.delay_micros() != 0);
+    }
+
+    #[tokio::test]
+    async fn test_playback_timing() {
+        let clock_sync = Arc::new(RwLock::new(ClockSync::new()));
+        let mut timing = PlaybackTiming::new(44100, clock_sync);
+
+        // Set reference
+        let sync = SyncPacket {
+            extension: false,
+            rtp_timestamp: 44100,
+            ntp_timestamp: NtpTimestamp::now().to_u64(),
+            rtp_timestamp_at_ntp: 44100,
+        };
+        timing.update_from_sync(&sync);
+
+        // Timestamp one second later should play ~1 second later
+        let playback = timing.playback_time(44100 + 44100).await;
+        assert!(playback.is_some());
+    }
+
+    #[test]
+    fn test_rtp_to_duration() {
+        let clock_sync = Arc::new(RwLock::new(ClockSync::new()));
+        let timing = PlaybackTiming::new(44100, clock_sync);
+
+        let duration = timing.rtp_to_duration(44100);
+        assert!((duration.as_secs_f64() - 1.0).abs() < 0.001);
+
+        let duration = timing.rtp_to_duration(22050);
+        assert!((duration.as_secs_f64() - 0.5).abs() < 0.001);
+    }
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Receive and respond to timing requests
+- [ ] Compute clock offset from timing exchanges
+- [ ] Track round-trip delay
+- [ ] Map RTP timestamps to local playback time
+- [ ] Handle sync packet updates
+- [ ] Support configurable target latency
+- [ ] Detect stale synchronization
+- [ ] All unit tests pass
+
+---
+
+## Notes
+
+- **NTP format**: 64-bit timestamp with 32 bits seconds, 32 bits fraction
+- **Offset calculation**: Simplified without full NTP algorithm
+- **Drift compensation**: Not yet implemented; future enhancement
+- **Sync frequency**: Sender typically sends sync packets every few seconds
+- **Latency**: 2 seconds default matches shairport-sync
+
+---
+
+## References
+
+- [RFC 5905](https://tools.ietf.org/html/rfc5905) - Network Time Protocol Version 4
+- [RAOP Timing Protocol](https://nto.github.io/AirPlay.html#audio-timing)

--- a/docs/41-jitter-buffer-packet-loss.md
+++ b/docs/41-jitter-buffer-packet-loss.md
@@ -1,0 +1,687 @@
+# Section 41: Jitter Buffer & Packet Loss Handling
+
+## Dependencies
+- **Section 39**: RTP Receiver Core (audio packets)
+- **Section 40**: Timing Synchronization (playback scheduling)
+- **Section 12**: Audio Buffer & Timing (ring buffer)
+
+## Overview
+
+This section implements the jitter buffer, which handles:
+
+1. **Packet reordering**: Network may deliver packets out of order
+2. **Timing**: Hold packets until their scheduled playback time
+3. **Packet loss concealment**: Handle missing packets gracefully
+4. **Buffer management**: Maintain appropriate buffer depth
+
+The jitter buffer bridges the gap between unpredictable network arrival times and the steady, continuous audio output required by the audio device.
+
+## Objectives
+
+- Implement sequence-ordered jitter buffer
+- Reorder out-of-sequence packets
+- Detect and conceal packet loss
+- Provide steady packet output stream
+- Support configurable buffer depth
+- Track buffer statistics (fill level, underruns)
+
+---
+
+## Tasks
+
+### 41.1 Jitter Buffer Core
+
+- [ ] **41.1.1** Implement sequence-keyed jitter buffer
+
+**File:** `src/audio/jitter.rs`
+
+```rust
+//! Jitter buffer for RTP packet reordering and timing
+//!
+//! Buffers incoming packets, reorders them by sequence number,
+//! and releases them at the appropriate playback time.
+
+use crate::receiver::rtp_receiver::AudioPacket;
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant};
+
+/// Jitter buffer configuration
+#[derive(Debug, Clone)]
+pub struct JitterBufferConfig {
+    /// Target buffer depth in packets
+    pub target_depth: usize,
+    /// Minimum depth before playback starts
+    pub min_depth: usize,
+    /// Maximum depth (excess packets dropped)
+    pub max_depth: usize,
+    /// Maximum age before packet is considered too old
+    pub max_age: Duration,
+    /// Packets per second (for timing calculations)
+    pub packets_per_second: f64,
+}
+
+impl Default for JitterBufferConfig {
+    fn default() -> Self {
+        Self {
+            target_depth: 50,      // ~400ms at 352 samples/packet, 44.1kHz
+            min_depth: 10,         // ~80ms
+            max_depth: 200,        // ~1.6s
+            max_age: Duration::from_secs(3),
+            packets_per_second: 44100.0 / 352.0,  // ~125 packets/sec
+        }
+    }
+}
+
+/// Buffer state
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BufferState {
+    /// Filling up, not ready for playback
+    Buffering,
+    /// Normal playback
+    Playing,
+    /// Underrun, rebuffering
+    Underrun,
+}
+
+/// Statistics from the jitter buffer
+#[derive(Debug, Clone, Default)]
+pub struct JitterStats {
+    pub packets_received: u64,
+    pub packets_played: u64,
+    pub packets_dropped_late: u64,
+    pub packets_dropped_overflow: u64,
+    pub packets_concealed: u64,
+    pub underruns: u64,
+    pub current_depth: usize,
+    pub max_depth_seen: usize,
+}
+
+/// Jitter buffer for audio packets
+pub struct JitterBuffer {
+    config: JitterBufferConfig,
+    /// Packets ordered by sequence number
+    packets: BTreeMap<u16, AudioPacket>,
+    /// Next sequence number expected for playback
+    next_play_seq: Option<u16>,
+    /// Current state
+    state: BufferState,
+    /// Statistics
+    stats: JitterStats,
+    /// Last packet receive time
+    last_receive: Option<Instant>,
+}
+
+impl JitterBuffer {
+    pub fn new(config: JitterBufferConfig) -> Self {
+        Self {
+            config,
+            packets: BTreeMap::new(),
+            next_play_seq: None,
+            state: BufferState::Buffering,
+            stats: JitterStats::default(),
+            last_receive: None,
+        }
+    }
+
+    /// Insert a packet into the buffer
+    pub fn insert(&mut self, packet: AudioPacket) {
+        self.stats.packets_received += 1;
+        self.last_receive = Some(Instant::now());
+
+        let seq = packet.sequence;
+
+        // Check if packet is too old (behind playback point)
+        if let Some(next_seq) = self.next_play_seq {
+            let diff = seq.wrapping_sub(next_seq) as i16;
+            if diff < 0 && diff > -1000 {
+                // Packet is late
+                self.stats.packets_dropped_late += 1;
+                tracing::debug!("Dropping late packet seq={}, expected={}", seq, next_seq);
+                return;
+            }
+        }
+
+        // Check buffer overflow
+        if self.packets.len() >= self.config.max_depth {
+            self.stats.packets_dropped_overflow += 1;
+            // Drop oldest packet
+            if let Some(oldest) = self.packets.keys().next().copied() {
+                self.packets.remove(&oldest);
+            }
+        }
+
+        self.packets.insert(seq, packet);
+
+        // Update max depth stat
+        if self.packets.len() > self.stats.max_depth_seen {
+            self.stats.max_depth_seen = self.packets.len();
+        }
+
+        // Check state transitions
+        self.update_state();
+    }
+
+    /// Get next packet for playback if available
+    pub fn pop(&mut self) -> Option<AudioPacket> {
+        if self.state == BufferState::Buffering {
+            return None;
+        }
+
+        let next_seq = self.next_play_seq?;
+
+        if let Some(packet) = self.packets.remove(&next_seq) {
+            self.next_play_seq = Some(next_seq.wrapping_add(1));
+            self.stats.packets_played += 1;
+            self.stats.current_depth = self.packets.len();
+            Some(packet)
+        } else {
+            // Missing packet - try to conceal or skip
+            self.handle_missing_packet(next_seq)
+        }
+    }
+
+    /// Handle a missing packet at playback time
+    fn handle_missing_packet(&mut self, missing_seq: u16) -> Option<AudioPacket> {
+        self.stats.packets_concealed += 1;
+
+        // Find the next available packet
+        let next_available = self.packets.keys().next().copied();
+
+        if let Some(avail_seq) = next_available {
+            let gap = avail_seq.wrapping_sub(missing_seq);
+
+            if gap < 10 {
+                // Small gap, skip to available packet
+                tracing::debug!("Concealing gap: {} packets from {} to {}", gap, missing_seq, avail_seq);
+                self.next_play_seq = Some(avail_seq.wrapping_add(1));
+                return self.packets.remove(&avail_seq);
+            }
+        }
+
+        // Large gap or no packets - advance sequence and return nothing
+        self.next_play_seq = Some(missing_seq.wrapping_add(1));
+        None
+    }
+
+    /// Update buffer state based on current depth
+    fn update_state(&mut self) {
+        let depth = self.packets.len();
+
+        match self.state {
+            BufferState::Buffering => {
+                if depth >= self.config.min_depth {
+                    self.state = BufferState::Playing;
+                    // Set initial playback sequence
+                    if self.next_play_seq.is_none() {
+                        self.next_play_seq = self.packets.keys().next().copied();
+                    }
+                    tracing::info!("Jitter buffer ready, starting playback");
+                }
+            }
+            BufferState::Playing => {
+                if depth == 0 {
+                    self.state = BufferState::Underrun;
+                    self.stats.underruns += 1;
+                    tracing::warn!("Jitter buffer underrun");
+                }
+            }
+            BufferState::Underrun => {
+                if depth >= self.config.min_depth {
+                    self.state = BufferState::Playing;
+                    tracing::info!("Recovered from underrun");
+                }
+            }
+        }
+
+        self.stats.current_depth = depth;
+    }
+
+    /// Get current state
+    pub fn state(&self) -> BufferState {
+        self.state
+    }
+
+    /// Get statistics
+    pub fn stats(&self) -> &JitterStats {
+        &self.stats
+    }
+
+    /// Check if buffer is ready for playback
+    pub fn is_ready(&self) -> bool {
+        self.state == BufferState::Playing
+    }
+
+    /// Get current depth in packets
+    pub fn depth(&self) -> usize {
+        self.packets.len()
+    }
+
+    /// Flush all packets (e.g., for FLUSH command)
+    pub fn flush(&mut self) {
+        self.packets.clear();
+        self.state = BufferState::Buffering;
+        self.next_play_seq = None;
+        tracing::info!("Jitter buffer flushed");
+    }
+
+    /// Flush packets from given RTP timestamp onwards
+    pub fn flush_from_timestamp(&mut self, rtp_time: u32) {
+        // Remove packets with timestamp >= rtp_time
+        // This is approximate as we track by sequence, not timestamp
+        self.packets.retain(|_, p| p.timestamp < rtp_time);
+
+        if self.packets.is_empty() {
+            self.state = BufferState::Buffering;
+            self.next_play_seq = None;
+        }
+    }
+
+    /// Remove old packets
+    pub fn prune_old(&mut self) {
+        let now = Instant::now();
+        let max_age = self.config.max_age;
+
+        self.packets.retain(|_, p| {
+            now.duration_since(p.received_at) < max_age
+        });
+    }
+}
+```
+
+---
+
+### 41.2 Packet Loss Concealment
+
+- [ ] **41.2.1** Implement basic concealment strategies
+
+**File:** `src/audio/concealment.rs`
+
+```rust
+//! Packet loss concealment strategies
+//!
+//! When packets are lost, we need to fill the gap to maintain
+//! continuous audio output.
+
+/// Concealment strategy
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConcealmentStrategy {
+    /// Fill with silence (zeros)
+    Silence,
+    /// Repeat the previous packet
+    Repeat,
+    /// Fade to silence over the gap
+    FadeOut,
+    /// Interpolate if next packet arrives
+    Interpolate,
+}
+
+impl Default for ConcealmentStrategy {
+    fn default() -> Self {
+        ConcealmentStrategy::Repeat
+    }
+}
+
+/// Concealment generator
+pub struct Concealer {
+    strategy: ConcealmentStrategy,
+    /// Previous packet audio data (for repeat)
+    previous_audio: Option<Vec<u8>>,
+    /// Sample rate
+    sample_rate: u32,
+    /// Bytes per sample (e.g., 4 for 16-bit stereo)
+    bytes_per_sample: usize,
+}
+
+impl Concealer {
+    pub fn new(strategy: ConcealmentStrategy, sample_rate: u32, bytes_per_sample: usize) -> Self {
+        Self {
+            strategy,
+            previous_audio: None,
+            sample_rate,
+            bytes_per_sample,
+        }
+    }
+
+    /// Record a good packet for later concealment
+    pub fn record_good_packet(&mut self, audio: &[u8]) {
+        self.previous_audio = Some(audio.to_vec());
+    }
+
+    /// Generate concealment audio for a missing packet
+    pub fn conceal(&self, packet_samples: usize) -> Vec<u8> {
+        let size = packet_samples * self.bytes_per_sample;
+
+        match self.strategy {
+            ConcealmentStrategy::Silence => {
+                vec![0u8; size]
+            }
+            ConcealmentStrategy::Repeat => {
+                self.previous_audio
+                    .clone()
+                    .unwrap_or_else(|| vec![0u8; size])
+            }
+            ConcealmentStrategy::FadeOut => {
+                // Fade previous packet to silence
+                if let Some(ref prev) = self.previous_audio {
+                    self.fade_out(prev, size)
+                } else {
+                    vec![0u8; size]
+                }
+            }
+            ConcealmentStrategy::Interpolate => {
+                // Would need next packet; fall back to repeat
+                self.previous_audio
+                    .clone()
+                    .unwrap_or_else(|| vec![0u8; size])
+            }
+        }
+    }
+
+    /// Fade audio to silence
+    fn fade_out(&self, audio: &[u8], target_size: usize) -> Vec<u8> {
+        let mut output = audio.to_vec();
+        output.resize(target_size, 0);
+
+        // Simple linear fade for 16-bit samples
+        let sample_count = output.len() / 2;
+        for i in 0..sample_count {
+            let fade = 1.0 - (i as f32 / sample_count as f32);
+
+            let idx = i * 2;
+            if idx + 1 < output.len() {
+                let sample = i16::from_le_bytes([output[idx], output[idx + 1]]);
+                let faded = (sample as f32 * fade) as i16;
+                let bytes = faded.to_le_bytes();
+                output[idx] = bytes[0];
+                output[idx + 1] = bytes[1];
+            }
+        }
+
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_silence_concealment() {
+        let concealer = Concealer::new(ConcealmentStrategy::Silence, 44100, 4);
+        let concealed = concealer.conceal(352);
+
+        assert_eq!(concealed.len(), 352 * 4);
+        assert!(concealed.iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn test_repeat_concealment() {
+        let mut concealer = Concealer::new(ConcealmentStrategy::Repeat, 44100, 4);
+
+        let audio = vec![0xAB; 1408];  // 352 samples * 4 bytes
+        concealer.record_good_packet(&audio);
+
+        let concealed = concealer.conceal(352);
+        assert_eq!(concealed, audio);
+    }
+
+    #[test]
+    fn test_repeat_no_previous() {
+        let concealer = Concealer::new(ConcealmentStrategy::Repeat, 44100, 4);
+        let concealed = concealer.conceal(352);
+
+        assert_eq!(concealed.len(), 352 * 4);
+        assert!(concealed.iter().all(|&b| b == 0));
+    }
+}
+```
+
+---
+
+### 41.3 Buffer Statistics & Monitoring
+
+- [ ] **41.3.1** Implement buffer health monitoring
+
+**File:** `src/audio/jitter.rs` (additions)
+
+```rust
+impl JitterBuffer {
+    /// Get fill percentage (0.0 to 1.0)
+    pub fn fill_ratio(&self) -> f64 {
+        self.packets.len() as f64 / self.config.target_depth as f64
+    }
+
+    /// Check if buffer health is good
+    pub fn is_healthy(&self) -> bool {
+        let depth = self.packets.len();
+        depth >= self.config.min_depth / 2 && depth <= self.config.max_depth
+    }
+
+    /// Get estimated latency based on buffer depth
+    pub fn estimated_latency(&self) -> Duration {
+        let packets = self.packets.len() as f64;
+        Duration::from_secs_f64(packets / self.config.packets_per_second)
+    }
+
+    /// Calculate packet loss rate
+    pub fn loss_rate(&self) -> f64 {
+        let total = self.stats.packets_received + self.stats.packets_concealed;
+        if total == 0 {
+            return 0.0;
+        }
+        self.stats.packets_concealed as f64 / total as f64
+    }
+}
+
+/// Buffer health report
+#[derive(Debug, Clone)]
+pub struct BufferHealth {
+    pub state: BufferState,
+    pub depth: usize,
+    pub fill_ratio: f64,
+    pub estimated_latency: Duration,
+    pub loss_rate: f64,
+    pub underruns: u64,
+    pub is_healthy: bool,
+}
+
+impl JitterBuffer {
+    /// Get comprehensive health report
+    pub fn health(&self) -> BufferHealth {
+        BufferHealth {
+            state: self.state,
+            depth: self.packets.len(),
+            fill_ratio: self.fill_ratio(),
+            estimated_latency: self.estimated_latency(),
+            loss_rate: self.loss_rate(),
+            underruns: self.stats.underruns,
+            is_healthy: self.is_healthy(),
+        }
+    }
+}
+```
+
+---
+
+## Unit Tests
+
+### 41.4 Unit Tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_packet(seq: u16, timestamp: u32) -> AudioPacket {
+        AudioPacket {
+            sequence: seq,
+            timestamp,
+            ssrc: 0x12345678,
+            audio_data: vec![0u8; 1408],
+            received_at: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn test_in_order_packets() {
+        let mut buffer = JitterBuffer::new(JitterBufferConfig {
+            min_depth: 3,
+            ..Default::default()
+        });
+
+        buffer.insert(make_packet(1, 352));
+        buffer.insert(make_packet(2, 704));
+        buffer.insert(make_packet(3, 1056));
+
+        assert!(buffer.is_ready());
+        assert_eq!(buffer.depth(), 3);
+
+        let p1 = buffer.pop().unwrap();
+        assert_eq!(p1.sequence, 1);
+
+        let p2 = buffer.pop().unwrap();
+        assert_eq!(p2.sequence, 2);
+    }
+
+    #[test]
+    fn test_out_of_order_packets() {
+        let mut buffer = JitterBuffer::new(JitterBufferConfig {
+            min_depth: 3,
+            ..Default::default()
+        });
+
+        // Insert out of order
+        buffer.insert(make_packet(3, 1056));
+        buffer.insert(make_packet(1, 352));
+        buffer.insert(make_packet(2, 704));
+
+        assert!(buffer.is_ready());
+
+        // Should pop in order
+        assert_eq!(buffer.pop().unwrap().sequence, 1);
+        assert_eq!(buffer.pop().unwrap().sequence, 2);
+        assert_eq!(buffer.pop().unwrap().sequence, 3);
+    }
+
+    #[test]
+    fn test_buffering_state() {
+        let mut buffer = JitterBuffer::new(JitterBufferConfig {
+            min_depth: 3,
+            ..Default::default()
+        });
+
+        buffer.insert(make_packet(1, 352));
+        assert!(!buffer.is_ready());
+
+        buffer.insert(make_packet(2, 704));
+        assert!(!buffer.is_ready());
+
+        buffer.insert(make_packet(3, 1056));
+        assert!(buffer.is_ready());
+    }
+
+    #[test]
+    fn test_late_packet_dropped() {
+        let mut buffer = JitterBuffer::new(JitterBufferConfig {
+            min_depth: 2,
+            ..Default::default()
+        });
+
+        buffer.insert(make_packet(10, 3520));
+        buffer.insert(make_packet(11, 3872));
+
+        // Pop first packet
+        buffer.pop();
+
+        // Now insert a late packet (seq 5, before current playback)
+        buffer.insert(make_packet(5, 1760));
+
+        assert_eq!(buffer.stats.packets_dropped_late, 1);
+    }
+
+    #[test]
+    fn test_flush() {
+        let mut buffer = JitterBuffer::new(JitterBufferConfig {
+            min_depth: 2,
+            ..Default::default()
+        });
+
+        buffer.insert(make_packet(1, 352));
+        buffer.insert(make_packet(2, 704));
+        buffer.insert(make_packet(3, 1056));
+
+        buffer.flush();
+
+        assert_eq!(buffer.depth(), 0);
+        assert_eq!(buffer.state(), BufferState::Buffering);
+    }
+
+    #[test]
+    fn test_underrun() {
+        let mut buffer = JitterBuffer::new(JitterBufferConfig {
+            min_depth: 2,
+            ..Default::default()
+        });
+
+        buffer.insert(make_packet(1, 352));
+        buffer.insert(make_packet(2, 704));
+
+        buffer.pop();
+        buffer.pop();
+
+        // Buffer now empty
+        let result = buffer.pop();
+        assert!(result.is_none());
+        assert_eq!(buffer.state(), BufferState::Underrun);
+    }
+
+    #[test]
+    fn test_wraparound_sequence() {
+        let mut buffer = JitterBuffer::new(JitterBufferConfig {
+            min_depth: 2,
+            ..Default::default()
+        });
+
+        buffer.insert(make_packet(65534, 0));
+        buffer.insert(make_packet(65535, 352));
+        buffer.insert(make_packet(0, 704));
+
+        assert_eq!(buffer.pop().unwrap().sequence, 65534);
+        assert_eq!(buffer.pop().unwrap().sequence, 65535);
+        assert_eq!(buffer.pop().unwrap().sequence, 0);
+    }
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Buffer receives and stores packets by sequence
+- [ ] Out-of-order packets reordered correctly
+- [ ] Late packets (behind playback) dropped
+- [ ] Buffer overflow handled (oldest dropped)
+- [ ] Buffering state transitions correctly
+- [ ] Underrun detected and recovered
+- [ ] Concealment generates appropriate fill audio
+- [ ] Flush clears buffer and resets state
+- [ ] Statistics track all relevant metrics
+- [ ] 16-bit sequence wraparound handled
+- [ ] All unit tests pass
+
+---
+
+## Notes
+
+- **BTreeMap**: Used for efficient ordered iteration by sequence
+- **Concealment**: Simple strategies; could add more sophisticated PLC
+- **Depth tuning**: Trades latency for robustness
+- **Underrun recovery**: Waits for min_depth before resuming
+- **Memory**: Each packet buffered (~1.5KB), max_depth limits memory
+
+---
+
+## References
+
+- [Jitter Buffer Design](https://en.wikipedia.org/wiki/Jitter_buffer)
+- [WebRTC Jitter Buffer](https://webrtc.googlesource.com/src/+/refs/heads/main/modules/audio_coding/neteq/)

--- a/docs/42-audio-output-abstraction.md
+++ b/docs/42-audio-output-abstraction.md
@@ -1,0 +1,705 @@
+# Section 42: Audio Output Abstraction
+
+## Dependencies
+- **Section 34**: Receiver Overview (feature flags)
+- **Section 41**: Jitter Buffer (audio data source)
+- **Section 11**: Audio Formats & Codecs (format types)
+
+## Overview
+
+This section implements the audio output abstraction layer, enabling the receiver to play audio through various platform backends:
+
+- **CoreAudio** (macOS) - Priority platform
+- **CPAL** (cross-platform) - Fallback for all platforms
+- **ALSA** (Linux) - Native Linux support
+- **WASAPI** (Windows) - Native Windows support (via CPAL)
+
+The design uses traits to abstract the output backend, allowing compile-time selection via feature flags and runtime selection where appropriate.
+
+## Objectives
+
+- Define `AudioOutput` trait for platform abstraction
+- Implement CoreAudio backend (macOS priority)
+- Implement CPAL backend (cross-platform fallback)
+- Support audio format negotiation
+- Handle buffer management and callback-based output
+- Provide volume control at output level
+
+---
+
+## Tasks
+
+### 42.1 Audio Output Trait
+
+- [ ] **42.1.1** Define platform-agnostic audio output trait
+
+**File:** `src/audio/output.rs`
+
+```rust
+//! Audio output abstraction
+//!
+//! Platform-agnostic trait for audio playback with implementations
+//! for CoreAudio, CPAL, ALSA, etc.
+
+use crate::audio::format::{AudioFormat, SampleFormat, SampleRate};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Errors from audio output
+#[derive(Debug, thiserror::Error)]
+pub enum AudioOutputError {
+    #[error("Device not found: {0}")]
+    DeviceNotFound(String),
+
+    #[error("Format not supported: {0:?}")]
+    FormatNotSupported(AudioFormat),
+
+    #[error("Stream error: {0}")]
+    StreamError(String),
+
+    #[error("Device error: {0}")]
+    DeviceError(String),
+
+    #[error("Buffer underrun")]
+    Underrun,
+
+    #[error("Output closed")]
+    Closed,
+}
+
+/// Audio output state
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputState {
+    Stopped,
+    Playing,
+    Paused,
+}
+
+/// Audio device information
+#[derive(Debug, Clone)]
+pub struct AudioDevice {
+    /// Device identifier
+    pub id: String,
+    /// Human-readable name
+    pub name: String,
+    /// Whether this is the default device
+    pub is_default: bool,
+    /// Supported sample rates
+    pub supported_rates: Vec<SampleRate>,
+    /// Supported channel counts
+    pub supported_channels: Vec<u8>,
+}
+
+/// Callback for providing audio data
+pub type AudioCallback = Box<dyn FnMut(&mut [u8]) -> usize + Send + 'static>;
+
+/// Audio output trait
+///
+/// Implementations provide platform-specific audio playback.
+pub trait AudioOutput: Send {
+    /// Get available output devices
+    fn enumerate_devices(&self) -> Result<Vec<AudioDevice>, AudioOutputError>;
+
+    /// Get the default output device
+    fn default_device(&self) -> Result<AudioDevice, AudioOutputError>;
+
+    /// Open output stream with specified format
+    fn open(
+        &mut self,
+        device: Option<&str>,
+        format: AudioFormat,
+    ) -> Result<(), AudioOutputError>;
+
+    /// Start playback with callback
+    ///
+    /// The callback is invoked to fill output buffers.
+    fn start(&mut self, callback: AudioCallback) -> Result<(), AudioOutputError>;
+
+    /// Stop playback
+    fn stop(&mut self) -> Result<(), AudioOutputError>;
+
+    /// Pause playback
+    fn pause(&mut self) -> Result<(), AudioOutputError>;
+
+    /// Resume playback
+    fn resume(&mut self) -> Result<(), AudioOutputError>;
+
+    /// Get current state
+    fn state(&self) -> OutputState;
+
+    /// Set volume (0.0 to 1.0)
+    fn set_volume(&mut self, volume: f32) -> Result<(), AudioOutputError>;
+
+    /// Get current volume
+    fn volume(&self) -> f32;
+
+    /// Get output latency
+    fn latency(&self) -> Duration;
+
+    /// Get the actual format being used
+    fn format(&self) -> Option<AudioFormat>;
+
+    /// Close the output
+    fn close(&mut self) -> Result<(), AudioOutputError>;
+}
+
+/// Create the default audio output for the current platform
+pub fn create_default_output() -> Result<Box<dyn AudioOutput>, AudioOutputError> {
+    #[cfg(feature = "audio-coreaudio")]
+    {
+        return Ok(Box::new(super::output_coreaudio::CoreAudioOutput::new()?));
+    }
+
+    #[cfg(feature = "audio-cpal")]
+    {
+        return Ok(Box::new(super::output_cpal::CpalOutput::new()?));
+    }
+
+    #[cfg(feature = "audio-alsa")]
+    {
+        return Ok(Box::new(super::output_alsa::AlsaOutput::new()?));
+    }
+
+    #[cfg(not(any(feature = "audio-coreaudio", feature = "audio-cpal", feature = "audio-alsa")))]
+    {
+        Err(AudioOutputError::DeviceError(
+            "No audio backend enabled. Enable audio-coreaudio, audio-cpal, or audio-alsa feature.".into()
+        ))
+    }
+}
+```
+
+---
+
+### 42.2 CPAL Backend (Cross-Platform)
+
+- [ ] **42.2.1** Implement CPAL-based audio output
+
+**File:** `src/audio/output_cpal.rs`
+
+```rust
+//! CPAL-based audio output
+//!
+//! Cross-platform audio output using the `cpal` crate.
+//! Works on macOS, Windows, Linux, iOS, Android.
+
+#[cfg(feature = "audio-cpal")]
+mod implementation {
+    use super::super::output::{
+        AudioOutput, AudioOutputError, OutputState, AudioDevice, AudioCallback
+    };
+    use crate::audio::format::{AudioFormat, SampleFormat, SampleRate};
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    pub struct CpalOutput {
+        host: cpal::Host,
+        device: Option<cpal::Device>,
+        stream: Option<cpal::Stream>,
+        state: OutputState,
+        volume: f32,
+        format: Option<AudioFormat>,
+        callback: Arc<Mutex<Option<AudioCallback>>>,
+    }
+
+    impl CpalOutput {
+        pub fn new() -> Result<Self, AudioOutputError> {
+            let host = cpal::default_host();
+
+            Ok(Self {
+                host,
+                device: None,
+                stream: None,
+                state: OutputState::Stopped,
+                volume: 1.0,
+                format: None,
+                callback: Arc::new(Mutex::new(None)),
+            })
+        }
+
+        fn sample_rate_to_cpal(rate: SampleRate) -> cpal::SampleRate {
+            cpal::SampleRate(rate.as_hz())
+        }
+    }
+
+    impl AudioOutput for CpalOutput {
+        fn enumerate_devices(&self) -> Result<Vec<AudioDevice>, AudioOutputError> {
+            let default_name = self.host.default_output_device()
+                .map(|d| d.name().unwrap_or_default());
+
+            let devices = self.host.output_devices()
+                .map_err(|e| AudioOutputError::DeviceError(e.to_string()))?;
+
+            let mut result = Vec::new();
+            for device in devices {
+                let name = device.name().unwrap_or_else(|_| "Unknown".to_string());
+                let is_default = default_name.as_ref() == Some(&name);
+
+                // Get supported configs
+                let mut supported_rates = Vec::new();
+                let mut supported_channels = Vec::new();
+
+                if let Ok(configs) = device.supported_output_configs() {
+                    for config in configs {
+                        // Add min and max sample rates
+                        supported_rates.push(SampleRate::from_hz(config.min_sample_rate().0));
+                        supported_rates.push(SampleRate::from_hz(config.max_sample_rate().0));
+                        supported_channels.push(config.channels() as u8);
+                    }
+                }
+
+                supported_rates.sort();
+                supported_rates.dedup();
+                supported_channels.sort();
+                supported_channels.dedup();
+
+                result.push(AudioDevice {
+                    id: name.clone(),
+                    name,
+                    is_default,
+                    supported_rates,
+                    supported_channels,
+                });
+            }
+
+            Ok(result)
+        }
+
+        fn default_device(&self) -> Result<AudioDevice, AudioOutputError> {
+            let device = self.host.default_output_device()
+                .ok_or_else(|| AudioOutputError::DeviceNotFound("No default device".into()))?;
+
+            let name = device.name().unwrap_or_else(|_| "Default".to_string());
+
+            Ok(AudioDevice {
+                id: name.clone(),
+                name,
+                is_default: true,
+                supported_rates: vec![SampleRate::Hz44100, SampleRate::Hz48000],
+                supported_channels: vec![2],
+            })
+        }
+
+        fn open(
+            &mut self,
+            device_id: Option<&str>,
+            format: AudioFormat,
+        ) -> Result<(), AudioOutputError> {
+            let device = if let Some(id) = device_id {
+                self.host.output_devices()
+                    .map_err(|e| AudioOutputError::DeviceError(e.to_string()))?
+                    .find(|d| d.name().ok().as_deref() == Some(id))
+                    .ok_or_else(|| AudioOutputError::DeviceNotFound(id.to_string()))?
+            } else {
+                self.host.default_output_device()
+                    .ok_or_else(|| AudioOutputError::DeviceNotFound("No default".into()))?
+            };
+
+            self.device = Some(device);
+            self.format = Some(format);
+
+            Ok(())
+        }
+
+        fn start(&mut self, callback: AudioCallback) -> Result<(), AudioOutputError> {
+            let device = self.device.as_ref()
+                .ok_or_else(|| AudioOutputError::DeviceError("No device opened".into()))?;
+
+            let format = self.format
+                .ok_or_else(|| AudioOutputError::DeviceError("No format set".into()))?;
+
+            // Store callback
+            *self.callback.lock().unwrap() = Some(callback);
+            let callback_ref = self.callback.clone();
+            let volume = self.volume;
+
+            // Configure stream
+            let config = cpal::StreamConfig {
+                channels: format.channels as u16,
+                sample_rate: cpal::SampleRate(format.sample_rate.as_hz()),
+                buffer_size: cpal::BufferSize::Default,
+            };
+
+            // Build stream based on sample format
+            let stream = match format.sample_format {
+                SampleFormat::I16 => {
+                    device.build_output_stream(
+                        &config,
+                        move |data: &mut [i16], _: &cpal::OutputCallbackInfo| {
+                            let bytes: &mut [u8] = unsafe {
+                                std::slice::from_raw_parts_mut(
+                                    data.as_mut_ptr() as *mut u8,
+                                    data.len() * 2,
+                                )
+                            };
+
+                            let mut cb = callback_ref.lock().unwrap();
+                            if let Some(ref mut callback) = *cb {
+                                callback(bytes);
+                            }
+
+                            // Apply volume
+                            for sample in data.iter_mut() {
+                                *sample = (*sample as f32 * volume) as i16;
+                            }
+                        },
+                        |err| {
+                            tracing::error!("CPAL stream error: {}", err);
+                        },
+                        None,
+                    )
+                }
+                SampleFormat::F32 => {
+                    device.build_output_stream(
+                        &config,
+                        move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                            let bytes: &mut [u8] = unsafe {
+                                std::slice::from_raw_parts_mut(
+                                    data.as_mut_ptr() as *mut u8,
+                                    data.len() * 4,
+                                )
+                            };
+
+                            let mut cb = callback_ref.lock().unwrap();
+                            if let Some(ref mut callback) = *cb {
+                                callback(bytes);
+                            }
+
+                            // Apply volume
+                            for sample in data.iter_mut() {
+                                *sample *= volume;
+                            }
+                        },
+                        |err| {
+                            tracing::error!("CPAL stream error: {}", err);
+                        },
+                        None,
+                    )
+                }
+                _ => {
+                    return Err(AudioOutputError::FormatNotSupported(format));
+                }
+            }.map_err(|e| AudioOutputError::StreamError(e.to_string()))?;
+
+            stream.play().map_err(|e| AudioOutputError::StreamError(e.to_string()))?;
+
+            self.stream = Some(stream);
+            self.state = OutputState::Playing;
+
+            Ok(())
+        }
+
+        fn stop(&mut self) -> Result<(), AudioOutputError> {
+            if let Some(stream) = self.stream.take() {
+                drop(stream);
+            }
+            self.state = OutputState::Stopped;
+            Ok(())
+        }
+
+        fn pause(&mut self) -> Result<(), AudioOutputError> {
+            if let Some(ref stream) = self.stream {
+                stream.pause().map_err(|e| AudioOutputError::StreamError(e.to_string()))?;
+            }
+            self.state = OutputState::Paused;
+            Ok(())
+        }
+
+        fn resume(&mut self) -> Result<(), AudioOutputError> {
+            if let Some(ref stream) = self.stream {
+                stream.play().map_err(|e| AudioOutputError::StreamError(e.to_string()))?;
+            }
+            self.state = OutputState::Playing;
+            Ok(())
+        }
+
+        fn state(&self) -> OutputState {
+            self.state
+        }
+
+        fn set_volume(&mut self, volume: f32) -> Result<(), AudioOutputError> {
+            self.volume = volume.clamp(0.0, 1.0);
+            Ok(())
+        }
+
+        fn volume(&self) -> f32 {
+            self.volume
+        }
+
+        fn latency(&self) -> Duration {
+            // CPAL doesn't expose latency directly; estimate
+            Duration::from_millis(50)
+        }
+
+        fn format(&self) -> Option<AudioFormat> {
+            self.format
+        }
+
+        fn close(&mut self) -> Result<(), AudioOutputError> {
+            self.stop()
+        }
+    }
+}
+
+#[cfg(feature = "audio-cpal")]
+pub use implementation::CpalOutput;
+```
+
+---
+
+### 42.3 CoreAudio Backend (macOS)
+
+- [ ] **42.3.1** Implement CoreAudio-based output (macOS priority)
+
+**File:** `src/audio/output_coreaudio.rs`
+
+```rust
+//! CoreAudio-based audio output for macOS
+//!
+//! Native macOS audio output for lowest latency and best integration.
+
+#[cfg(all(target_os = "macos", feature = "audio-coreaudio"))]
+mod implementation {
+    use super::super::output::{
+        AudioOutput, AudioOutputError, OutputState, AudioDevice, AudioCallback
+    };
+    use crate::audio::format::{AudioFormat, SampleFormat, SampleRate};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    // Note: This is a skeleton. Full implementation would use coreaudio-rs crate.
+
+    pub struct CoreAudioOutput {
+        state: OutputState,
+        volume: f32,
+        format: Option<AudioFormat>,
+        // Would contain AudioUnit, etc.
+    }
+
+    impl CoreAudioOutput {
+        pub fn new() -> Result<Self, AudioOutputError> {
+            Ok(Self {
+                state: OutputState::Stopped,
+                volume: 1.0,
+                format: None,
+            })
+        }
+    }
+
+    impl AudioOutput for CoreAudioOutput {
+        fn enumerate_devices(&self) -> Result<Vec<AudioDevice>, AudioOutputError> {
+            // Use AudioObjectGetPropertyData to enumerate devices
+            Ok(vec![AudioDevice {
+                id: "default".to_string(),
+                name: "Default Output".to_string(),
+                is_default: true,
+                supported_rates: vec![SampleRate::Hz44100, SampleRate::Hz48000],
+                supported_channels: vec![2],
+            }])
+        }
+
+        fn default_device(&self) -> Result<AudioDevice, AudioOutputError> {
+            Ok(AudioDevice {
+                id: "default".to_string(),
+                name: "Default Output".to_string(),
+                is_default: true,
+                supported_rates: vec![SampleRate::Hz44100, SampleRate::Hz48000],
+                supported_channels: vec![2],
+            })
+        }
+
+        fn open(&mut self, _device: Option<&str>, format: AudioFormat) -> Result<(), AudioOutputError> {
+            self.format = Some(format);
+            // Would configure AudioUnit here
+            Ok(())
+        }
+
+        fn start(&mut self, _callback: AudioCallback) -> Result<(), AudioOutputError> {
+            // Would start AudioUnit
+            self.state = OutputState::Playing;
+            Ok(())
+        }
+
+        fn stop(&mut self) -> Result<(), AudioOutputError> {
+            self.state = OutputState::Stopped;
+            Ok(())
+        }
+
+        fn pause(&mut self) -> Result<(), AudioOutputError> {
+            self.state = OutputState::Paused;
+            Ok(())
+        }
+
+        fn resume(&mut self) -> Result<(), AudioOutputError> {
+            self.state = OutputState::Playing;
+            Ok(())
+        }
+
+        fn state(&self) -> OutputState {
+            self.state
+        }
+
+        fn set_volume(&mut self, volume: f32) -> Result<(), AudioOutputError> {
+            self.volume = volume.clamp(0.0, 1.0);
+            Ok(())
+        }
+
+        fn volume(&self) -> f32 {
+            self.volume
+        }
+
+        fn latency(&self) -> Duration {
+            // CoreAudio typically has very low latency
+            Duration::from_millis(10)
+        }
+
+        fn format(&self) -> Option<AudioFormat> {
+            self.format
+        }
+
+        fn close(&mut self) -> Result<(), AudioOutputError> {
+            self.stop()
+        }
+    }
+}
+
+#[cfg(all(target_os = "macos", feature = "audio-coreaudio"))]
+pub use implementation::CoreAudioOutput;
+```
+
+---
+
+### 42.4 Audio Pipeline Integration
+
+- [ ] **42.4.1** Connect jitter buffer to audio output
+
+**File:** `src/receiver/audio_pipeline.rs`
+
+```rust
+//! Audio pipeline connecting jitter buffer to output
+
+use crate::audio::output::{AudioOutput, AudioOutputError, AudioCallback};
+use crate::audio::jitter::JitterBuffer;
+use crate::audio::format::AudioFormat;
+use crate::receiver::session::AudioCodec;
+use std::sync::{Arc, Mutex};
+
+/// Audio pipeline state
+pub struct AudioPipeline {
+    jitter_buffer: Arc<Mutex<JitterBuffer>>,
+    output: Box<dyn AudioOutput>,
+    decoder: Option<AudioDecoder>,
+    format: AudioFormat,
+}
+
+/// Audio decoder (codec-specific)
+pub enum AudioDecoder {
+    Alac(AlacDecoder),
+    Aac(AacDecoder),
+    Pcm,  // No decoding needed
+}
+
+// Placeholder decoder types
+pub struct AlacDecoder;
+pub struct AacDecoder;
+
+impl AudioPipeline {
+    pub fn new(
+        jitter_buffer: Arc<Mutex<JitterBuffer>>,
+        output: Box<dyn AudioOutput>,
+        codec: AudioCodec,
+        format: AudioFormat,
+    ) -> Result<Self, AudioOutputError> {
+        let decoder = match codec {
+            AudioCodec::Alac => Some(AudioDecoder::Alac(AlacDecoder)),
+            AudioCodec::AacLc | AudioCodec::AacEld => Some(AudioDecoder::Aac(AacDecoder)),
+            AudioCodec::Pcm => Some(AudioDecoder::Pcm),
+        };
+
+        Ok(Self {
+            jitter_buffer,
+            output,
+            decoder,
+            format,
+        })
+    }
+
+    /// Start the audio pipeline
+    pub fn start(&mut self) -> Result<(), AudioOutputError> {
+        self.output.open(None, self.format)?;
+
+        let jitter = self.jitter_buffer.clone();
+
+        let callback: AudioCallback = Box::new(move |buffer: &mut [u8]| {
+            let mut jitter = jitter.lock().unwrap();
+
+            let mut written = 0;
+            while written < buffer.len() {
+                if let Some(packet) = jitter.pop() {
+                    let to_copy = std::cmp::min(
+                        packet.audio_data.len(),
+                        buffer.len() - written
+                    );
+                    buffer[written..written + to_copy]
+                        .copy_from_slice(&packet.audio_data[..to_copy]);
+                    written += to_copy;
+                } else {
+                    // Underrun - fill with silence
+                    for b in buffer[written..].iter_mut() {
+                        *b = 0;
+                    }
+                    break;
+                }
+            }
+
+            written
+        });
+
+        self.output.start(callback)
+    }
+
+    /// Stop the pipeline
+    pub fn stop(&mut self) -> Result<(), AudioOutputError> {
+        self.output.stop()
+    }
+
+    /// Set volume
+    pub fn set_volume(&mut self, volume: f32) -> Result<(), AudioOutputError> {
+        self.output.set_volume(volume)
+    }
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] AudioOutput trait defined with all required methods
+- [ ] CPAL backend compiles and runs on macOS, Linux, Windows
+- [ ] CoreAudio backend skeleton for macOS
+- [ ] Device enumeration works
+- [ ] Format negotiation works
+- [ ] Callback-based playback works
+- [ ] Volume control works
+- [ ] Latency reported accurately
+- [ ] Feature flags gate backends correctly
+- [ ] All unit tests pass
+
+---
+
+## Notes
+
+- **Priority**: CoreAudio for macOS, CPAL as fallback
+- **Latency**: Target under 20ms for good responsiveness
+- **Callback**: Output pulls data from jitter buffer
+- **Format**: Typically 16-bit, 44.1kHz, stereo for RAOP
+- **Volume**: Applied digitally if hardware control unavailable
+
+---
+
+## References
+
+- [cpal crate](https://docs.rs/cpal/)
+- [coreaudio-rs](https://docs.rs/coreaudio/)
+- [ALSA](https://www.alsa-project.org/)

--- a/docs/43-volume-metadata-handling.md
+++ b/docs/43-volume-metadata-handling.md
@@ -1,0 +1,595 @@
+# Section 43: Volume & Metadata Handling
+
+## Dependencies
+- **Section 36**: RTSP Server (SET_PARAMETER handling)
+- **Section 37**: Session Management (session state)
+- **Section 31**: DAAP Metadata (DMAP parsing)
+
+## Overview
+
+This section implements handling for:
+
+1. **Volume Control**: Via RTSP SET_PARAMETER with volume values
+2. **Track Metadata**: Artist, title, album from DMAP/DAAP format
+3. **Album Artwork**: Cover images from RTSP
+4. **Playback Progress**: Track position updates
+
+These features enable rich display of "now playing" information on the receiver.
+
+## Objectives
+
+- Parse volume commands from SET_PARAMETER
+- Map AirPlay dB volume to linear scale
+- Parse DMAP-encoded track metadata
+- Handle artwork (JPEG/PNG) delivery
+- Parse playback progress updates
+- Provide callbacks/events for UI integration
+
+---
+
+## Tasks
+
+### 43.1 Volume Handling
+
+- [ ] **43.1.1** Parse and apply volume from SET_PARAMETER
+
+**File:** `src/receiver/volume_handler.rs`
+
+```rust
+//! Volume handling for AirPlay receiver
+
+use std::str::FromStr;
+
+/// AirPlay volume range
+/// -144.0 dB = silence
+/// 0.0 dB = full volume
+const VOLUME_MIN_DB: f32 = -144.0;
+const VOLUME_MAX_DB: f32 = 0.0;
+
+/// Volume update from SET_PARAMETER
+#[derive(Debug, Clone, Copy)]
+pub struct VolumeUpdate {
+    /// Volume in dB (-144.0 to 0.0)
+    pub db: f32,
+    /// Muted (volume = -144)
+    pub muted: bool,
+    /// Linear volume (0.0 to 1.0)
+    pub linear: f32,
+}
+
+impl VolumeUpdate {
+    /// Create from dB value
+    pub fn from_db(db: f32) -> Self {
+        let db = db.clamp(VOLUME_MIN_DB, VOLUME_MAX_DB);
+        let muted = db <= VOLUME_MIN_DB;
+        let linear = db_to_linear(db);
+
+        Self { db, muted, linear }
+    }
+}
+
+/// Parse volume from SET_PARAMETER body
+///
+/// Format: "volume: -15.000000\r\n"
+pub fn parse_volume_parameter(body: &str) -> Option<VolumeUpdate> {
+    for line in body.lines() {
+        let line = line.trim();
+
+        if let Some(value_str) = line.strip_prefix("volume:") {
+            let value_str = value_str.trim();
+
+            if let Ok(db) = f32::from_str(value_str) {
+                return Some(VolumeUpdate::from_db(db));
+            }
+        }
+    }
+
+    None
+}
+
+/// Convert dB volume to linear (0.0 to 1.0)
+///
+/// Uses power law: linear = 10^(dB/20)
+pub fn db_to_linear(db: f32) -> f32 {
+    if db <= VOLUME_MIN_DB {
+        return 0.0;
+    }
+    if db >= VOLUME_MAX_DB {
+        return 1.0;
+    }
+
+    // Standard dB to linear conversion
+    10.0_f32.powf(db / 20.0)
+}
+
+/// Convert linear volume (0.0 to 1.0) to dB
+pub fn linear_to_db(linear: f32) -> f32 {
+    if linear <= 0.0 {
+        return VOLUME_MIN_DB;
+    }
+    if linear >= 1.0 {
+        return VOLUME_MAX_DB;
+    }
+
+    20.0 * linear.log10()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_volume() {
+        let body = "volume: -15.000000\r\n";
+        let update = parse_volume_parameter(body).unwrap();
+
+        assert!((update.db - -15.0).abs() < 0.01);
+        assert!(!update.muted);
+    }
+
+    #[test]
+    fn test_parse_muted() {
+        let body = "volume: -144.000000\r\n";
+        let update = parse_volume_parameter(body).unwrap();
+
+        assert!(update.muted);
+        assert!(update.linear < 0.001);
+    }
+
+    #[test]
+    fn test_db_to_linear() {
+        assert!((db_to_linear(0.0) - 1.0).abs() < 0.001);
+        assert!((db_to_linear(-20.0) - 0.1).abs() < 0.01);
+        assert!(db_to_linear(-144.0) < 0.001);
+    }
+
+    #[test]
+    fn test_linear_to_db() {
+        assert!((linear_to_db(1.0) - 0.0).abs() < 0.01);
+        assert!((linear_to_db(0.1) - -20.0).abs() < 0.1);
+    }
+}
+```
+
+---
+
+### 43.2 Metadata Parsing
+
+- [ ] **43.2.1** Parse DMAP-encoded track metadata
+
+**File:** `src/receiver/metadata_handler.rs`
+
+```rust
+//! Track metadata handling for AirPlay receiver
+//!
+//! Parses DMAP (Digital Media Access Protocol) encoded metadata
+//! from SET_PARAMETER requests.
+
+use std::collections::HashMap;
+
+/// Track metadata
+#[derive(Debug, Clone, Default)]
+pub struct TrackMetadata {
+    /// Track title
+    pub title: Option<String>,
+    /// Artist name
+    pub artist: Option<String>,
+    /// Album name
+    pub album: Option<String>,
+    /// Genre
+    pub genre: Option<String>,
+    /// Track number
+    pub track_number: Option<u32>,
+    /// Total tracks on album
+    pub track_count: Option<u32>,
+    /// Disc number
+    pub disc_number: Option<u32>,
+    /// Total discs
+    pub disc_count: Option<u32>,
+    /// Duration in milliseconds
+    pub duration_ms: Option<u32>,
+}
+
+/// DMAP tag codes for metadata
+mod dmap_tags {
+    pub const ITEM_NAME: &[u8] = b"minm";        // Title
+    pub const ITEM_ARTIST: &[u8] = b"asar";      // Artist
+    pub const ITEM_ALBUM: &[u8] = b"asal";       // Album
+    pub const ITEM_GENRE: &[u8] = b"asgn";       // Genre
+    pub const TRACK_NUMBER: &[u8] = b"astn";     // Track number
+    pub const TRACK_COUNT: &[u8] = b"astc";      // Track count
+    pub const DISC_NUMBER: &[u8] = b"asdn";      // Disc number
+    pub const DISC_COUNT: &[u8] = b"asdc";       // Disc count
+    pub const DURATION: &[u8] = b"astm";         // Duration (ms)
+}
+
+/// Parse DMAP metadata from binary data
+pub fn parse_dmap_metadata(data: &[u8]) -> Result<TrackMetadata, MetadataError> {
+    let mut metadata = TrackMetadata::default();
+    let mut offset = 0;
+
+    while offset + 8 <= data.len() {
+        // DMAP format: 4-byte tag, 4-byte length, data
+        let tag = &data[offset..offset + 4];
+        let length = u32::from_be_bytes([
+            data[offset + 4],
+            data[offset + 5],
+            data[offset + 6],
+            data[offset + 7],
+        ]) as usize;
+
+        offset += 8;
+
+        if offset + length > data.len() {
+            break;
+        }
+
+        let value = &data[offset..offset + length];
+        offset += length;
+
+        // Parse based on tag
+        match tag {
+            t if t == dmap_tags::ITEM_NAME => {
+                metadata.title = Some(String::from_utf8_lossy(value).into_owned());
+            }
+            t if t == dmap_tags::ITEM_ARTIST => {
+                metadata.artist = Some(String::from_utf8_lossy(value).into_owned());
+            }
+            t if t == dmap_tags::ITEM_ALBUM => {
+                metadata.album = Some(String::from_utf8_lossy(value).into_owned());
+            }
+            t if t == dmap_tags::ITEM_GENRE => {
+                metadata.genre = Some(String::from_utf8_lossy(value).into_owned());
+            }
+            t if t == dmap_tags::TRACK_NUMBER && length >= 4 => {
+                metadata.track_number = Some(u32::from_be_bytes([
+                    value[0], value[1], value[2], value[3]
+                ]));
+            }
+            t if t == dmap_tags::TRACK_COUNT && length >= 4 => {
+                metadata.track_count = Some(u32::from_be_bytes([
+                    value[0], value[1], value[2], value[3]
+                ]));
+            }
+            t if t == dmap_tags::DISC_NUMBER && length >= 4 => {
+                metadata.disc_number = Some(u32::from_be_bytes([
+                    value[0], value[1], value[2], value[3]
+                ]));
+            }
+            t if t == dmap_tags::DISC_COUNT && length >= 4 => {
+                metadata.disc_count = Some(u32::from_be_bytes([
+                    value[0], value[1], value[2], value[3]
+                ]));
+            }
+            t if t == dmap_tags::DURATION && length >= 4 => {
+                metadata.duration_ms = Some(u32::from_be_bytes([
+                    value[0], value[1], value[2], value[3]
+                ]));
+            }
+            _ => {
+                // Unknown tag, skip
+            }
+        }
+    }
+
+    Ok(metadata)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MetadataError {
+    #[error("Invalid DMAP format")]
+    InvalidFormat,
+
+    #[error("Incomplete data")]
+    IncompleteData,
+}
+```
+
+---
+
+### 43.3 Artwork Handling
+
+- [ ] **43.3.1** Parse and store album artwork
+
+**File:** `src/receiver/artwork_handler.rs`
+
+```rust
+//! Album artwork handling
+
+/// Album artwork
+#[derive(Debug, Clone)]
+pub struct Artwork {
+    /// Image data (JPEG or PNG)
+    pub data: Vec<u8>,
+    /// MIME type
+    pub mime_type: String,
+    /// Width (if known)
+    pub width: Option<u32>,
+    /// Height (if known)
+    pub height: Option<u32>,
+}
+
+impl Artwork {
+    /// Create from raw image data
+    pub fn from_data(data: Vec<u8>) -> Option<Self> {
+        let mime_type = detect_image_type(&data)?;
+
+        Some(Self {
+            data,
+            mime_type,
+            width: None,
+            height: None,
+        })
+    }
+
+    /// Check if artwork is JPEG
+    pub fn is_jpeg(&self) -> bool {
+        self.mime_type == "image/jpeg"
+    }
+
+    /// Check if artwork is PNG
+    pub fn is_png(&self) -> bool {
+        self.mime_type == "image/png"
+    }
+}
+
+/// Detect image type from magic bytes
+fn detect_image_type(data: &[u8]) -> Option<String> {
+    if data.len() < 4 {
+        return None;
+    }
+
+    // JPEG: starts with FF D8 FF
+    if data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF {
+        return Some("image/jpeg".to_string());
+    }
+
+    // PNG: starts with 89 50 4E 47
+    if data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47 {
+        return Some("image/png".to_string());
+    }
+
+    None
+}
+
+/// Parse artwork from SET_PARAMETER body
+pub fn parse_artwork(content_type: &str, data: &[u8]) -> Option<Artwork> {
+    if content_type.contains("image/jpeg") || content_type.contains("image/png") {
+        Artwork::from_data(data.to_vec())
+    } else {
+        None
+    }
+}
+```
+
+---
+
+### 43.4 Progress Updates
+
+- [ ] **43.4.1** Parse playback progress
+
+**File:** `src/receiver/progress_handler.rs`
+
+```rust
+//! Playback progress handling
+
+use std::time::Duration;
+
+/// Playback progress update
+#[derive(Debug, Clone, Copy)]
+pub struct PlaybackProgress {
+    /// Start position in seconds
+    pub start: f64,
+    /// Current position in seconds
+    pub current: f64,
+    /// End position (duration) in seconds
+    pub end: f64,
+}
+
+impl PlaybackProgress {
+    /// Get current position as Duration
+    pub fn position(&self) -> Duration {
+        Duration::from_secs_f64(self.current)
+    }
+
+    /// Get total duration
+    pub fn duration(&self) -> Duration {
+        Duration::from_secs_f64(self.end)
+    }
+
+    /// Get progress as percentage (0.0 to 1.0)
+    pub fn percentage(&self) -> f64 {
+        if self.end <= 0.0 {
+            return 0.0;
+        }
+        (self.current / self.end).clamp(0.0, 1.0)
+    }
+
+    /// Get remaining time
+    pub fn remaining(&self) -> Duration {
+        Duration::from_secs_f64((self.end - self.current).max(0.0))
+    }
+}
+
+/// Parse progress from SET_PARAMETER body
+///
+/// Format: "progress: start/current/end\r\n"
+/// Values are in seconds (can be floating point)
+pub fn parse_progress(body: &str) -> Option<PlaybackProgress> {
+    for line in body.lines() {
+        let line = line.trim();
+
+        if let Some(value) = line.strip_prefix("progress:") {
+            let parts: Vec<&str> = value.trim().split('/').collect();
+
+            if parts.len() == 3 {
+                let start: f64 = parts[0].parse().ok()?;
+                let current: f64 = parts[1].parse().ok()?;
+                let end: f64 = parts[2].parse().ok()?;
+
+                return Some(PlaybackProgress { start, current, end });
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_progress() {
+        let body = "progress: 0.0/30.5/180.0\r\n";
+        let progress = parse_progress(body).unwrap();
+
+        assert!((progress.start - 0.0).abs() < 0.01);
+        assert!((progress.current - 30.5).abs() < 0.01);
+        assert!((progress.end - 180.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_progress_percentage() {
+        let progress = PlaybackProgress {
+            start: 0.0,
+            current: 60.0,
+            end: 120.0,
+        };
+
+        assert!((progress.percentage() - 0.5).abs() < 0.01);
+    }
+}
+```
+
+---
+
+### 43.5 SET_PARAMETER Router
+
+- [ ] **43.5.1** Route SET_PARAMETER to appropriate handler
+
+**File:** `src/receiver/set_parameter_handler.rs`
+
+```rust
+//! SET_PARAMETER request routing
+
+use crate::protocol::rtsp::RtspRequest;
+use super::volume_handler::{parse_volume_parameter, VolumeUpdate};
+use super::metadata_handler::{parse_dmap_metadata, TrackMetadata};
+use super::artwork_handler::{parse_artwork, Artwork};
+use super::progress_handler::{parse_progress, PlaybackProgress};
+
+/// Result of processing SET_PARAMETER
+#[derive(Debug)]
+pub enum ParameterUpdate {
+    Volume(VolumeUpdate),
+    Metadata(TrackMetadata),
+    Artwork(Artwork),
+    Progress(PlaybackProgress),
+    Unknown(String),
+}
+
+/// Process SET_PARAMETER request
+pub fn process_set_parameter(request: &RtspRequest) -> Vec<ParameterUpdate> {
+    let mut updates = Vec::new();
+
+    let content_type = request.headers.get("Content-Type")
+        .map(|s| s.as_str())
+        .unwrap_or("");
+
+    let body = &request.body;
+    let body_str = String::from_utf8_lossy(body);
+
+    // Route based on content type
+    if content_type.contains("text/parameters") {
+        // Text parameters (volume, progress)
+        if let Some(volume) = parse_volume_parameter(&body_str) {
+            updates.push(ParameterUpdate::Volume(volume));
+        }
+
+        if let Some(progress) = parse_progress(&body_str) {
+            updates.push(ParameterUpdate::Progress(progress));
+        }
+    } else if content_type.contains("application/x-dmap-tagged") {
+        // DMAP metadata
+        if let Ok(metadata) = parse_dmap_metadata(body) {
+            updates.push(ParameterUpdate::Metadata(metadata));
+        }
+    } else if content_type.contains("image/") {
+        // Artwork
+        if let Some(artwork) = parse_artwork(content_type, body) {
+            updates.push(ParameterUpdate::Artwork(artwork));
+        }
+    } else if !content_type.is_empty() {
+        updates.push(ParameterUpdate::Unknown(content_type.to_string()));
+    }
+
+    updates
+}
+```
+
+---
+
+## Unit Tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dmap_metadata_parsing() {
+        // Construct minimal DMAP data
+        // "minm" + length(5) + "Hello"
+        let mut data = Vec::new();
+        data.extend_from_slice(b"minm");
+        data.extend_from_slice(&5u32.to_be_bytes());
+        data.extend_from_slice(b"Hello");
+
+        let metadata = parse_dmap_metadata(&data).unwrap();
+        assert_eq!(metadata.title, Some("Hello".to_string()));
+    }
+
+    #[test]
+    fn test_artwork_detection() {
+        // JPEG magic bytes
+        let jpeg_data = vec![0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
+        let artwork = Artwork::from_data(jpeg_data).unwrap();
+        assert!(artwork.is_jpeg());
+
+        // PNG magic bytes
+        let png_data = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A];
+        let artwork = Artwork::from_data(png_data).unwrap();
+        assert!(artwork.is_png());
+    }
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Volume parsing works for all valid dB values
+- [ ] dB to linear conversion accurate
+- [ ] DMAP metadata parsing extracts all fields
+- [ ] Artwork detection works for JPEG and PNG
+- [ ] Progress parsing works with floating point values
+- [ ] SET_PARAMETER routing selects correct handler
+- [ ] All unit tests pass
+
+---
+
+## Notes
+
+- **Volume range**: -144 to 0 dB (AirPlay standard)
+- **Metadata**: Not all fields always present; handle gracefully
+- **Artwork**: Can be large (several MB); consider memory management
+- **Progress**: Updates may come frequently; debounce for UI
+- **Password**: Future section will add authentication hooks
+
+---
+
+## References
+
+- [DMAP Protocol](https://daap.sourceforge.net/)
+- [AirPlay Volume](https://nto.github.io/AirPlay.html#audio-volume)

--- a/docs/44-receiver-integration.md
+++ b/docs/44-receiver-integration.md
@@ -1,0 +1,754 @@
+# Section 44: Receiver Integration
+
+## Dependencies
+- **All previous receiver sections (35-43)**
+- **Section 34**: Receiver Overview (architecture)
+
+## Overview
+
+This section integrates all receiver components into a cohesive `AirPlayReceiver` high-level API. It wires together:
+
+- Service advertisement (Section 35)
+- RTSP server (Section 36)
+- Session management (Section 37)
+- SDP parsing (Section 38)
+- RTP reception (Section 39)
+- Timing sync (Section 40)
+- Jitter buffer (Section 41)
+- Audio output (Section 42)
+- Volume/metadata (Section 43)
+
+The result is a simple, event-driven receiver that can be started with a few lines of code.
+
+## Objectives
+
+- Create `AirPlayReceiver` public API
+- Wire all components together
+- Provide event-based callbacks for UI integration
+- Handle lifecycle (start, stop, reconnect)
+- Support configuration customization
+- Ensure clean shutdown and resource cleanup
+
+---
+
+## Tasks
+
+### 44.1 Receiver Configuration
+
+- [ ] **44.1.1** Define comprehensive configuration
+
+**File:** `src/receiver/config.rs`
+
+```rust
+//! AirPlay receiver configuration
+
+use std::time::Duration;
+use crate::discovery::advertiser::RaopCapabilities;
+
+/// Receiver configuration
+#[derive(Debug, Clone)]
+pub struct ReceiverConfig {
+    /// Device name shown to senders
+    pub name: String,
+
+    /// RTSP listen port (0 = auto-assign)
+    pub port: u16,
+
+    /// Receiver capabilities
+    pub capabilities: RaopCapabilities,
+
+    /// Session timeout
+    pub session_timeout: Duration,
+
+    /// Allow session preemption
+    pub allow_preemption: bool,
+
+    /// Target audio latency in milliseconds
+    pub latency_ms: u32,
+
+    /// Jitter buffer configuration
+    pub jitter_buffer_depth: usize,
+
+    /// Audio output device (None = default)
+    pub audio_device: Option<String>,
+
+    /// Initial volume (0.0 to 1.0)
+    pub initial_volume: f32,
+
+    /// Enable debug logging
+    pub debug: bool,
+}
+
+impl Default for ReceiverConfig {
+    fn default() -> Self {
+        Self {
+            name: "AirPlay Receiver".to_string(),
+            port: 5000,
+            capabilities: RaopCapabilities::default(),
+            session_timeout: Duration::from_secs(60),
+            allow_preemption: true,
+            latency_ms: 2000,
+            jitter_buffer_depth: 50,
+            audio_device: None,
+            initial_volume: 1.0,
+            debug: false,
+        }
+    }
+}
+
+impl ReceiverConfig {
+    /// Create with custom name
+    pub fn with_name(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Set port
+    pub fn port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+
+    /// Set latency
+    pub fn latency_ms(mut self, ms: u32) -> Self {
+        self.latency_ms = ms;
+        self
+    }
+
+    /// Set audio device
+    pub fn audio_device(mut self, device: impl Into<String>) -> Self {
+        self.audio_device = Some(device.into());
+        self
+    }
+}
+```
+
+---
+
+### 44.2 Receiver Events
+
+- [ ] **44.2.1** Define event types for callbacks
+
+**File:** `src/receiver/events.rs`
+
+```rust
+//! Receiver events for UI and application integration
+
+use std::net::SocketAddr;
+use super::metadata_handler::TrackMetadata;
+use super::artwork_handler::Artwork;
+use super::progress_handler::PlaybackProgress;
+use super::session::SessionState;
+
+/// Events emitted by the receiver
+#[derive(Debug, Clone)]
+pub enum ReceiverEvent {
+    /// Receiver started and advertising
+    Started {
+        name: String,
+        port: u16,
+    },
+
+    /// Receiver stopped
+    Stopped,
+
+    /// Client connected
+    ClientConnected {
+        address: SocketAddr,
+        user_agent: Option<String>,
+    },
+
+    /// Client disconnected
+    ClientDisconnected {
+        address: SocketAddr,
+        reason: String,
+    },
+
+    /// Playback started
+    PlaybackStarted,
+
+    /// Playback paused
+    PlaybackPaused,
+
+    /// Playback stopped
+    PlaybackStopped,
+
+    /// Volume changed
+    VolumeChanged {
+        /// Volume in dB (-144 to 0)
+        db: f32,
+        /// Linear volume (0.0 to 1.0)
+        linear: f32,
+        /// Is muted
+        muted: bool,
+    },
+
+    /// Track metadata updated
+    MetadataUpdated(TrackMetadata),
+
+    /// Artwork updated
+    ArtworkUpdated(Artwork),
+
+    /// Progress updated
+    ProgressUpdated(PlaybackProgress),
+
+    /// Buffer status changed
+    BufferStatus {
+        /// Buffer fill percentage
+        fill: f64,
+        /// Is underrunning
+        underrun: bool,
+    },
+
+    /// Error occurred
+    Error {
+        message: String,
+        recoverable: bool,
+    },
+}
+
+/// Callback type for receiver events
+pub type EventCallback = Box<dyn Fn(ReceiverEvent) + Send + Sync + 'static>;
+```
+
+---
+
+### 44.3 Main Receiver Struct
+
+- [ ] **44.3.1** Implement AirPlayReceiver
+
+**File:** `src/receiver/server.rs`
+
+```rust
+//! Main AirPlay receiver implementation
+
+use super::config::ReceiverConfig;
+use super::events::{ReceiverEvent, EventCallback};
+use super::session_manager::{SessionManager, SessionManagerConfig, SessionEvent};
+use super::rtp_receiver::AudioPacket;
+use super::timing::TimingHandler;
+use super::receiver_manager::ReceiverManager;
+use crate::discovery::advertiser::{AsyncRaopAdvertiser, AdvertiserConfig};
+use crate::protocol::rtsp::{RtspServerCodec, RtspRequest};
+use crate::protocol::sdp::raop::extract_stream_parameters;
+use crate::audio::jitter::{JitterBuffer, JitterBufferConfig};
+use crate::audio::output::{create_default_output, AudioOutput};
+use crate::audio::format::AudioFormat;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::{TcpListener, TcpStream, UdpSocket};
+use tokio::sync::{broadcast, mpsc, RwLock, Mutex};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// AirPlay 1 receiver
+pub struct AirPlayReceiver {
+    config: ReceiverConfig,
+    state: Arc<RwLock<ReceiverState>>,
+    event_tx: broadcast::Sender<ReceiverEvent>,
+    shutdown_tx: Option<mpsc::Sender<()>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReceiverState {
+    Stopped,
+    Starting,
+    Running,
+    Stopping,
+}
+
+impl AirPlayReceiver {
+    /// Create a new receiver with configuration
+    pub fn new(config: ReceiverConfig) -> Self {
+        let (event_tx, _) = broadcast::channel(64);
+
+        Self {
+            config,
+            state: Arc::new(RwLock::new(ReceiverState::Stopped)),
+            event_tx,
+            shutdown_tx: None,
+        }
+    }
+
+    /// Create with default configuration
+    pub fn with_name(name: impl Into<String>) -> Self {
+        Self::new(ReceiverConfig::with_name(name))
+    }
+
+    /// Subscribe to events
+    pub fn subscribe(&self) -> broadcast::Receiver<ReceiverEvent> {
+        self.event_tx.subscribe()
+    }
+
+    /// Get current state
+    pub async fn state(&self) -> ReceiverState {
+        *self.state.read().await
+    }
+
+    /// Start the receiver
+    pub async fn start(&mut self) -> Result<(), ReceiverError> {
+        {
+            let mut state = self.state.write().await;
+            if *state != ReceiverState::Stopped {
+                return Err(ReceiverError::AlreadyRunning);
+            }
+            *state = ReceiverState::Starting;
+        }
+
+        // Create shutdown channel
+        let (shutdown_tx, mut shutdown_rx) = mpsc::channel(1);
+        self.shutdown_tx = Some(shutdown_tx);
+
+        // Start mDNS advertisement
+        let advertiser_config = AdvertiserConfig {
+            name: self.config.name.clone(),
+            port: self.config.port,
+            capabilities: self.config.capabilities.clone(),
+            ..Default::default()
+        };
+
+        let advertiser = AsyncRaopAdvertiser::start(advertiser_config).await
+            .map_err(|e| ReceiverError::Advertisement(e.to_string()))?;
+
+        // Start TCP listener
+        let listener = TcpListener::bind(format!("0.0.0.0:{}", self.config.port)).await
+            .map_err(|e| ReceiverError::Network(e.to_string()))?;
+
+        let actual_port = listener.local_addr()?.port();
+
+        // Create session manager
+        let session_manager = Arc::new(SessionManager::new(SessionManagerConfig {
+            idle_timeout: self.config.session_timeout,
+            preemption_policy: if self.config.allow_preemption {
+                super::session_manager::PreemptionPolicy::AllowPreempt
+            } else {
+                super::session_manager::PreemptionPolicy::Reject
+            },
+            ..Default::default()
+        }));
+
+        // Emit started event
+        let _ = self.event_tx.send(ReceiverEvent::Started {
+            name: self.config.name.clone(),
+            port: actual_port,
+        });
+
+        *self.state.write().await = ReceiverState::Running;
+
+        // Clone for async task
+        let event_tx = self.event_tx.clone();
+        let state = self.state.clone();
+        let config = self.config.clone();
+
+        // Main server loop
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    result = listener.accept() => {
+                        match result {
+                            Ok((stream, addr)) => {
+                                let session_manager = session_manager.clone();
+                                let event_tx = event_tx.clone();
+                                let config = config.clone();
+
+                                tokio::spawn(async move {
+                                    if let Err(e) = handle_connection(
+                                        stream,
+                                        addr,
+                                        session_manager,
+                                        event_tx,
+                                        config,
+                                    ).await {
+                                        tracing::error!("Connection error: {}", e);
+                                    }
+                                });
+                            }
+                            Err(e) => {
+                                tracing::error!("Accept error: {}", e);
+                            }
+                        }
+                    }
+                    _ = shutdown_rx.recv() => {
+                        break;
+                    }
+                }
+            }
+
+            // Cleanup
+            advertiser.shutdown().await;
+            *state.write().await = ReceiverState::Stopped;
+            let _ = event_tx.send(ReceiverEvent::Stopped);
+        });
+
+        Ok(())
+    }
+
+    /// Stop the receiver
+    pub async fn stop(&mut self) -> Result<(), ReceiverError> {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(()).await;
+            *self.state.write().await = ReceiverState::Stopping;
+        }
+        Ok(())
+    }
+}
+
+/// Handle a single client connection
+async fn handle_connection(
+    mut stream: TcpStream,
+    addr: SocketAddr,
+    session_manager: Arc<SessionManager>,
+    event_tx: broadcast::Sender<ReceiverEvent>,
+    config: ReceiverConfig,
+) -> Result<(), ReceiverError> {
+    let _ = event_tx.send(ReceiverEvent::ClientConnected {
+        address: addr,
+        user_agent: None,
+    });
+
+    // Start session
+    let session_id = session_manager.start_session(addr).await
+        .map_err(|e| ReceiverError::Session(e.to_string()))?;
+
+    let mut codec = RtspServerCodec::new();
+    let mut buf = vec![0u8; 4096];
+
+    loop {
+        let n = match stream.read(&mut buf).await {
+            Ok(0) => break,  // Connection closed
+            Ok(n) => n,
+            Err(e) => {
+                tracing::error!("Read error: {}", e);
+                break;
+            }
+        };
+
+        codec.feed(&buf[..n]);
+
+        while let Ok(Some(request)) = codec.decode() {
+            // Process request
+            let result = crate::receiver::rtsp_handler::handle_request(
+                &request,
+                &session_manager,
+            );
+
+            // Send response
+            if stream.write_all(&result.response).await.is_err() {
+                break;
+            }
+
+            // Handle state changes
+            if let Some(new_state) = result.new_state {
+                let _ = session_manager.update_state(new_state).await;
+
+                match new_state {
+                    super::session::SessionState::Streaming => {
+                        let _ = event_tx.send(ReceiverEvent::PlaybackStarted);
+                    }
+                    super::session::SessionState::Paused => {
+                        let _ = event_tx.send(ReceiverEvent::PlaybackPaused);
+                    }
+                    super::session::SessionState::Teardown => {
+                        let _ = event_tx.send(ReceiverEvent::PlaybackStopped);
+                    }
+                    _ => {}
+                }
+            }
+
+            if result.stop_streaming {
+                break;
+            }
+        }
+    }
+
+    // Cleanup
+    session_manager.end_session("Connection closed").await;
+    let _ = event_tx.send(ReceiverEvent::ClientDisconnected {
+        address: addr,
+        reason: "Connection closed".to_string(),
+    });
+
+    Ok(())
+}
+
+/// Receiver errors
+#[derive(Debug, thiserror::Error)]
+pub enum ReceiverError {
+    #[error("Receiver already running")]
+    AlreadyRunning,
+
+    #[error("Advertisement error: {0}")]
+    Advertisement(String),
+
+    #[error("Network error: {0}")]
+    Network(String),
+
+    #[error("Session error: {0}")]
+    Session(String),
+
+    #[error("Audio error: {0}")]
+    Audio(String),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+```
+
+---
+
+### 44.4 Public API
+
+- [ ] **44.4.1** Export receiver in library
+
+**File:** `src/receiver/mod.rs`
+
+```rust
+//! AirPlay 1 receiver implementation
+//!
+//! This module provides a complete AirPlay 1 (RAOP) receiver that can:
+//! - Advertise on the local network
+//! - Accept connections from AirPlay senders
+//! - Receive and play audio streams
+//! - Display track metadata and artwork
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use airplay2::receiver::{AirPlayReceiver, ReceiverConfig};
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     // Create receiver
+//!     let config = ReceiverConfig::with_name("Living Room Speaker");
+//!     let mut receiver = AirPlayReceiver::new(config);
+//!
+//!     // Subscribe to events
+//!     let mut events = receiver.subscribe();
+//!     tokio::spawn(async move {
+//!         while let Ok(event) = events.recv().await {
+//!             println!("Event: {:?}", event);
+//!         }
+//!     });
+//!
+//!     // Start receiver
+//!     receiver.start().await?;
+//!
+//!     // Keep running...
+//!     tokio::signal::ctrl_c().await?;
+//!
+//!     receiver.stop().await?;
+//!     Ok(())
+//! }
+//! ```
+
+mod config;
+mod events;
+mod server;
+mod session;
+mod session_manager;
+mod rtsp_handler;
+mod rtp_receiver;
+mod control_receiver;
+mod timing;
+mod playback_timing;
+mod receiver_manager;
+mod sequence_tracker;
+mod volume_handler;
+mod metadata_handler;
+mod artwork_handler;
+mod progress_handler;
+mod set_parameter_handler;
+mod announce_handler;
+
+// Public exports
+pub use config::ReceiverConfig;
+pub use events::{ReceiverEvent, EventCallback};
+pub use server::{AirPlayReceiver, ReceiverState, ReceiverError};
+pub use session::{SessionState, StreamParameters, AudioCodec};
+pub use metadata_handler::TrackMetadata;
+pub use artwork_handler::Artwork;
+pub use progress_handler::PlaybackProgress;
+pub use volume_handler::VolumeUpdate;
+```
+
+---
+
+## Unit Tests
+
+### 44.5 Unit Tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_receiver_creation() {
+        let config = ReceiverConfig::with_name("Test Receiver");
+        let receiver = AirPlayReceiver::new(config);
+
+        assert_eq!(receiver.state().await, ReceiverState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn test_receiver_config_builder() {
+        let config = ReceiverConfig::with_name("Kitchen")
+            .port(5001)
+            .latency_ms(1500);
+
+        assert_eq!(config.name, "Kitchen");
+        assert_eq!(config.port, 5001);
+        assert_eq!(config.latency_ms, 1500);
+    }
+
+    #[tokio::test]
+    async fn test_event_subscription() {
+        let config = ReceiverConfig::default();
+        let receiver = AirPlayReceiver::new(config);
+
+        let mut events = receiver.subscribe();
+
+        // Events should be receivable (even if none sent yet)
+        assert!(events.try_recv().is_err());  // Empty
+    }
+}
+```
+
+---
+
+## Integration Tests
+
+**File:** `tests/receiver/integration_tests.rs`
+
+```rust
+use airplay2::receiver::{AirPlayReceiver, ReceiverConfig, ReceiverEvent};
+use std::time::Duration;
+
+#[tokio::test]
+async fn test_receiver_start_stop() {
+    let config = ReceiverConfig::with_name("Integration Test")
+        .port(0);  // Auto-assign port
+
+    let mut receiver = AirPlayReceiver::new(config);
+    let mut events = receiver.subscribe();
+
+    // Start
+    receiver.start().await.unwrap();
+
+    // Wait for started event
+    let event = tokio::time::timeout(
+        Duration::from_secs(5),
+        events.recv()
+    ).await.unwrap().unwrap();
+
+    assert!(matches!(event, ReceiverEvent::Started { .. }));
+
+    // Stop
+    receiver.stop().await.unwrap();
+
+    // Wait for stopped event
+    tokio::time::sleep(Duration::from_millis(100)).await;
+}
+```
+
+---
+
+## Example Application
+
+**File:** `examples/receiver.rs`
+
+```rust
+//! Simple AirPlay receiver example
+
+use airplay2::receiver::{AirPlayReceiver, ReceiverConfig, ReceiverEvent};
+use tracing_subscriber;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Setup logging
+    tracing_subscriber::fmt::init();
+
+    // Create receiver with custom name
+    let config = ReceiverConfig::with_name("Rust AirPlay Receiver")
+        .latency_ms(2000);
+
+    let mut receiver = AirPlayReceiver::new(config);
+
+    // Handle events
+    let mut events = receiver.subscribe();
+    tokio::spawn(async move {
+        while let Ok(event) = events.recv().await {
+            match event {
+                ReceiverEvent::Started { name, port } => {
+                    println!("Receiver '{}' started on port {}", name, port);
+                }
+                ReceiverEvent::ClientConnected { address, .. } => {
+                    println!("Client connected from {}", address);
+                }
+                ReceiverEvent::PlaybackStarted => {
+                    println!("Playback started!");
+                }
+                ReceiverEvent::VolumeChanged { linear, muted, .. } => {
+                    if muted {
+                        println!("Muted");
+                    } else {
+                        println!("Volume: {:.0}%", linear * 100.0);
+                    }
+                }
+                ReceiverEvent::MetadataUpdated(meta) => {
+                    if let (Some(title), Some(artist)) = (&meta.title, &meta.artist) {
+                        println!("Now playing: {} - {}", artist, title);
+                    }
+                }
+                _ => {}
+            }
+        }
+    });
+
+    // Start receiver
+    receiver.start().await?;
+    println!("Receiver running. Press Ctrl+C to stop.");
+
+    // Wait for shutdown signal
+    tokio::signal::ctrl_c().await?;
+
+    // Cleanup
+    receiver.stop().await?;
+    println!("Receiver stopped.");
+
+    Ok(())
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] AirPlayReceiver starts and advertises on network
+- [ ] Clients can discover receiver via mDNS
+- [ ] RTSP connections accepted and handled
+- [ ] Audio streams played through output device
+- [ ] Events emitted for all state changes
+- [ ] Clean shutdown with resource cleanup
+- [ ] Configuration options work correctly
+- [ ] Example application runs successfully
+- [ ] All unit tests pass
+- [ ] Integration tests pass
+
+---
+
+## Notes
+
+- **Event-driven**: All UI integration via events
+- **Async**: Fully async with Tokio
+- **Clean shutdown**: Proper resource cleanup
+- **Extensibility**: Easy to add new event types
+- **Thread-safe**: All state behind Arc<RwLock>
+
+---
+
+## References
+
+- [shairport-sync architecture](https://github.com/mikebrady/shairport-sync)

--- a/docs/45-receiver-testing-infrastructure.md
+++ b/docs/45-receiver-testing-infrastructure.md
@@ -1,0 +1,1004 @@
+# Section 45: Receiver Testing Infrastructure
+
+## Dependencies
+- **All receiver sections (34-44)**: Components to test
+- **Section 20**: Mock Server (testing patterns)
+- **Section 33**: AirPlay 1 Testing (client testing patterns)
+
+## Overview
+
+Testing is **critical** for the receiver implementation. This section provides comprehensive testing infrastructure including:
+
+1. **Mock AirPlay Sender**: Simulates iTunes/iOS sending audio
+2. **Protocol Conformance Tests**: Verify RTSP/RTP behavior
+3. **Network Simulation**: Packet loss, jitter, reordering
+4. **Reference Comparison**: Compare with shairport-sync
+5. **Interoperability Tests**: Real sender compatibility
+6. **Performance Benchmarks**: Latency, throughput
+
+## Objectives
+
+- Build mock AirPlay sender for automated testing
+- Create comprehensive protocol test suites
+- Implement network condition simulation
+- Document manual interoperability testing
+- Provide performance benchmarks
+- Ensure CI/CD integration
+
+---
+
+## Tasks
+
+### 45.1 Mock AirPlay Sender
+
+- [ ] **45.1.1** Implement mock sender for testing receiver
+
+**File:** `src/testing/mock_sender.rs`
+
+```rust
+//! Mock AirPlay sender for testing the receiver
+//!
+//! Simulates an AirPlay sender (like iTunes) to test receiver functionality
+//! without requiring real hardware or software.
+
+use crate::protocol::rtsp::{RtspResponse, RtspCodec, Method, Headers};
+use crate::protocol::rtp::RtpPacket;
+use crate::protocol::sdp::encoder::SdpBuilder;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::{TcpStream, UdpSocket};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::Mutex;
+
+/// Mock sender configuration
+#[derive(Debug, Clone)]
+pub struct MockSenderConfig {
+    /// Receiver address to connect to
+    pub receiver_addr: SocketAddr,
+    /// Audio codec to use
+    pub codec: MockCodec,
+    /// Enable encryption
+    pub encrypted: bool,
+    /// Sample rate
+    pub sample_rate: u32,
+    /// Frames per packet
+    pub frames_per_packet: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum MockCodec {
+    Alac,
+    Pcm,
+    Aac,
+}
+
+impl Default for MockSenderConfig {
+    fn default() -> Self {
+        Self {
+            receiver_addr: "127.0.0.1:5000".parse().unwrap(),
+            codec: MockCodec::Alac,
+            encrypted: false,
+            sample_rate: 44100,
+            frames_per_packet: 352,
+        }
+    }
+}
+
+/// Mock AirPlay sender
+pub struct MockSender {
+    config: MockSenderConfig,
+    rtsp_stream: Option<TcpStream>,
+    audio_socket: Option<UdpSocket>,
+    control_socket: Option<UdpSocket>,
+    timing_socket: Option<UdpSocket>,
+    cseq: u32,
+    session_id: Option<String>,
+    server_ports: Option<ServerPorts>,
+    sequence: u16,
+    timestamp: u32,
+}
+
+#[derive(Debug, Clone)]
+struct ServerPorts {
+    audio: u16,
+    control: u16,
+    timing: u16,
+}
+
+impl MockSender {
+    pub fn new(config: MockSenderConfig) -> Self {
+        Self {
+            config,
+            rtsp_stream: None,
+            audio_socket: None,
+            control_socket: None,
+            timing_socket: None,
+            cseq: 0,
+            session_id: None,
+            server_ports: None,
+            sequence: 0,
+            timestamp: 0,
+        }
+    }
+
+    /// Connect to receiver
+    pub async fn connect(&mut self) -> Result<(), MockSenderError> {
+        let stream = TcpStream::connect(self.config.receiver_addr).await?;
+        self.rtsp_stream = Some(stream);
+        Ok(())
+    }
+
+    /// Perform OPTIONS request
+    pub async fn options(&mut self) -> Result<RtspResponse, MockSenderError> {
+        self.send_rtsp_request(Method::Options, "*", None).await
+    }
+
+    /// Perform ANNOUNCE with SDP
+    pub async fn announce(&mut self) -> Result<RtspResponse, MockSenderError> {
+        let sdp = self.build_sdp();
+        let uri = format!("rtsp://{}/1234", self.config.receiver_addr);
+
+        self.send_rtsp_request(
+            Method::Announce,
+            &uri,
+            Some(("application/sdp", sdp.as_bytes())),
+        ).await
+    }
+
+    /// Perform SETUP
+    pub async fn setup(&mut self) -> Result<RtspResponse, MockSenderError> {
+        // Bind local UDP sockets
+        let audio_socket = UdpSocket::bind("0.0.0.0:0").await?;
+        let control_socket = UdpSocket::bind("0.0.0.0:0").await?;
+        let timing_socket = UdpSocket::bind("0.0.0.0:0").await?;
+
+        let control_port = control_socket.local_addr()?.port();
+        let timing_port = timing_socket.local_addr()?.port();
+
+        let transport = format!(
+            "RTP/AVP/UDP;unicast;mode=record;control_port={};timing_port={}",
+            control_port, timing_port
+        );
+
+        let uri = format!("rtsp://{}/1234", self.config.receiver_addr);
+
+        let response = self.send_rtsp_request_with_headers(
+            Method::Setup,
+            &uri,
+            vec![("Transport", &transport)],
+            None,
+        ).await?;
+
+        // Parse response for server ports and session
+        if response.status.0 == 200 {
+            self.session_id = response.headers.get("Session").cloned();
+            self.server_ports = self.parse_transport(&response);
+
+            self.audio_socket = Some(audio_socket);
+            self.control_socket = Some(control_socket);
+            self.timing_socket = Some(timing_socket);
+
+            // Connect audio socket to server
+            if let Some(ref ports) = self.server_ports {
+                let server_audio = SocketAddr::new(
+                    self.config.receiver_addr.ip(),
+                    ports.audio,
+                );
+                self.audio_socket.as_ref().unwrap().connect(server_audio).await?;
+            }
+        }
+
+        Ok(response)
+    }
+
+    /// Perform RECORD
+    pub async fn record(&mut self) -> Result<RtspResponse, MockSenderError> {
+        let uri = format!("rtsp://{}/1234", self.config.receiver_addr);
+
+        self.send_rtsp_request_with_headers(
+            Method::Record,
+            &uri,
+            vec![
+                ("Range", "npt=0-"),
+                ("RTP-Info", &format!("seq={};rtptime={}", self.sequence, self.timestamp)),
+            ],
+            None,
+        ).await
+    }
+
+    /// Send an audio packet
+    pub async fn send_audio(&mut self, audio_data: &[u8]) -> Result<(), MockSenderError> {
+        let socket = self.audio_socket.as_ref()
+            .ok_or(MockSenderError::NotSetup)?;
+
+        // Build RTP packet
+        let mut packet = vec![
+            0x80, 0x60,  // V=2, PT=96
+            (self.sequence >> 8) as u8, self.sequence as u8,
+            (self.timestamp >> 24) as u8, (self.timestamp >> 16) as u8,
+            (self.timestamp >> 8) as u8, self.timestamp as u8,
+            0x12, 0x34, 0x56, 0x78,  // SSRC
+        ];
+        packet.extend_from_slice(audio_data);
+
+        socket.send(&packet).await?;
+
+        self.sequence = self.sequence.wrapping_add(1);
+        self.timestamp = self.timestamp.wrapping_add(self.config.frames_per_packet);
+
+        Ok(())
+    }
+
+    /// Send a sync packet
+    pub async fn send_sync(&mut self) -> Result<(), MockSenderError> {
+        let socket = self.control_socket.as_ref()
+            .ok_or(MockSenderError::NotSetup)?;
+
+        let ports = self.server_ports.as_ref()
+            .ok_or(MockSenderError::NotSetup)?;
+
+        let server_control = SocketAddr::new(
+            self.config.receiver_addr.ip(),
+            ports.control,
+        );
+
+        // Build sync packet
+        let now_ntp = crate::receiver::timing::NtpTimestamp::now();
+        let mut packet = vec![
+            0x90, 0xD4,  // Sync packet type
+            0x00, 0x00,  // Sequence (unused)
+        ];
+
+        // RTP timestamp
+        packet.extend_from_slice(&self.timestamp.to_be_bytes());
+
+        // NTP timestamp
+        packet.extend_from_slice(&now_ntp.to_u64().to_be_bytes());
+
+        // RTP timestamp at NTP
+        packet.extend_from_slice(&self.timestamp.to_be_bytes());
+
+        socket.send_to(&packet, server_control).await?;
+
+        Ok(())
+    }
+
+    /// Perform TEARDOWN
+    pub async fn teardown(&mut self) -> Result<RtspResponse, MockSenderError> {
+        let uri = format!("rtsp://{}/1234", self.config.receiver_addr);
+        self.send_rtsp_request(Method::Teardown, &uri, None).await
+    }
+
+    /// Set volume
+    pub async fn set_volume(&mut self, db: f32) -> Result<RtspResponse, MockSenderError> {
+        let uri = format!("rtsp://{}/1234", self.config.receiver_addr);
+        let body = format!("volume: {:.6}\r\n", db);
+
+        self.send_rtsp_request_with_headers(
+            Method::SetParameter,
+            &uri,
+            vec![("Content-Type", "text/parameters")],
+            Some(("text/parameters", body.as_bytes())),
+        ).await
+    }
+
+    // Helper methods
+
+    fn build_sdp(&self) -> String {
+        let codec_name = match self.config.codec {
+            MockCodec::Alac => "AppleLossless",
+            MockCodec::Pcm => "L16",
+            MockCodec::Aac => "mpeg4-generic",
+        };
+
+        format!(
+            "v=0\r\n\
+             o=iTunes 0 0 IN IP4 {}\r\n\
+             s=iTunes\r\n\
+             c=IN IP4 {}\r\n\
+             t=0 0\r\n\
+             m=audio 0 RTP/AVP 96\r\n\
+             a=rtpmap:96 {}\r\n\
+             a=fmtp:96 {} 0 16 40 10 14 2 255 0 0 {}\r\n",
+            self.config.receiver_addr.ip(),
+            self.config.receiver_addr.ip(),
+            codec_name,
+            self.config.frames_per_packet,
+            self.config.sample_rate,
+        )
+    }
+
+    async fn send_rtsp_request(
+        &mut self,
+        method: Method,
+        uri: &str,
+        body: Option<(&str, &[u8])>,
+    ) -> Result<RtspResponse, MockSenderError> {
+        self.send_rtsp_request_with_headers(method, uri, vec![], body).await
+    }
+
+    async fn send_rtsp_request_with_headers(
+        &mut self,
+        method: Method,
+        uri: &str,
+        headers: Vec<(&str, &str)>,
+        body: Option<(&str, &[u8])>,
+    ) -> Result<RtspResponse, MockSenderError> {
+        let stream = self.rtsp_stream.as_mut()
+            .ok_or(MockSenderError::NotConnected)?;
+
+        self.cseq += 1;
+
+        // Build request
+        let mut request = format!("{} {} RTSP/1.0\r\n", method, uri);
+        request.push_str(&format!("CSeq: {}\r\n", self.cseq));
+
+        if let Some(ref session) = self.session_id {
+            request.push_str(&format!("Session: {}\r\n", session));
+        }
+
+        for (name, value) in headers {
+            request.push_str(&format!("{}: {}\r\n", name, value));
+        }
+
+        if let Some((content_type, data)) = body {
+            request.push_str(&format!("Content-Type: {}\r\n", content_type));
+            request.push_str(&format!("Content-Length: {}\r\n", data.len()));
+            request.push_str("\r\n");
+            stream.write_all(request.as_bytes()).await?;
+            stream.write_all(data).await?;
+        } else {
+            request.push_str("\r\n");
+            stream.write_all(request.as_bytes()).await?;
+        }
+
+        // Read response
+        let mut buf = vec![0u8; 4096];
+        let n = stream.read(&mut buf).await?;
+
+        self.parse_response(&buf[..n])
+    }
+
+    fn parse_response(&self, data: &[u8]) -> Result<RtspResponse, MockSenderError> {
+        let text = String::from_utf8_lossy(data);
+        let mut lines = text.lines();
+
+        // Status line
+        let status_line = lines.next()
+            .ok_or(MockSenderError::InvalidResponse)?;
+
+        let parts: Vec<&str> = status_line.split_whitespace().collect();
+        if parts.len() < 2 {
+            return Err(MockSenderError::InvalidResponse);
+        }
+
+        let status_code: u16 = parts[1].parse()
+            .map_err(|_| MockSenderError::InvalidResponse)?;
+
+        // Headers
+        let mut headers = Headers::new();
+        for line in lines {
+            if line.is_empty() {
+                break;
+            }
+            if let Some(pos) = line.find(':') {
+                headers.insert(
+                    line[..pos].trim().to_string(),
+                    line[pos + 1..].trim().to_string(),
+                );
+            }
+        }
+
+        Ok(RtspResponse {
+            status: crate::protocol::rtsp::StatusCode(status_code),
+            headers,
+            body: Vec::new(),
+        })
+    }
+
+    fn parse_transport(&self, response: &RtspResponse) -> Option<ServerPorts> {
+        let transport = response.headers.get("Transport")?;
+
+        let mut audio = 0u16;
+        let mut control = 0u16;
+        let mut timing = 0u16;
+
+        for part in transport.split(';') {
+            if let Some(value) = part.strip_prefix("server_port=") {
+                if let Some(port_str) = value.split('-').next() {
+                    audio = port_str.parse().unwrap_or(0);
+                }
+            }
+            if let Some(value) = part.strip_prefix("control_port=") {
+                control = value.parse().unwrap_or(0);
+            }
+            if let Some(value) = part.strip_prefix("timing_port=") {
+                timing = value.parse().unwrap_or(0);
+            }
+        }
+
+        if audio > 0 && control > 0 && timing > 0 {
+            Some(ServerPorts { audio, control, timing })
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MockSenderError {
+    #[error("Not connected")]
+    NotConnected,
+
+    #[error("Not setup")]
+    NotSetup,
+
+    #[error("Invalid response")]
+    InvalidResponse,
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+```
+
+---
+
+### 45.2 Protocol Conformance Tests
+
+- [ ] **45.2.1** Implement comprehensive protocol tests
+
+**File:** `tests/receiver/protocol_tests.rs`
+
+```rust
+//! Protocol conformance tests for AirPlay receiver
+
+use airplay2::testing::mock_sender::{MockSender, MockSenderConfig};
+use airplay2::receiver::{AirPlayReceiver, ReceiverConfig, ReceiverEvent};
+use std::time::Duration;
+
+/// Test complete session negotiation
+#[tokio::test]
+async fn test_complete_session() {
+    // Start receiver
+    let mut receiver = AirPlayReceiver::new(
+        ReceiverConfig::with_name("Test").port(0)
+    );
+    receiver.start().await.unwrap();
+
+    // Get actual port
+    let mut events = receiver.subscribe();
+    let event = events.recv().await.unwrap();
+    let port = match event {
+        ReceiverEvent::Started { port, .. } => port,
+        _ => panic!("Expected Started event"),
+    };
+
+    // Create sender
+    let mut sender = MockSender::new(MockSenderConfig {
+        receiver_addr: format!("127.0.0.1:{}", port).parse().unwrap(),
+        ..Default::default()
+    });
+
+    // Connect and negotiate
+    sender.connect().await.unwrap();
+
+    let options = sender.options().await.unwrap();
+    assert_eq!(options.status.0, 200);
+
+    let announce = sender.announce().await.unwrap();
+    assert_eq!(announce.status.0, 200);
+
+    let setup = sender.setup().await.unwrap();
+    assert_eq!(setup.status.0, 200);
+    assert!(setup.headers.get("Transport").is_some());
+    assert!(setup.headers.get("Session").is_some());
+
+    let record = sender.record().await.unwrap();
+    assert_eq!(record.status.0, 200);
+
+    // Send some audio
+    for _ in 0..10 {
+        sender.send_audio(&vec![0u8; 1408]).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(8)).await;
+    }
+
+    let teardown = sender.teardown().await.unwrap();
+    assert_eq!(teardown.status.0, 200);
+
+    receiver.stop().await.unwrap();
+}
+
+/// Test volume control
+#[tokio::test]
+async fn test_volume_control() {
+    let mut receiver = AirPlayReceiver::new(
+        ReceiverConfig::with_name("Test").port(0)
+    );
+    let mut events = receiver.subscribe();
+    receiver.start().await.unwrap();
+
+    let event = events.recv().await.unwrap();
+    let port = match event {
+        ReceiverEvent::Started { port, .. } => port,
+        _ => panic!("Expected Started event"),
+    };
+
+    let mut sender = MockSender::new(MockSenderConfig {
+        receiver_addr: format!("127.0.0.1:{}", port).parse().unwrap(),
+        ..Default::default()
+    });
+
+    sender.connect().await.unwrap();
+    sender.options().await.unwrap();
+    sender.announce().await.unwrap();
+    sender.setup().await.unwrap();
+
+    // Set volume
+    let response = sender.set_volume(-15.0).await.unwrap();
+    assert_eq!(response.status.0, 200);
+
+    // Check event
+    // Note: May need to filter for VolumeChanged event
+
+    sender.teardown().await.unwrap();
+    receiver.stop().await.unwrap();
+}
+
+/// Test session preemption
+#[tokio::test]
+async fn test_session_preemption() {
+    let mut receiver = AirPlayReceiver::new(
+        ReceiverConfig::with_name("Test")
+            .port(0)
+    );
+    let mut events = receiver.subscribe();
+    receiver.start().await.unwrap();
+
+    let event = events.recv().await.unwrap();
+    let port = match event {
+        ReceiverEvent::Started { port, .. } => port,
+        _ => panic!("Expected Started event"),
+    };
+
+    // First sender connects
+    let mut sender1 = MockSender::new(MockSenderConfig {
+        receiver_addr: format!("127.0.0.1:{}", port).parse().unwrap(),
+        ..Default::default()
+    });
+
+    sender1.connect().await.unwrap();
+    sender1.options().await.unwrap();
+    sender1.announce().await.unwrap();
+    sender1.setup().await.unwrap();
+    sender1.record().await.unwrap();
+
+    // Second sender preempts
+    let mut sender2 = MockSender::new(MockSenderConfig {
+        receiver_addr: format!("127.0.0.1:{}", port).parse().unwrap(),
+        ..Default::default()
+    });
+
+    sender2.connect().await.unwrap();
+    let response = sender2.options().await.unwrap();
+    assert_eq!(response.status.0, 200);  // Should succeed with preemption
+
+    receiver.stop().await.unwrap();
+}
+```
+
+---
+
+### 45.3 Network Simulation
+
+- [ ] **45.3.1** Simulate adverse network conditions
+
+**File:** `src/testing/network_sim.rs`
+
+```rust
+//! Network condition simulation for testing
+
+use rand::Rng;
+use std::time::Duration;
+
+/// Network condition simulator
+pub struct NetworkSimulator {
+    /// Packet loss probability (0.0 to 1.0)
+    pub loss_rate: f64,
+    /// Jitter range (max delay added)
+    pub jitter_ms: u32,
+    /// Base delay added to all packets
+    pub delay_ms: u32,
+    /// Probability of reordering
+    pub reorder_rate: f64,
+}
+
+impl NetworkSimulator {
+    /// Perfect network (no issues)
+    pub fn perfect() -> Self {
+        Self {
+            loss_rate: 0.0,
+            jitter_ms: 0,
+            delay_ms: 0,
+            reorder_rate: 0.0,
+        }
+    }
+
+    /// Good WiFi conditions
+    pub fn good_wifi() -> Self {
+        Self {
+            loss_rate: 0.001,
+            jitter_ms: 5,
+            delay_ms: 2,
+            reorder_rate: 0.001,
+        }
+    }
+
+    /// Moderate WiFi conditions
+    pub fn moderate_wifi() -> Self {
+        Self {
+            loss_rate: 0.01,
+            jitter_ms: 20,
+            delay_ms: 10,
+            reorder_rate: 0.01,
+        }
+    }
+
+    /// Poor WiFi conditions
+    pub fn poor_wifi() -> Self {
+        Self {
+            loss_rate: 0.05,
+            jitter_ms: 50,
+            delay_ms: 30,
+            reorder_rate: 0.05,
+        }
+    }
+
+    /// Very poor conditions (stress test)
+    pub fn stress_test() -> Self {
+        Self {
+            loss_rate: 0.10,
+            jitter_ms: 100,
+            delay_ms: 50,
+            reorder_rate: 0.10,
+        }
+    }
+
+    /// Should this packet be dropped?
+    pub fn should_drop(&self) -> bool {
+        rand::thread_rng().gen_bool(self.loss_rate)
+    }
+
+    /// Get delay for this packet
+    pub fn get_delay(&self) -> Duration {
+        let jitter: u32 = if self.jitter_ms > 0 {
+            rand::thread_rng().gen_range(0..self.jitter_ms)
+        } else {
+            0
+        };
+
+        Duration::from_millis((self.delay_ms + jitter) as u64)
+    }
+
+    /// Should this packet be reordered?
+    pub fn should_reorder(&self) -> bool {
+        rand::thread_rng().gen_bool(self.reorder_rate)
+    }
+}
+
+/// Run test with network conditions
+pub async fn with_network_conditions<F, Fut>(
+    conditions: NetworkSimulator,
+    test: F,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<(), Box<dyn std::error::Error>>>,
+{
+    // In a real implementation, this would intercept network I/O
+    // For now, just run the test
+    test().await
+}
+```
+
+---
+
+### 45.4 Reference Comparison Tests
+
+- [ ] **45.4.1** Compare behavior with shairport-sync
+
+**File:** `tests/receiver/reference_tests.rs`
+
+```rust
+//! Reference comparison tests
+//!
+//! These tests compare our receiver behavior against shairport-sync
+//! to ensure compatibility.
+
+/// Compare RTSP response formats
+#[test]
+fn test_options_response_format() {
+    // Our response should match shairport-sync format
+    let expected_methods = [
+        "ANNOUNCE", "SETUP", "RECORD", "PAUSE", "FLUSH",
+        "TEARDOWN", "OPTIONS", "GET_PARAMETER", "SET_PARAMETER"
+    ];
+
+    // Verify all methods are in our Public header
+    // (Test implementation would go here)
+}
+
+/// Compare audio latency behavior
+#[test]
+fn test_audio_latency_header() {
+    // shairport-sync returns Audio-Latency in RECORD response
+    // We should too, with similar values
+}
+
+/// Compare timing packet format
+#[test]
+fn test_timing_packet_format() {
+    // Verify our timing packets match the expected format
+}
+```
+
+---
+
+### 45.5 Interoperability Test Documentation
+
+- [ ] **45.5.1** Document manual interoperability tests
+
+**File:** `tests/receiver/INTEROP_TESTS.md`
+
+```markdown
+# Interoperability Test Procedures
+
+## Test Matrix
+
+| Sender | macOS Version | Status | Notes |
+|--------|---------------|--------|-------|
+| iTunes | 12.x (macOS) | Pending | Primary test target |
+| Music.app | macOS 11+ | Pending | Modern macOS |
+| iOS | 14+ | Pending | iPhone/iPad |
+| OwnTone | Latest | Pending | Open source sender |
+| Roon | Latest | Pending | Audiophile software |
+
+## Test Procedure
+
+### 1. Discovery Test
+1. Start receiver with known name
+2. Open sender application
+3. Verify receiver appears in device list
+4. Verify icon/name display correctly
+
+### 2. Basic Playback Test
+1. Connect to receiver
+2. Play audio file
+3. Verify audio output
+4. Verify no clicks/pops
+5. Verify timing stability
+
+### 3. Volume Test
+1. During playback, adjust volume
+2. Verify receiver responds
+3. Test mute/unmute
+4. Verify smooth transitions
+
+### 4. Metadata Test
+1. Play track with metadata
+2. Verify title received
+3. Verify artist received
+4. Verify artwork received
+
+### 5. Session Test
+1. Start playback
+2. Pause/resume
+3. Switch tracks
+4. Disconnect cleanly
+
+### 6. Preemption Test
+1. Connect sender A
+2. Start playback
+3. Connect sender B
+4. Verify A disconnected
+5. Verify B plays correctly
+
+## Reporting Issues
+
+Document any failures with:
+- Sender version
+- Receiver log output
+- Packet captures if available
+- Steps to reproduce
+```
+
+---
+
+### 45.6 Performance Benchmarks
+
+- [ ] **45.6.1** Implement performance benchmarks
+
+**File:** `benches/receiver_benchmarks.rs`
+
+```rust
+//! Performance benchmarks for receiver components
+
+use criterion::{criterion_group, criterion_main, Criterion, black_box};
+use airplay2::audio::jitter::{JitterBuffer, JitterBufferConfig};
+use airplay2::receiver::rtp_receiver::AudioPacket;
+use std::time::Instant;
+
+fn jitter_buffer_insert(c: &mut Criterion) {
+    c.bench_function("jitter_insert", |b| {
+        let config = JitterBufferConfig::default();
+        let mut buffer = JitterBuffer::new(config);
+
+        let mut seq = 0u16;
+
+        b.iter(|| {
+            let packet = AudioPacket {
+                sequence: seq,
+                timestamp: seq as u32 * 352,
+                ssrc: 0x12345678,
+                audio_data: vec![0u8; 1408],
+                received_at: Instant::now(),
+            };
+
+            buffer.insert(black_box(packet));
+            seq = seq.wrapping_add(1);
+        });
+    });
+}
+
+fn jitter_buffer_pop(c: &mut Criterion) {
+    c.bench_function("jitter_pop", |b| {
+        let config = JitterBufferConfig {
+            min_depth: 10,
+            target_depth: 50,
+            max_depth: 200,
+            ..Default::default()
+        };
+        let mut buffer = JitterBuffer::new(config);
+
+        // Fill buffer
+        for seq in 0..100u16 {
+            buffer.insert(AudioPacket {
+                sequence: seq,
+                timestamp: seq as u32 * 352,
+                ssrc: 0x12345678,
+                audio_data: vec![0u8; 1408],
+                received_at: Instant::now(),
+            });
+        }
+
+        b.iter(|| {
+            let _ = black_box(buffer.pop());
+        });
+    });
+}
+
+fn rtp_header_parse(c: &mut Criterion) {
+    c.bench_function("rtp_parse", |b| {
+        let packet = vec![
+            0x80, 0x60,
+            0x00, 0x01,
+            0x00, 0x00, 0x01, 0x60,
+            0x12, 0x34, 0x56, 0x78,
+        ];
+
+        b.iter(|| {
+            use airplay2::protocol::rtp::RtpHeader;
+            let _ = black_box(RtpHeader::parse(&packet));
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    jitter_buffer_insert,
+    jitter_buffer_pop,
+    rtp_header_parse,
+);
+
+criterion_main!(benches);
+```
+
+---
+
+### 45.7 CI/CD Integration
+
+- [ ] **45.7.1** Configure receiver tests for CI
+
+**File:** `.github/workflows/receiver-tests.yml`
+
+```yaml
+name: Receiver Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust: [stable]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Install audio dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev
+
+      - name: Run unit tests
+        run: cargo test --features receiver
+
+      - name: Run receiver tests
+        run: cargo test --features receiver --test 'receiver*'
+
+      - name: Run benchmarks (check only)
+        run: cargo bench --features receiver --no-run
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev
+
+      - name: Install tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Generate coverage
+        run: cargo tarpaulin --features receiver --out Xml
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Mock sender can complete full session
+- [ ] All RTSP methods tested
+- [ ] Packet loss handling tested
+- [ ] Jitter simulation tested
+- [ ] Benchmarks run without regression
+- [ ] CI passes on Linux and macOS
+- [ ] Interoperability documented
+- [ ] Code coverage > 70%
+
+---
+
+## Notes
+
+- **Mock sender**: Essential for automated testing without real devices
+- **Network simulation**: Critical for robustness testing
+- **Reference comparison**: Ensures compatibility with established implementations
+- **Interoperability**: Manual tests documented for hardware testing
+- **CI/CD**: All tests run automatically on PRs
+
+---
+
+## References
+
+- [shairport-sync](https://github.com/mikebrady/shairport-sync)
+- [pyatv](https://pyatv.dev/)
+- [OwnTone](https://owntone.github.io/owntone-server/)


### PR DESCRIPTION
## Summary

This PR introduces comprehensive documentation and architectural planning for implementing AirPlay 1 **receiver** functionality in `airplay2-rs`. The receiver will enable the library to accept incoming audio streams from AirPlay senders (iTunes, iOS, macOS), complementing the existing client implementation.

## Key Changes

- **Section 34 (Receiver Overview)**: Complete architectural documentation including:
  - Design philosophy and objectives
  - Inverted data flow comparison (client vs receiver modes)
  - Multi-layer architecture diagram (API, Session, Audio, Protocol, Network)
  - Code reuse strategy identifying 7 components to reuse directly
  - Feature flag design for lightweight client-only builds
  - Proposed module structure for receiver implementation
  - Receiver state machine (Idle → Connected → Announced → Setup → Streaming → Teardown)
  - Parallel work streams and dependency graph

- **Updated Section 00 (Overview)**: Added comprehensive receiver section with:
  - Dependency diagram showing 12 interconnected sections (34-45)
  - Documentation roadmap table for all receiver sections
  - Feature flag specifications for receiver builds
  - Component reuse matrix
  - Implementation stream RF with 5 sequential phases

- **Placeholder sections 35-45**: Created stub documentation files for:
  - 35: RAOP Service Advertisement
  - 36: RTSP Server (Sans-IO)
  - 37: Session Management
  - 38: SDP Parsing & Stream Setup
  - 39: RTP Receiver Core
  - 40: Timing Synchronization
  - 41: Jitter Buffer & Packet Loss
  - 42: Audio Output Abstraction
  - 43: Volume & Metadata Handling
  - 44: Receiver Integration
  - 45: Receiver Testing

## Notable Implementation Details

1. **Code Reuse**: Identified 5 existing components (RtspCodec, RtpPacket, RaopEncryption, AudioRingBuffer, DmapParser) that can be reused with minimal changes, plus 4 components requiring extensions.

2. **Feature Flags**: Designed modular feature flags (`receiver`, `audio-decode`, `audio-coreaudio`, `audio-cpal`, `audio-alsa`, `receiver-full`) to keep client-only builds lightweight while enabling full receiver functionality.

3. **Architecture Layers**: Defined 5-layer architecture (Public API → Session → Audio → Protocol Sans-IO → Network) with clear separation of concerns.

4. **Platform Support**: Prioritizes macOS (CoreAudio) with fallbacks to CPAL (cross-platform) and ALSA (Linux native).

5. **Testing Philosophy**: Established comprehensive testing strategy including unit tests, integration tests, conformance tests, interoperability tests, network simulation, and performance tests.

6. **Parallel Work Streams**: Identified 4 independent work streams (Network & Discovery, Protocol Core, Audio Pipeline, Testing Infrastructure) that can proceed in parallel with clear convergence points.

## Next Steps

- Implement Section 35 (Service Advertisement) - mDNS publishing
- Implement Section 36 (RTSP Server) - Sans-IO protocol handling
- Implement Section 42 (Audio Output) - Platform-specific backends
- Proceed with remaining sections following dependency graph

This documentation provides the foundation for implementing a production-quality AirPlay 1 receiver while maintaining code quality, testability, and platform independence.