### PR TITLE
feat(playback): implement fast-forward and rewind rate control

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -418,6 +418,30 @@ impl AirPlayClient {
         self.playback.seek(position).await
     }
 
+    /// Fast forward
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
+        self.ensure_connected().await?;
+        self.playback.fast_forward().await?;
+        self.state.update(|s| s.playback.is_playing = true).await;
+        Ok(())
+    }
+
+    /// Rewind
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn rewind(&self) -> Result<(), AirPlayError> {
+        self.ensure_connected().await?;
+        self.playback.rewind().await?;
+        self.state.update(|s| s.playback.is_playing = true).await;
+        Ok(())
+    }
+
     /// Get current playback state
     pub async fn playback_state(&self) -> PlaybackState {
         self.state.get().await.playback

--- a/src/control/playback.rs
+++ b/src/control/playback.rs
@@ -242,24 +242,24 @@ impl PlaybackController {
 
     /// Fast forward
     ///
+    /// Sends `SetRateAnchorTime` with `rate=2.0`.
+    ///
     /// # Errors
     ///
     /// Returns error if network fails
     pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip forward 10s
-        self.seek_relative(Duration::from_secs(10), true).await
+        self.set_rate(2.0).await
     }
 
     /// Rewind
+    ///
+    /// Sends `SetRateAnchorTime` with `rate=-2.0`.
     ///
     /// # Errors
     ///
     /// Returns error if network fails
     pub async fn rewind(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip backward 10s
-        self.seek_relative(Duration::from_secs(10), false).await
+        self.set_rate(-2.0).await
     }
 
     /// Set repeat mode
@@ -397,6 +397,35 @@ impl PlaybackController {
                 Some("application/x-dmap-tagged".to_string()),
             )
             .await?;
+        Ok(())
+    }
+
+    /// Internal: send rate command
+    async fn set_rate(&self, rate: f64) -> Result<(), AirPlayError> {
+        let body = DictBuilder::new()
+            .insert("rate", rate)
+            .insert("rtpTime", 0u64)
+            .build();
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
+
+        self.connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
+            )
+            .await?;
+
+        // Update local state if not paused
+        if rate.abs() > f64::EPSILON {
+            let mut state = self.state.write().await;
+            state.is_playing = true;
+        }
+
         Ok(())
     }
 

--- a/src/control/tests/playback.rs
+++ b/src/control/tests/playback.rs
@@ -113,6 +113,21 @@ async fn test_playback_controller_play_pause_stop_not_connected() {
 }
 
 #[tokio::test]
+async fn test_playback_controller_fast_forward_rewind_not_connected() {
+    use std::sync::Arc;
+
+    use crate::connection::ConnectionManager;
+    use crate::types::AirPlayConfig;
+
+    let config = AirPlayConfig::default();
+    let manager = Arc::new(ConnectionManager::new(config));
+    let controller = crate::control::playback::PlaybackController::new(manager);
+
+    assert!(controller.fast_forward().await.is_err());
+    assert!(controller.rewind().await.is_err());
+}
+
+#[tokio::test]
 async fn test_playback_controller_set_shuffle_and_repeat() {
     use std::sync::Arc;
 

--- a/tests/client_integration.rs
+++ b/tests/client_integration.rs
@@ -114,6 +114,16 @@ async fn test_client_integration_flow() {
     assert!(!server.is_streaming().await);
     assert!(!client.playback_state().await.is_playing);
 
+    // Fast Forward
+    client.fast_forward().await.expect("Fast forward failed");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(client.playback_state().await.is_playing); // State updates to playing
+
+    // Rewind
+    client.rewind().await.expect("Rewind failed");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(client.playback_state().await.is_playing); // State updates to playing
+
     // 6. Disconnect
     println!("Disconnecting...");
     client.disconnect().await.expect("Disconnect failed");


### PR DESCRIPTION
Resolves a TODO for AirPlay playback rate control by properly implementing fast forward and rewind via RTSP.

---
*PR created automatically by Jules for task [1839823254307852467](https://jules.google.com/task/1839823254307852467) started by @jburnhams*