### PR TITLE
feat(control): implement rate control for fast forward and rewind

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -354,6 +354,26 @@ impl AirPlayClient {
         self.playback.toggle().await
     }
 
+    /// Fast forward
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
+        self.ensure_connected().await?;
+        self.playback.fast_forward().await
+    }
+
+    /// Rewind
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn rewind(&self) -> Result<(), AirPlayError> {
+        self.ensure_connected().await?;
+        self.playback.rewind().await
+    }
+
     /// Stop playback
     ///
     /// # Errors

--- a/src/control/playback.rs
+++ b/src/control/playback.rs
@@ -246,9 +246,7 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip forward 10s
-        self.seek_relative(Duration::from_secs(10), true).await
+        self.set_rate(2.0).await
     }
 
     /// Rewind
@@ -257,9 +255,7 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn rewind(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip backward 10s
-        self.seek_relative(Duration::from_secs(10), false).await
+        self.set_rate(-2.0).await
     }
 
     /// Set repeat mode
@@ -385,6 +381,32 @@ impl PlaybackController {
         );
 
         self.set_progress(progress).await
+    }
+
+    /// Internal: send rate command
+    async fn set_rate(&self, rate: f64) -> Result<(), AirPlayError> {
+        let body = DictBuilder::new()
+            .insert("rate", rate)
+            .insert("rtpTime", 0u64)
+            .build();
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
+
+        self.connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
+            )
+            .await?;
+
+        // Update playing state based on rate
+        let mut state = self.state.write().await;
+        state.is_playing = rate.abs() > f64::EPSILON;
+        Ok(())
     }
 
     /// Internal: send metadata command

--- a/src/control/tests/playback.rs
+++ b/src/control/tests/playback.rs
@@ -78,6 +78,24 @@ fn test_shuffle_mode_defaults() {
 }
 
 #[tokio::test]
+async fn test_playback_controller_fast_forward_rewind_not_connected() {
+    use std::sync::Arc;
+
+    use crate::connection::ConnectionManager;
+    use crate::types::AirPlayConfig;
+
+    let config = AirPlayConfig::default();
+    let manager = Arc::new(ConnectionManager::new(config));
+    let controller = crate::control::playback::PlaybackController::new(manager);
+
+    let res = controller.fast_forward().await;
+    assert!(res.is_err(), "fast_forward() should fail when disconnected");
+
+    let res = controller.rewind().await;
+    assert!(res.is_err(), "rewind() should fail when disconnected");
+}
+
+#[tokio::test]
 async fn test_playback_controller_next_prev_not_connected() {
     use std::sync::Arc;
 

--- a/src/testing/mock_server.rs
+++ b/src/testing/mock_server.rs
@@ -65,6 +65,8 @@ struct ServerState {
     audio_packets: Vec<RtpPacket>,
     /// Current volume level in dB (or similar scale).
     volume: f32,
+    /// Current playback rate.
+    rate: f64,
     /// Whether the client is paired.
     paired: bool,
     /// Pairing server instance
@@ -101,6 +103,7 @@ impl MockServer {
                 session_id: None,
                 audio_packets: Vec::new(),
                 volume: 0.0,
+                rate: 0.0,
                 paired: false,
                 pairing_server,
             })),
@@ -190,6 +193,11 @@ impl MockServer {
     /// Checks if the server is currently streaming.
     pub async fn is_streaming(&self) -> bool {
         self.state.read().await.streaming
+    }
+
+    /// Gets the current playback rate.
+    pub async fn rate(&self) -> f64 {
+        self.state.read().await.rate
     }
 
     /// Handles a single client connection.
@@ -422,24 +430,27 @@ impl MockServer {
             }
             Method::SetRateAnchorTime => {
                 // Parse body to check rate
-                let streaming = if let Ok(plist) = crate::protocol::plist::decode(&request.body) {
-                    if let Some(dict) = plist.as_dict() {
-                        if let Some(rate) = dict
-                            .get("rate")
-                            .and_then(crate::protocol::plist::PlistValue::as_f64)
-                        {
-                            rate.abs() > f64::EPSILON
+                let (streaming, rate) =
+                    if let Ok(plist) = crate::protocol::plist::decode(&request.body) {
+                        if let Some(dict) = plist.as_dict() {
+                            if let Some(rate) = dict
+                                .get("rate")
+                                .and_then(crate::protocol::plist::PlistValue::as_f64)
+                            {
+                                (rate.abs() > f64::EPSILON, rate)
+                            } else {
+                                (true, 1.0)
+                            }
                         } else {
-                            true
+                            (true, 1.0)
                         }
                     } else {
-                        true
-                    }
-                } else {
-                    true
-                };
+                        (true, 1.0)
+                    };
 
-                state.write().await.streaming = streaming;
+                let mut state_guard = state.write().await;
+                state_guard.streaming = streaming;
+                state_guard.rate = rate;
                 Self::response(StatusCode::OK, cseq, None, None)
             }
             Method::Pause => {

--- a/tests/client_integration.rs
+++ b/tests/client_integration.rs
@@ -135,6 +135,57 @@ async fn test_client_integration_flow() {
 }
 
 #[tokio::test]
+async fn test_fast_forward_and_rewind() {
+    let config = MockServerConfig {
+        rtsp_port: 0,
+        ..Default::default()
+    };
+    let mut server = MockServer::new(config);
+    let addr = server.start().await.expect("Failed to start mock server");
+
+    let client = AirPlayClient::default_client();
+    let device = AirPlayDevice {
+        id: "mock_device_ffwd_rewind".to_string(),
+        name: "Mock Device".to_string(),
+        model: Some("MockModel".to_string()),
+        addresses: vec![addr.ip()],
+        port: addr.port(),
+        capabilities: Default::default(),
+        raop_port: None,
+        raop_capabilities: None,
+        txt_records: std::collections::HashMap::new(),
+        last_seen: None,
+    };
+
+    client.connect(&device).await.expect("Connection failed");
+
+    assert!(client.is_connected().await);
+
+    // Fast Forward
+    client.fast_forward().await.expect("Fast forward failed");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let rate = server.rate().await;
+    assert!(
+        (rate - 2.0).abs() < f64::EPSILON,
+        "Server received rate {}, expected 2.0",
+        rate
+    );
+
+    // Rewind
+    client.rewind().await.expect("Rewind failed");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let rate = server.rate().await;
+    assert!(
+        (rate - (-2.0)).abs() < f64::EPSILON,
+        "Server received rate {}, expected -2.0",
+        rate
+    );
+
+    client.disconnect().await.expect("Disconnect failed");
+    server.stop().await;
+}
+
+#[tokio::test]
 async fn test_client_connect_failure() {
     let client = AirPlayClient::default_client();
     let _events = client.subscribe_events();


### PR DESCRIPTION
Replaced the TODO placeholders for fast_forward and rewind in
PlaybackController with actual implementations using the AirPlay
SetRateAnchorTime command. Added set_rate function, exposed methods on AirPlayClient, updated MockServer to track rate, and added relevant unit and integration tests.

---
*PR created automatically by Jules for task [992273266639144698](https://jules.google.com/task/992273266639144698) started by @jburnhams*