### PR TITLE
feat: implement rate control for fast-forward and rewind

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -418,6 +418,26 @@ impl AirPlayClient {
         self.playback.seek(position).await
     }
 
+    /// Fast forward
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
+        self.ensure_connected().await?;
+        self.playback.fast_forward().await
+    }
+
+    /// Rewind
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn rewind(&self) -> Result<(), AirPlayError> {
+        self.ensure_connected().await?;
+        self.playback.rewind().await
+    }
+
     /// Get current playback state
     pub async fn playback_state(&self) -> PlaybackState {
         self.state.get().await.playback

--- a/src/control/playback.rs
+++ b/src/control/playback.rs
@@ -246,9 +246,7 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip forward 10s
-        self.seek_relative(Duration::from_secs(10), true).await
+        self.send_rate(2.0).await
     }
 
     /// Rewind
@@ -257,9 +255,7 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn rewind(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip backward 10s
-        self.seek_relative(Duration::from_secs(10), false).await
+        self.send_rate(-2.0).await
     }
 
     /// Set repeat mode
@@ -395,6 +391,28 @@ impl PlaybackController {
                 Method::SetParameter,
                 Some(body),
                 Some("application/x-dmap-tagged".to_string()),
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Internal: send rate command
+    async fn send_rate(&self, rate: f64) -> Result<(), AirPlayError> {
+        let body = DictBuilder::new()
+            .insert("rate", rate)
+            .insert("rtpTime", 0u64)
+            .build();
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
+
+        self.connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
             )
             .await?;
         Ok(())

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -360,6 +360,24 @@ impl AirPlayPlayer {
         self.client.previous().await
     }
 
+    /// Fast forward
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
+        self.client.fast_forward().await
+    }
+
+    /// Rewind
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn rewind(&self) -> Result<(), AirPlayError> {
+        self.client.rewind().await
+    }
+
     /// Seek to position (in seconds)
     ///
     /// # Errors

--- a/src/testing/mock_server.rs
+++ b/src/testing/mock_server.rs
@@ -69,6 +69,8 @@ struct ServerState {
     paired: bool,
     /// Pairing server instance
     pairing_server: PairingServer,
+    /// Last rate received in `SetRateAnchorTime`
+    last_rate: Option<f64>,
 }
 
 /// A Mock `AirPlay` server.
@@ -103,6 +105,7 @@ impl MockServer {
                 volume: 0.0,
                 paired: false,
                 pairing_server,
+                last_rate: None,
             })),
             shutdown: None,
             address: None,
@@ -190,6 +193,11 @@ impl MockServer {
     /// Checks if the server is currently streaming.
     pub async fn is_streaming(&self) -> bool {
         self.state.read().await.streaming
+    }
+
+    /// Gets the last received playback rate.
+    pub async fn last_rate(&self) -> Option<f64> {
+        self.state.read().await.last_rate
     }
 
     /// Handles a single client connection.
@@ -422,12 +430,14 @@ impl MockServer {
             }
             Method::SetRateAnchorTime => {
                 // Parse body to check rate
+                let mut parsed_rate = None;
                 let streaming = if let Ok(plist) = crate::protocol::plist::decode(&request.body) {
                     if let Some(dict) = plist.as_dict() {
                         if let Some(rate) = dict
                             .get("rate")
                             .and_then(crate::protocol::plist::PlistValue::as_f64)
                         {
+                            parsed_rate = Some(rate);
                             rate.abs() > f64::EPSILON
                         } else {
                             true
@@ -439,7 +449,12 @@ impl MockServer {
                     true
                 };
 
-                state.write().await.streaming = streaming;
+                let mut write_state = state.write().await;
+                write_state.streaming = streaming;
+                if let Some(rate) = parsed_rate {
+                    write_state.last_rate = Some(rate);
+                }
+                drop(write_state);
                 Self::response(StatusCode::OK, cseq, None, None)
             }
             Method::Pause => {

--- a/tests/player_integration.rs
+++ b/tests/player_integration.rs
@@ -184,6 +184,57 @@ async fn test_player_advanced_controls() {
 }
 
 #[tokio::test]
+async fn test_player_rate_control() {
+    let config = MockServerConfig {
+        rtsp_port: 0,
+        ..Default::default()
+    };
+    let mut server = MockServer::new(config);
+    let addr = server.start().await.expect("Failed to start server");
+
+    let player = AirPlayPlayer::new();
+    let device = AirPlayDevice {
+        id: "player_test_rate".to_string(),
+        name: "Rate Control Test Device".to_string(),
+        model: Some("Mock".to_string()),
+        addresses: vec![addr.ip()],
+        port: addr.port(),
+        capabilities: airplay2::types::DeviceCapabilities {
+            airplay2: true,
+            supports_audio: true,
+            ..Default::default()
+        },
+        raop_port: None,
+        raop_capabilities: None,
+        txt_records: std::collections::HashMap::new(),
+        last_seen: None,
+    };
+
+    player.connect(&device).await.expect("Connect failed");
+
+    // Fast forward should set rate to 2.0
+    player.fast_forward().await.expect("Fast forward failed");
+    let rate = server.last_rate().await.expect("Expected a rate to be set");
+    assert!(
+        (rate - 2.0).abs() < f64::EPSILON,
+        "Expected rate to be 2.0, got {}",
+        rate
+    );
+
+    // Rewind should set rate to -2.0
+    player.rewind().await.expect("Rewind failed");
+    let rate = server.last_rate().await.expect("Expected a rate to be set");
+    assert!(
+        (rate - (-2.0)).abs() < f64::EPSILON,
+        "Expected rate to be -2.0, got {}",
+        rate
+    );
+
+    player.disconnect().await.expect("Disconnect failed");
+    server.stop().await;
+}
+
+#[tokio::test]
 async fn test_player_builder() {
     let player = PlayerBuilder::new()
         .connection_timeout(Duration::from_secs(5))


### PR DESCRIPTION
Implements proper rate control for AirPlay fast-forward and rewind mechanisms in place of the old 10-second seek behavior. Adds unit/integration test coverage with the mock server.

---
*PR created automatically by Jules for task [11853806512858676140](https://jules.google.com/task/11853806512858676140) started by @jburnhams*