### PR TITLE
Fix silently swallowed errors by adding proper tracing and logging

### DIFF
--- a/integration_tests/tests/heartbeat_integration.rs
+++ b/integration_tests/tests/heartbeat_integration.rs
@@ -55,8 +55,9 @@ async fn test_device_presence_heartbeat() -> Result<(), Box<dyn std::error::Erro
             }
             Ok(Some(_)) => {} // Ignore other events
             Ok(None) => break,
-            Err(_) => {
+            Err(e) => {
                 // Timeout, no new events in 2s
+                tracing::debug!("Timeout, no new events in 2s: {:?}", e);
             }
         }
 

--- a/src/protocol/rtp/ntp_client.rs
+++ b/src/protocol/rtp/ntp_client.rs
@@ -97,7 +97,9 @@ impl NtpClient {
                     valid_response = true;
                     break;
                 }
-                Ok(Err(_)) => {}                             // Ignore socket errors
+                Ok(Err(e)) => {
+                    tracing::debug!("Ignoring socket error: {:?}", e);
+                } // Ignore socket errors
                 Err(_) => return Err(AirPlayError::Timeout), // Timeout
             }
         }

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -182,7 +182,10 @@ impl EventFilter {
         loop {
             match self.rx.recv().await {
                 Ok(event) if (self.filter)(&event) => return Some(event),
-                Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {}
+                Ok(_) => {}
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    tracing::warn!("Event receiver lagged, skipped {} events", skipped);
+                }
                 Err(broadcast::error::RecvError::Closed) => return None,
             }
         }

--- a/tests/client_integration.rs
+++ b/tests/client_integration.rs
@@ -158,14 +158,16 @@ async fn test_client_connect_failure() {
     // We expect the connection to either timeout (if OS drops) or return an error (Connection
     // refused)
     match result {
-        Ok(Err(_e)) => {
+        Ok(Err(e)) => {
             // Connection failed as expected
+            tracing::info!("Connection failed as expected: {:?}", e);
         }
         Ok(Ok(_)) => {
             panic!("Connection succeeded when it should have failed");
         }
-        Err(_) => {
+        Err(e) => {
             // Timeout is also an acceptable failure mode depending on OS
+            tracing::info!("Connection timeout as expected: {:?}", e);
         }
     }
 


### PR DESCRIPTION
This PR addresses issues where `Err(_)` variants were being caught in match statements and ignored without logging or context, both in source files and testing files.

Changes made:
- Added `tracing::info!` log lines in `tests/client_integration.rs` for expected connection failure cases to provide better test visibility.
- Added a `tracing::debug!` log line in `integration_tests/tests/heartbeat_integration.rs` when timeouts occur.
- Added a `tracing::debug!` log line in `src/protocol/rtp/ntp_client.rs` to track socket errors that are correctly being ignored during NTP offset queries.
- Updated `src/state/events.rs` to explicitly catch `broadcast::error::RecvError::Lagged(skipped)` and emit a `tracing::warn!` with the number of skipped events rather than silently swallowing it with a generic `Ok(_) | Err(broadcast::error::RecvError::Lagged(_))` catchall.

Verified that tests continue to pass and `cargo clippy` and `cargo fmt` checks are clean.

---
*PR created automatically by Jules for task [13993438425871426890](https://jules.google.com/task/13993438425871426890) started by @jburnhams*