### PR TITLE
Run cargo fmt and verify clippy

### DIFF
--- a/src/receiver/rtp_receiver.rs
+++ b/src/receiver/rtp_receiver.rs
@@ -5,8 +5,8 @@
 
 use crate::protocol::rtp::{RtpDecodeError, RtpHeader};
 use crate::receiver::session::StreamParameters;
-use aes::cipher::{BlockDecrypt, KeyInit, generic_array::GenericArray};
 use aes::Aes128;
+use aes::cipher::{BlockDecrypt, KeyInit, generic_array::GenericArray};
 use std::sync::Arc;
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc;


### PR DESCRIPTION
This change runs `cargo fmt` to address formatting inconsistencies (specifically import reordering) and verifies the codebase using `cargo clippy`. No functional changes were made, only cosmetic formatting updates to comply with the project's style guidelines. All tests passed.

---
*PR created automatically by Jules for task [3308407928955528372](https://jules.google.com/task/3308407928955528372) started by @jburnhams*