### PR TITLE
test: Expand player unit and integration tests

### DIFF
--- a/src/player/tests/mod.rs
+++ b/src/player/tests/mod.rs
@@ -207,6 +207,30 @@ async fn test_device_initially_none() {
 }
 
 #[tokio::test]
+async fn test_current_track_initially_none() {
+    let player = AirPlayPlayer::new();
+    assert!(player.current_track().await.is_none());
+}
+
+#[tokio::test]
+async fn test_set_auto_reconnect_flag() {
+    let mut player = AirPlayPlayer::new();
+    // Default is true
+    assert!(player.auto_reconnect.load(Ordering::SeqCst));
+
+    player.set_auto_reconnect(false);
+    assert!(!player.auto_reconnect.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn test_set_target_device_name_property() {
+    let player = AirPlayPlayer::new();
+    player.set_target_device_name(Some("Living Room".to_string())).await;
+    let name = player.target_device_name.read().await.clone();
+    assert_eq!(name, Some("Living Room".to_string()));
+}
+
+#[tokio::test]
 async fn test_initial_queue_length() {
     let player = AirPlayPlayer::new();
     assert_eq!(player.queue_length().await, 0);

--- a/src/player/tests/mod.rs
+++ b/src/player/tests/mod.rs
@@ -225,7 +225,9 @@ async fn test_set_auto_reconnect_flag() {
 #[tokio::test]
 async fn test_set_target_device_name_property() {
     let player = AirPlayPlayer::new();
-    player.set_target_device_name(Some("Living Room".to_string())).await;
+    player
+        .set_target_device_name(Some("Living Room".to_string()))
+        .await;
     let name = player.target_device_name.read().await.clone();
     assert_eq!(name, Some("Living Room".to_string()));
 }

--- a/tests/player_integration.rs
+++ b/tests/player_integration.rs
@@ -218,3 +218,57 @@ async fn test_player_disconnected_errors() {
     let res = player.seek(10.0).await;
     assert!(matches!(res, Err(AirPlayError::Disconnected { .. })));
 }
+
+#[tokio::test]
+async fn test_player_connect_and_device_state() {
+    let config = MockServerConfig {
+        rtsp_port: 0,
+        ..Default::default()
+    };
+    let mut server = MockServer::new(config);
+    let addr = server.start().await.expect("Failed to start server");
+
+    let player = AirPlayPlayer::new();
+
+    // Initially not connected
+    assert!(!player.is_connected().await);
+    assert!(player.device().await.is_none());
+
+    let device = AirPlayDevice {
+        id: "player_connect_state".to_string(),
+        name: "Connect State Device".to_string(),
+        model: Some("Mock".to_string()),
+        addresses: vec![addr.ip()],
+        port: addr.port(),
+        capabilities: airplay2::types::DeviceCapabilities {
+            airplay2: true,
+            supports_audio: true,
+            ..Default::default()
+        },
+        raop_port: None,
+        raop_capabilities: None,
+        txt_records: std::collections::HashMap::new(),
+        last_seen: None,
+    };
+
+    // Connect
+    player.connect(&device).await.expect("Connect failed");
+
+    // Check state after connecting
+    assert!(player.is_connected().await);
+    let connected_device = player
+        .device()
+        .await
+        .expect("Expected a device to be returned");
+    assert_eq!(connected_device.id, device.id);
+    assert_eq!(connected_device.name, device.name);
+
+    // Disconnect
+    player.disconnect().await.expect("Disconnect failed");
+
+    // Check state after disconnecting
+    assert!(!player.is_connected().await);
+    assert!(player.device().await.is_none());
+
+    server.stop().await;
+}


### PR DESCRIPTION
Expanded the testing footprint of the `AirPlayPlayer` API. I noticed `tests.rs` was at the top level of `player` so I converted it into a modular layout via `tests/mod.rs` and added checks for connection state mapping. Expanded integration tests to capture missing state verifications when utilizing `MockServer`.

---
*PR created automatically by Jules for task [11770444713716072032](https://jules.google.com/task/11770444713716072032) started by @jburnhams*