### PR TITLE
Implement RAOP connection logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ raop = ["rsa", "sha1"]
 [dependencies]
 # Async
 # Pinned to 1.38.2 to align socket2 dependency (0.5) with mdns-sd
-tokio = { version = "=1.38.2", features = ["net", "sync", "time", "rt", "macros", "fs"], optional = true }
+tokio = { version = "=1.38.2", features = ["net", "sync", "time", "rt", "macros", "fs", "io-util"], optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 async-trait = "0.1"
 futures = "0.3"


### PR DESCRIPTION
Implemented the RAOP connection logic in `src/client/session.rs`. The `connect` method now performs the standard AirPlay 1 RTSP handshake:
1. Connects via TCP.
2. Sends OPTIONS and verifies response.
3. Sends ANNOUNCE with SDP (including RSA-encrypted AES keys).
4. Binds ephemeral UDP ports for control and timing.
5. Sends SETUP with client ports.
6. Initializes `RaopStreamer` with negotiated session keys and server ports.
7. Sends RECORD to start the session.

Also added `send_request` helper which properly handles RTSP response parsing using a persistent `RtspCodec` to avoid data loss from buffered reads.

Updated `Cargo.toml` to include `tokio/io-util` for async IO traits.
Updated `src/client/tests/unified_tests.rs` to use `MockRaopServer` instead of expecting connection failure or success against localhost without a listener.


---
*PR created automatically by Jules for task [12583253752850668205](https://jules.google.com/task/12583253752850668205) started by @jburnhams*