### PR TITLE
feat: implement fast-forward and rewind via rate control

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -430,6 +430,22 @@ impl AirPlayClient {
         self.volume.get().await.as_f32()
     }
 
+    /// Fast forward
+    ///
+    /// # Errors
+    /// Returns error if network fails
+    pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
+        self.playback.fast_forward().await
+    }
+
+    /// Rewind
+    ///
+    /// # Errors
+    /// Returns error if network fails
+    pub async fn rewind(&self) -> Result<(), AirPlayError> {
+        self.playback.rewind().await
+    }
+
     /// Set volume (0.0 - 1.0)
     ///
     /// # Errors

--- a/src/control/playback.rs
+++ b/src/control/playback.rs
@@ -242,24 +242,24 @@ impl PlaybackController {
 
     /// Fast forward
     ///
+    /// Sends `SetRateAnchorTime` with `rate=2.0`.
+    ///
     /// # Errors
     ///
     /// Returns error if network fails
     pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip forward 10s
-        self.seek_relative(Duration::from_secs(10), true).await
+        self.send_rate(2.0).await
     }
 
     /// Rewind
+    ///
+    /// Sends `SetRateAnchorTime` with `rate=-2.0`.
     ///
     /// # Errors
     ///
     /// Returns error if network fails
     pub async fn rewind(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip backward 10s
-        self.seek_relative(Duration::from_secs(10), false).await
+        self.send_rate(-2.0).await
     }
 
     /// Set repeat mode
@@ -407,6 +407,30 @@ impl PlaybackController {
 
         // We use send_post_command.
         let _ = self.connection.send_post_command(&path, None, None).await?;
+        Ok(())
+    }
+
+    /// Internal: send rate command
+    async fn send_rate(&self, rate: f64) -> Result<(), AirPlayError> {
+        let body = DictBuilder::new()
+            .insert("rate", rate)
+            .insert("rtpTime", 0u64)
+            .build();
+
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
+
+        self.connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
+            )
+            .await?;
+
         Ok(())
     }
 }

--- a/src/control/tests/mod.rs
+++ b/src/control/tests/mod.rs
@@ -1,3 +1,4 @@
 mod playback;
 mod queue;
 mod volume;
+mod playback_rate;

--- a/src/control/tests/mod.rs
+++ b/src/control/tests/mod.rs
@@ -1,4 +1,4 @@
 mod playback;
+mod playback_rate;
 mod queue;
 mod volume;
-mod playback_rate;

--- a/src/control/tests/playback_rate.rs
+++ b/src/control/tests/playback_rate.rs
@@ -18,17 +18,14 @@ async fn test_fast_forward_rewind() {
         model: Some("MockModel".to_string()),
         addresses: vec![addr.ip()],
         port: addr.port(),
-        capabilities: Default::default(),
+        capabilities: crate::types::DeviceCapabilities::default(),
         raop_port: None,
         raop_capabilities: None,
         txt_records: std::collections::HashMap::new(),
         last_seen: None,
     };
 
-    client
-        .connect(&device)
-        .await
-        .expect("Connection failed");
+    client.connect(&device).await.expect("Connection failed");
 
     // Fast forward should set rate to 2.0
     client.fast_forward().await.expect("Fast forward failed");

--- a/src/control/tests/playback_rate.rs
+++ b/src/control/tests/playback_rate.rs
@@ -1,0 +1,45 @@
+#[tokio::test]
+async fn test_fast_forward_rewind() {
+    use crate::AirPlayClient;
+    use crate::testing::mock_server::{MockServer, MockServerConfig};
+    use crate::types::AirPlayDevice;
+
+    let config = MockServerConfig {
+        rtsp_port: 0,
+        ..Default::default()
+    };
+    let mut server = MockServer::new(config);
+    let addr = server.start().await.expect("Failed to start mock server");
+
+    let client = AirPlayClient::default_client();
+    let device = AirPlayDevice {
+        id: "mock_device_rate".to_string(),
+        name: "Mock Device".to_string(),
+        model: Some("MockModel".to_string()),
+        addresses: vec![addr.ip()],
+        port: addr.port(),
+        capabilities: Default::default(),
+        raop_port: None,
+        raop_capabilities: None,
+        txt_records: std::collections::HashMap::new(),
+        last_seen: None,
+    };
+
+    client
+        .connect(&device)
+        .await
+        .expect("Connection failed");
+
+    // Fast forward should set rate to 2.0
+    client.fast_forward().await.expect("Fast forward failed");
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(server.current_rate().await, Some(2.0));
+
+    // Rewind should set rate to -2.0
+    client.rewind().await.expect("Rewind failed");
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(server.current_rate().await, Some(-2.0));
+
+    client.disconnect().await.expect("Disconnect failed");
+    server.stop().await;
+}

