### PR TITLE
feat: implement rate playback controls

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -418,6 +418,26 @@ impl AirPlayClient {
         self.playback.seek(position).await
     }
 
+    /// Fast forward
+    ///
+    /// # Errors
+    ///
+    /// Returns error if network fails
+    pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
+        self.ensure_connected().await?;
+        self.playback.fast_forward().await
+    }
+
+    /// Rewind
+    ///
+    /// # Errors
+    ///
+    /// Returns error if network fails
+    pub async fn rewind(&self) -> Result<(), AirPlayError> {
+        self.ensure_connected().await?;
+        self.playback.rewind().await
+    }
+
     /// Get current playback state
     pub async fn playback_state(&self) -> PlaybackState {
         self.state.get().await.playback

--- a/src/control/playback.rs
+++ b/src/control/playback.rs
@@ -246,9 +246,25 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip forward 10s
-        self.seek_relative(Duration::from_secs(10), true).await
+        let body = DictBuilder::new()
+            .insert("rate", 2.0f64)
+            .insert("rtpTime", 0u64)
+            .build();
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
+
+        let _ = self
+            .connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
+            )
+            .await?;
+        Ok(())
     }
 
     /// Rewind
@@ -257,9 +273,25 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn rewind(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip backward 10s
-        self.seek_relative(Duration::from_secs(10), false).await
+        let body = DictBuilder::new()
+            .insert("rate", -2.0f64)
+            .insert("rtpTime", 0u64)
+            .build();
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
+
+        let _ = self
+            .connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
+            )
+            .await?;
+        Ok(())
     }
 
     /// Set repeat mode

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -369,6 +369,24 @@ impl AirPlayPlayer {
         self.client.seek(Duration::from_secs_f64(seconds)).await
     }
 
+    /// Fast forward
+    ///
+    /// # Errors
+    ///
+    /// Returns error if network fails
+    pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
+        self.client.fast_forward().await
+    }
+
+    /// Rewind
+    ///
+    /// # Errors
+    ///
+    /// Returns error if network fails
+    pub async fn rewind(&self) -> Result<(), AirPlayError> {
+        self.client.rewind().await
+    }
+
     // === Volume ===
 
     /// Set volume (0.0 - 1.0)

--- a/src/testing/mock_server.rs
+++ b/src/testing/mock_server.rs
@@ -65,6 +65,8 @@ struct ServerState {
     audio_packets: Vec<RtpPacket>,
     /// Current volume level in dB (or similar scale).
     volume: f32,
+    /// Current playback rate.
+    rate: f64,
     /// Whether the client is paired.
     paired: bool,
     /// Pairing server instance
@@ -101,6 +103,7 @@ impl MockServer {
                 session_id: None,
                 audio_packets: Vec::new(),
                 volume: 0.0,
+                rate: 0.0,
                 paired: false,
                 pairing_server,
             })),
@@ -185,6 +188,11 @@ impl MockServer {
     /// Returns the current volume level.
     pub async fn volume(&self) -> f32 {
         self.state.read().await.volume
+    }
+
+    /// Returns the current playback rate.
+    pub async fn rate(&self) -> f64 {
+        self.state.read().await.rate
     }
 
     /// Checks if the server is currently streaming.
@@ -422,12 +430,14 @@ impl MockServer {
             }
             Method::SetRateAnchorTime => {
                 // Parse body to check rate
+                let mut rate_val = 0.0;
                 let streaming = if let Ok(plist) = crate::protocol::plist::decode(&request.body) {
                     if let Some(dict) = plist.as_dict() {
                         if let Some(rate) = dict
                             .get("rate")
                             .and_then(crate::protocol::plist::PlistValue::as_f64)
                         {
+                            rate_val = rate;
                             rate.abs() > f64::EPSILON
                         } else {
                             true
@@ -439,7 +449,10 @@ impl MockServer {
                     true
                 };
 
-                state.write().await.streaming = streaming;
+                let mut s = state.write().await;
+                s.streaming = streaming;
+                s.rate = rate_val;
+                drop(s);
                 Self::response(StatusCode::OK, cseq, None, None)
             }
             Method::Pause => {

--- a/tests/player_integration.rs
+++ b/tests/player_integration.rs
@@ -218,3 +218,54 @@ async fn test_player_disconnected_errors() {
     let res = player.seek(10.0).await;
     assert!(matches!(res, Err(AirPlayError::Disconnected { .. })));
 }
+
+#[tokio::test]
+async fn test_player_fast_forward_and_rewind() {
+    let config = MockServerConfig {
+        rtsp_port: 0,
+        ..Default::default()
+    };
+    let mut server = MockServer::new(config);
+    let addr = server.start().await.expect("Failed to start server");
+
+    let player = AirPlayPlayer::new();
+    let device = AirPlayDevice {
+        id: "player_test_ffwd_rewind".to_string(),
+        name: "FFwd Rewind Test Device".to_string(),
+        model: Some("Mock".to_string()),
+        addresses: vec![addr.ip()],
+        port: addr.port(),
+        capabilities: airplay2::types::DeviceCapabilities {
+            airplay2: true,
+            supports_audio: true,
+            ..Default::default()
+        },
+        raop_port: None,
+        raop_capabilities: None,
+        txt_records: std::collections::HashMap::new(),
+        last_seen: None,
+    };
+
+    player.connect(&device).await.expect("Connect failed");
+
+    // Fast Forward
+    player.fast_forward().await.expect("Fast forward failed");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let rate = server.rate().await;
+    assert!(
+        (rate - 2.0).abs() < f64::EPSILON,
+        "Rate should be 2.0 after fast forward"
+    );
+
+    // Rewind
+    player.rewind().await.expect("Rewind failed");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let rate = server.rate().await;
+    assert!(
+        (rate - (-2.0)).abs() < f64::EPSILON,
+        "Rate should be -2.0 after rewind"
+    );
+
+    player.disconnect().await.expect("Disconnect failed");
+    server.stop().await;
+}


### PR DESCRIPTION
- Replace `TODO` in `fast_forward` and `rewind` functions of `src/control/playback.rs` to send actual `SetRateAnchorTime` commands.
- Track playback rate state inside testing `MockServer`.
- Expose `fast_forward` and `rewind` on `AirPlayClient` and `AirPlayPlayer`.
- Add integration tests verifying rate playback commands.

---
*PR created automatically by Jules for task [4358860693909295121](https://jules.google.com/task/4358860693909295121) started by @jburnhams*