### PR TITLE
feat: implement rate control for fast-forward and rewind

### DIFF
--- a/src/control/playback.rs
+++ b/src/control/playback.rs
@@ -246,9 +246,7 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip forward 10s
-        self.seek_relative(Duration::from_secs(10), true).await
+        self.send_rate(2.0).await
     }
 
     /// Rewind
@@ -257,9 +255,7 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn rewind(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip backward 10s
-        self.seek_relative(Duration::from_secs(10), false).await
+        self.send_rate(-2.0).await
     }
 
     /// Set repeat mode
@@ -407,6 +403,12 @@ impl PlaybackController {
 
         // We use send_post_command.
         let _ = self.connection.send_post_command(&path, None, None).await?;
+        Ok(())
+    }
+
+    /// Internal: send rate command
+    async fn send_rate(&self, rate: f64) -> Result<(), AirPlayError> {
+        self.connection.send_set_rate_anchor_time(rate).await?;
         Ok(())
     }
 }

--- a/src/control/tests/playback.rs
+++ b/src/control/tests/playback.rs
@@ -131,3 +131,52 @@ async fn test_playback_controller_set_shuffle_and_repeat() {
     // it returns an error, state might remain unchanged.
     assert!(res.is_err());
 }
+
+#[tokio::test]
+async fn test_playback_controller_fast_forward_rewind() {
+    use crate::testing::mock_server::MockServer;
+    use crate::types::AirPlayDevice;
+
+    let mut server = MockServer::default_server();
+    server.start().await.unwrap();
+
+    // Create connection manager
+    let config = AirPlayConfig::default();
+    let manager = Arc::new(ConnectionManager::new(config));
+
+    // Connect to mock server
+    let device = AirPlayDevice {
+        id: "mock_device_ff_rewind".to_string(),
+        name: "Mock Device".to_string(),
+        addresses: vec![std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)],
+        port: server.address().unwrap().port(),
+        model: None,
+        capabilities: crate::types::DeviceCapabilities::default(),
+        raop_port: None,
+        raop_capabilities: None,
+        txt_records: std::collections::HashMap::new(),
+        last_seen: None,
+    };
+
+    manager.connect(&device).await.unwrap();
+
+    let controller = crate::control::playback::PlaybackController::new(manager);
+
+    // Test fast forward
+    controller.fast_forward().await.unwrap();
+    // Verify rate is 2.0
+    let rate = server.last_rate().await.unwrap();
+    assert!(
+        (rate - 2.0).abs() < f64::EPSILON,
+        "Expected fast-forward rate to be 2.0, got {rate}"
+    );
+
+    // Test rewind
+    controller.rewind().await.unwrap();
+    // Verify rate is -2.0
+    let rate = server.last_rate().await.unwrap();
+    assert!(
+        (rate - -2.0).abs() < f64::EPSILON,
+        "Expected rewind rate to be -2.0, got {rate}"
+    );
+}

--- a/src/testing/mock_server.rs
+++ b/src/testing/mock_server.rs
@@ -69,6 +69,8 @@ struct ServerState {
     paired: bool,
     /// Pairing server instance
     pairing_server: PairingServer,
+    /// Last rate received in `SetRateAnchorTime`
+    last_rate: Option<f64>,
 }
 
 /// A Mock `AirPlay` server.
@@ -103,6 +105,7 @@ impl MockServer {
                 volume: 0.0,
                 paired: false,
                 pairing_server,
+                last_rate: None,
             })),
             shutdown: None,
             address: None,
@@ -180,6 +183,11 @@ impl MockServer {
     /// Returns the number of audio packets received.
     pub async fn audio_packet_count(&self) -> usize {
         self.state.read().await.audio_packets.len()
+    }
+
+    /// Get the last playback rate received.
+    pub async fn last_rate(&self) -> Option<f64> {
+        self.state.read().await.last_rate
     }
 
     /// Returns the current volume level.
@@ -428,6 +436,7 @@ impl MockServer {
                             .get("rate")
                             .and_then(crate::protocol::plist::PlistValue::as_f64)
                         {
+                            state.write().await.last_rate = Some(rate);
                             rate.abs() > f64::EPSILON
                         } else {
                             true


### PR DESCRIPTION
This PR replaces the placeholder logic in the playback controller's `fast_forward` and `rewind` functions (which merely skipped playback forwards or backwards by 10 seconds) with actual rate adjustments via the `SetRateAnchorTime` RTSP payload. The mock server testing infrastructure has also been updated to ensure the client communicates these playback rates properly.

---
*PR created automatically by Jules for task [17946117486071500562](https://jules.google.com/task/17946117486071500562) started by @jburnhams*