--- a/src/testing/mock_server.rs
+++ b/src/testing/mock_server.rs
@@ -59,6 +59,8 @@ impl Default for MockServerConfig {
 struct ServerState {
     /// Whether the server is currently in a streaming state.
     streaming: bool,
+    /// The current rate if SetRateAnchorTime was called
+    rate: Option<f64>,
     /// The current RTSP session ID, if any.
     session_id: Option<String>,
     /// Buffer of received audio packets.
@@ -69,6 +71,14 @@ struct ServerState {
     paired: bool,
     /// Pairing server instance
     pairing_server: PairingServer,
+}
+
+impl MockServer {
+    /// Get the current rate
+    #[must_use]
+    pub async fn current_rate(&self) -> Option<f64> {
+        self.state.read().await.rate
+    }
 }
 
 /// A Mock `AirPlay` server.
@@ -98,6 +108,7 @@ impl MockServer {
             config,
             state: Arc::new(RwLock::new(ServerState {
                 streaming: false,
+                rate: None,
                 session_id: None,
                 audio_packets: Vec::new(),
                 volume: 0.0,
@@ -422,12 +433,14 @@ impl MockServer {
             }
             Method::SetRateAnchorTime => {
                 // Parse body to check rate
+                let mut parsed_rate: Option<f64> = None;
                 let streaming = if let Ok(plist) = crate::protocol::plist::decode(&request.body) {
                     if let Some(dict) = plist.as_dict() {
                         if let Some(rate) = dict
                             .get("rate")
                             .and_then(crate::protocol::plist::PlistValue::as_f64)
                         {
+                            parsed_rate = Some(rate);
                             rate.abs() > f64::EPSILON
                         } else {
                             true
@@ -439,7 +452,11 @@ impl MockServer {
                     true
                 };
 
-                state.write().await.streaming = streaming;
+                let mut s = state.write().await;
+                s.streaming = streaming;
+                if parsed_rate.is_some() {
+                    s.rate = parsed_rate;
+                }
                 Self::response(StatusCode::OK, cseq, None, None)
             }
             Method::Pause => {

--- a/src/testing/mock_server.rs
+++ b/src/testing/mock_server.rs
@@ -59,7 +59,7 @@ impl Default for MockServerConfig {
 struct ServerState {
     /// Whether the server is currently in a streaming state.
     streaming: bool,
-    /// The current rate if SetRateAnchorTime was called
+    /// The current rate if `SetRateAnchorTime` was called
     rate: Option<f64>,
     /// The current RTSP session ID, if any.
     session_id: Option<String>,


### PR DESCRIPTION
This PR implements the "TODO: Implement rate control properly" found in `src/control/playback.rs`.

Previously, `fast_forward` and `rewind` were using a mock implementation that skipped forward or backward by 10 seconds. This changes the behavior to adhere to the AirPlay 2 protocol specification by sending a `SetRateAnchorTime` RTSP command to the device, populated with a binary plist containing the new `rate` (`2.0` for fast forward, `-2.0` for rewind).

The implementation adds a private helper method `send_rate` which encodes the standard `rtpTime` and `rate` dictionary to a binary plist format (`application/x-apple-binary-plist`). It exposes the methods up the stack through the `AirPlayClient` wrapper.

It also upgrades the test suite:
- `MockServer` and `ServerState` in `src/testing/mock_server.rs` were modified to parse and track the received `rate` when `SetRateAnchorTime` is processed.
- The unit test `test_fast_forward_rewind` in `src/control/tests/playback_rate.rs` was completely rewritten to actually connect to the `MockServer` on `127.0.0.1` and ensure the proper RTSP sequence and rate parameters are evaluated.

---
*PR created automatically by Jules for task [12062034818270190970](https://jules.google.com/task/12062034818270190970) started by @jburnhams*