### PR TITLE
refactor: Add reasons to allow attributes

### DIFF
--- a/examples/play_mp3.rs
+++ b/examples/play_mp3.rs
@@ -32,7 +32,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         cfg
     };
 
-    #[allow(unused_mut)]
+    #[allow(
+        unused_mut,
+        reason = "Variables might be conditionally mutated based on features"
+    )]
     let mut player = AirPlayPlayer::with_config(config);
     let mut retry_count = 0;
     let max_retries = 5;

--- a/examples/play_mp3_verified.rs
+++ b/examples/play_mp3_verified.rs
@@ -25,7 +25,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Step 1: Connect to Kitchen
     println!("[1/6] Connecting to '{}'...", target_name);
-    #[allow(unused_mut)]
+    #[allow(
+        unused_mut,
+        reason = "Variables might be conditionally mutated based on features"
+    )]
     let mut player = AirPlayPlayer::new();
     let mut connected = false;
 

--- a/integration_tests/tests/common/audio_verify.rs
+++ b/integration_tests/tests/common/audio_verify.rs
@@ -1,14 +1,14 @@
 use std::path::Path;
 use std::time::Duration;
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "Shared test utility functions may not be used by all test modules")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Endianness {
     Little,
     Big,
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "Shared test utility functions may not be used by all test modules")]
 #[derive(Debug, Clone)]
 pub struct SineWaveCheck {
     pub expected_frequency: f32,
@@ -36,7 +36,7 @@ impl Default for SineWaveCheck {
     }
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "Shared test utility functions may not be used by all test modules")]
 #[derive(Debug, Clone)]
 pub struct SineWaveResult {
     pub measured_frequency: f32,
@@ -343,7 +343,7 @@ pub fn measure_onset_latency(audio: &RawAudio, threshold: f32) -> Duration {
     }
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "Shared test utility functions may not be used by all test modules")]
 #[derive(Debug, Clone)]
 pub struct GapInfo {
     pub start_frame: usize,
@@ -400,7 +400,7 @@ pub fn measure_gap_latency(audio: &RawAudio, gap_threshold_ms: f32) -> Vec<GapIn
     gaps
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "Shared test utility functions may not be used by all test modules")]
 #[derive(Debug, Clone)]
 pub struct CompareResult {
     pub sample_count_match: bool,
@@ -546,7 +546,7 @@ pub fn compute_snr(original: &RawAudio, received: &RawAudio) -> f64 {
     10.0 * (signal_power as f64 / noise_power as f64).log10()
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "Shared test utility functions may not be used by all test modules")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CodecType {
     Pcm,
@@ -661,7 +661,7 @@ pub fn audio_diagnostic_report(audio: &RawAudio, filename: &str, checks: &[Box<d
     report
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "Shared test utility functions may not be used by all test modules")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RawAudioFormat {
     pub sample_rate: u32,
@@ -671,9 +671,9 @@ pub struct RawAudioFormat {
     pub signed: bool,
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "Shared test utility functions may not be used by all test modules")]
 impl RawAudioFormat {
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "Shared test utility functions may not be used by all test modules")]
     pub const CD_QUALITY: Self = Self {
         sample_rate: 44100,
         channels: 2,
@@ -681,7 +681,7 @@ impl RawAudioFormat {
         endianness: Endianness::Little,
         signed: true,
     };
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "Shared test utility functions may not be used by all test modules")]
     pub const HIRES: Self = Self {
         sample_rate: 48000,
         channels: 2,
@@ -691,7 +691,7 @@ impl RawAudioFormat {
     };
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "Shared test utility functions may not be used by all test modules")]
 #[derive(Debug, Clone)]
 pub struct RawAudio {
     pub data: Vec<u8>,
@@ -702,7 +702,7 @@ pub struct RawAudio {
     pub signed: bool,
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "Shared test utility functions may not be used by all test modules")]
 #[derive(Debug, thiserror::Error)]
 pub enum AudioVerifyError {
     #[error("IO error: {0}")]
@@ -714,7 +714,7 @@ pub enum AudioVerifyError {
 }
 
 impl RawAudio {
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "Shared test utility functions may not be used by all test modules")]
     pub fn from_file(path: &Path, format: RawAudioFormat) -> Result<Self, AudioVerifyError> {
         let data = std::fs::read(path)?;
         Ok(Self::from_bytes(data, format))

--- a/integration_tests/tests/common/subprocess.rs
+++ b/integration_tests/tests/common/subprocess.rs
@@ -15,7 +15,11 @@ use nix::sys::signal::Signal;
 /// never passed to kill() — see the `#[cfg(windows)]` block in `stop()`).
 #[cfg(windows)]
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[allow(non_camel_case_types, dead_code)]
+#[allow(
+    non_camel_case_types,
+    dead_code,
+    reason = "Windows dummy types might not be fully used or conform to standard casing"
+)]
 pub enum Signal {
     SIGTERM,
     SIGKILL,

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,7 +1,10 @@
 //! Audio handling module
 
-#![allow(unused_imports)]
-#![allow(dead_code)]
+#![allow(
+    unused_imports,
+    dead_code,
+    reason = "Placeholder or experimental modules may have unused imports and dead code"
+)]
 
 pub mod aac_encoder;
 pub mod buffer;

