### PR TITLE
Implement accurate rate control for fast-forward and rewind

### DIFF
--- a/src/control/playback.rs
+++ b/src/control/playback.rs
@@ -246,9 +246,25 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip forward 10s
-        self.seek_relative(Duration::from_secs(10), true).await
+        let body = DictBuilder::new()
+            .insert("rate", 2f64)
+            .insert("rtpTime", 0u64)
+            .build();
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
+
+        self.connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
+            )
+            .await?;
+
+        Ok(())
     }
 
     /// Rewind
@@ -257,9 +273,25 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn rewind(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip backward 10s
-        self.seek_relative(Duration::from_secs(10), false).await
+        let body = DictBuilder::new()
+            .insert("rate", -2f64)
+            .insert("rtpTime", 0u64)
+            .build();
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
+
+        self.connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
+            )
+            .await?;
+
+        Ok(())
     }
 
     /// Set repeat mode

--- a/src/control/tests/playback.rs
+++ b/src/control/tests/playback.rs
@@ -110,6 +110,68 @@ async fn test_playback_controller_play_pause_stop_not_connected() {
     assert!(controller.pause().await.is_err());
     assert!(controller.stop().await.is_err());
     assert!(controller.toggle().await.is_err());
+    assert!(controller.fast_forward().await.is_err());
+    assert!(controller.rewind().await.is_err());
+}
+
+#[tokio::test]
+async fn test_playback_controller_rate_control() {
+    use std::sync::Arc;
+
+    use crate::connection::ConnectionManager;
+    use crate::testing::mock_server::{MockServer, MockServerConfig};
+    use crate::types::AirPlayConfig;
+
+    let mut server = MockServer::new(MockServerConfig {
+        rtsp_port: 0,
+        audio_port: 0,
+        control_port: 0,
+        timing_port: 0,
+        ..MockServerConfig::default()
+    });
+    let addr = server.start().await.unwrap();
+
+    let config = AirPlayConfig::default();
+    let manager = Arc::new(ConnectionManager::new(config));
+
+    // Connect to mock server
+    let capabilities = crate::types::DeviceCapabilities {
+        airplay2: true,
+        ..Default::default()
+    };
+
+    let device = crate::types::AirPlayDevice {
+        id: "mock".to_string(),
+        name: "mock".to_string(),
+        model: None,
+        addresses: vec![addr.ip()],
+        port: addr.port(),
+        capabilities,
+        raop_port: None,
+        raop_capabilities: None,
+        txt_records: std::collections::HashMap::new(),
+        last_seen: Some(std::time::Instant::now()),
+    };
+
+    // Attempt connection - this establishes the RTSP channel so commands can be sent
+    manager.connect(&device).await.unwrap();
+
+    let controller = crate::control::playback::PlaybackController::new(manager);
+
+    assert!(controller.fast_forward().await.is_ok());
+
+    // Give the server a moment to process the command
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    assert_eq!(server.last_rate().await, Some(2.0));
+
+    assert!(controller.rewind().await.is_ok());
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    assert_eq!(server.last_rate().await, Some(-2.0));
+
+    server.stop().await;
 }
 
 #[tokio::test]

--- a/src/testing/mock_server.rs
+++ b/src/testing/mock_server.rs
@@ -69,6 +69,8 @@ struct ServerState {
     paired: bool,
     /// Pairing server instance
     pairing_server: PairingServer,
+    /// The last received rate value from `SetRateAnchorTime`
+    last_rate: Option<f64>,
 }
 
 /// A Mock `AirPlay` server.
@@ -103,6 +105,7 @@ impl MockServer {
                 volume: 0.0,
                 paired: false,
                 pairing_server,
+                last_rate: None,
             })),
             shutdown: None,
             address: None,
@@ -190,6 +193,11 @@ impl MockServer {
     /// Checks if the server is currently streaming.
     pub async fn is_streaming(&self) -> bool {
         self.state.read().await.streaming
+    }
+
+    /// Returns the last rate received.
+    pub async fn last_rate(&self) -> Option<f64> {
+        self.state.read().await.last_rate
     }
 
     /// Handles a single client connection.
@@ -422,12 +430,14 @@ impl MockServer {
             }
             Method::SetRateAnchorTime => {
                 // Parse body to check rate
+                let mut parsed_rate = None;
                 let streaming = if let Ok(plist) = crate::protocol::plist::decode(&request.body) {
                     if let Some(dict) = plist.as_dict() {
                         if let Some(rate) = dict
                             .get("rate")
                             .and_then(crate::protocol::plist::PlistValue::as_f64)
                         {
+                            parsed_rate = Some(rate);
                             rate.abs() > f64::EPSILON
                         } else {
                             true
@@ -439,7 +449,13 @@ impl MockServer {
                     true
                 };
 
-                state.write().await.streaming = streaming;
+                let mut state_write = state.write().await;
+                state_write.streaming = streaming;
+                if let Some(r) = parsed_rate {
+                    state_write.last_rate = Some(r);
+                }
+                drop(state_write);
+
                 Self::response(StatusCode::OK, cseq, None, None)
             }
             Method::Pause => {


### PR DESCRIPTION
Addresses the `TODO` for implementing rate control correctly in `PlaybackController::fast_forward` and `rewind`. 

- Modified `fast_forward` and `rewind` to send `SetRateAnchorTime` with `rate` of 2.0 and -2.0.
- Updated `MockServer` to extract and expose `last_rate` from the payload.
- Wrote unit tests leveraging `MockServer` to strictly verify payload contents and test for errors when disconnected.

---
*PR created automatically by Jules for task [8883865599161536045](https://jules.google.com/task/8883865599161536045) started by @jburnhams*