--- a/src/protocol/crypto/mod.rs
+++ b/src/protocol/crypto/mod.rs
@@ -1,13 +1,14 @@
 //! Cryptographic primitives for `AirPlay` authentication and encryption
 
-#![allow(dead_code)]
-#![allow(unused_imports)]
-#![allow(missing_docs)]
 #![allow(
+    dead_code,
+    unused_imports,
+    missing_docs,
     clippy::all,
     clippy::pedantic,
     clippy::nursery,
-    reason = "Legacy module"
+    reason = "Internal or work-in-progress cryptographic primitives where strict linting is \
+              currently relaxed"
 )]
 
 mod aes;

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,6 +1,6 @@
 //! Protocol module
 
-#![allow(missing_docs)]
+#![allow(missing_docs, reason = "Internal or work-in-progress protocols")]
 
 pub mod crypto;
 pub mod daap;

--- a/src/protocol/plist/mod.rs
+++ b/src/protocol/plist/mod.rs
@@ -1,12 +1,12 @@
 //! Binary plist codec for `AirPlay` protocol messages
-#![allow(dead_code)]
-#![allow(unused_imports)]
-#![allow(missing_docs)]
 #![allow(
+    dead_code,
+    unused_imports,
+    missing_docs,
     clippy::all,
     clippy::pedantic,
     clippy::nursery,
-    reason = "Legacy module"
+    reason = "Binary plist codec module where strict linting is currently relaxed"
 )]
 
 pub mod airplay;

--- a/src/protocol/ptp/tests/node.rs
+++ b/src/protocol/ptp/tests/node.rs
@@ -1590,7 +1590,10 @@ async fn test_delay_resp_correction_field_t4_extraction() {
     // ── Simulate HomePod sending Sync + Follow_Up ────────────────────────────
     // We use a HomePod-style epoch: T1 = 1000 s from HomePod reference.
     // Unix epoch offset would be ~56 years; we pick something computable.
-    #[allow(clippy::no_effect_underscore_binding)]
+    #[allow(
+        clippy::no_effect_underscore_binding,
+        reason = "kept for documentation"
+    )]
     let _t1_homepod_ns: i128 = 1_000_000_000_000; // 1000 s in HomePod ns (kept for documentation)
 
     // Build a Sync message (transport_specific=1, messageType=0x00).

--- a/src/protocol/rtsp/mod.rs
+++ b/src/protocol/rtsp/mod.rs
@@ -1,7 +1,10 @@
 //! Sans-IO RTSP protocol implementation for `AirPlay`
 
-#![allow(unused_imports)]
-#![allow(dead_code)]
+#![allow(
+    unused_imports,
+    dead_code,
+    reason = "Placeholder or experimental modules may have unused imports and dead code"
+)]
 
 pub mod codec;
 pub mod headers;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,5 @@
 //! Common test utilities and fixtures
-#![allow(dead_code)]
+#![allow(dead_code, reason = "Shared test utilities might not be used by all tests")]
 
 use std::sync::Once;
 use tracing_subscriber::{EnvFilter, fmt};


### PR DESCRIPTION
- Found multiple `allow` and `clippy::allow` directives that were missing the mandatory `reason` string to explain why a particular lint was bypassed.
- Specifically focused on consolidating multiple module-level allows into single multi-line `allow` directives (e.g. `src/protocol/crypto/mod.rs` and `src/audio/mod.rs`).
- Also fixed a handful of `dead_code` allows in test utilities and `unused_mut` in `examples/`.
- Validated via `cargo clippy --all-targets --all-features` and `cargo test`.

---
*PR created automatically by Jules for task [13370806590913063929](https://jules.google.com/task/13370806590913063929) started by @jburnhams*