### PR TITLE
Feat: Implement Playback Rate Controls for fast-forward/rewind

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -354,6 +354,26 @@ impl AirPlayClient {
         self.playback.toggle().await
     }
 
+    /// Fast forward
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
+        self.ensure_connected().await?;
+        self.playback.fast_forward().await
+    }
+
+    /// Rewind
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn rewind(&self) -> Result<(), AirPlayError> {
+        self.ensure_connected().await?;
+        self.playback.rewind().await
+    }
+
     /// Stop playback
     ///
     /// # Errors

--- a/src/control/playback.rs
+++ b/src/control/playback.rs
@@ -246,9 +246,7 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip forward 10s
-        self.seek_relative(Duration::from_secs(10), true).await
+        self.send_rate(2.0).await
     }
 
     /// Rewind
@@ -257,9 +255,7 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn rewind(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip backward 10s
-        self.seek_relative(Duration::from_secs(10), false).await
+        self.send_rate(-2.0).await
     }
 
     /// Set repeat mode
@@ -365,6 +361,25 @@ impl PlaybackController {
         Ok(())
     }
 
+    /// Internal: send rate command
+    async fn send_rate(&self, rate: f64) -> Result<(), AirPlayError> {
+        let body = DictBuilder::new().insert("rate", rate).build();
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
+
+        self.connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
+            )
+            .await?;
+        Ok(())
+    }
+
     /// Internal: send scrub command
     async fn send_scrub(&self, position: f64) -> Result<(), AirPlayError> {
         // AirPlay 2 uses progress parameter for scrub
@@ -437,5 +452,33 @@ impl PlaybackProgress {
     #[must_use]
     pub fn remaining(&self) -> Duration {
         self.duration.saturating_sub(self.position)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_playback_progress() {
+        let progress = PlaybackProgress {
+            position: Duration::from_secs(30),
+            duration: Duration::from_secs(120),
+            rate: 1.0,
+        };
+
+        assert!((progress.progress() - 0.25).abs() < f64::EPSILON);
+        assert_eq!(progress.remaining(), Duration::from_secs(90));
+    }
+
+    #[test]
+    fn test_progress_zero_duration() {
+        let progress = PlaybackProgress {
+            position: Duration::from_secs(0),
+            duration: Duration::from_secs(0),
+            rate: 0.0,
+        };
+
+        assert!((progress.progress() - 0.0).abs() < f64::EPSILON);
     }
 }

--- a/src/testing/mock_server.rs
+++ b/src/testing/mock_server.rs
@@ -65,6 +65,8 @@ struct ServerState {
     audio_packets: Vec<RtpPacket>,
     /// Current volume level in dB (or similar scale).
     volume: f32,
+    /// Current rate set by `SetRateAnchorTime`
+    rate: f64,
     /// Whether the client is paired.
     paired: bool,
     /// Pairing server instance
@@ -101,6 +103,7 @@ impl MockServer {
                 session_id: None,
                 audio_packets: Vec::new(),
                 volume: 0.0,
+                rate: 1.0,
                 paired: false,
                 pairing_server,
             })),
@@ -185,6 +188,11 @@ impl MockServer {
     /// Returns the current volume level.
     pub async fn volume(&self) -> f32 {
         self.state.read().await.volume
+    }
+
+    /// Gets the current rate.
+    pub async fn rate(&self) -> f64 {
+        self.state.read().await.rate
     }
 
     /// Checks if the server is currently streaming.
@@ -422,24 +430,26 @@ impl MockServer {
             }
             Method::SetRateAnchorTime => {
                 // Parse body to check rate
-                let streaming = if let Ok(plist) = crate::protocol::plist::decode(&request.body) {
+                let mut is_streaming = true;
+                let mut new_rate = None;
+                if let Ok(plist) = crate::protocol::plist::decode(&request.body) {
                     if let Some(dict) = plist.as_dict() {
                         if let Some(rate) = dict
                             .get("rate")
                             .and_then(crate::protocol::plist::PlistValue::as_f64)
                         {
-                            rate.abs() > f64::EPSILON
-                        } else {
-                            true
+                            new_rate = Some(rate);
+                            is_streaming = rate.abs() > f64::EPSILON;
                         }
-                    } else {
-                        true
                     }
-                } else {
-                    true
-                };
+                }
 
-                state.write().await.streaming = streaming;
+                let mut write_state = state.write().await;
+                if let Some(r) = new_rate {
+                    write_state.rate = r;
+                }
+                write_state.streaming = is_streaming;
+                drop(write_state);
                 Self::response(StatusCode::OK, cseq, None, None)
             }
             Method::Pause => {

--- a/tests/client_integration.rs
+++ b/tests/client_integration.rs
@@ -108,10 +108,21 @@ async fn test_client_integration_flow() {
     );
     assert!((client.volume().await - 0.5).abs() < f32::EPSILON);
 
+    // Fast forward
+    client.fast_forward().await.expect("Fast forward failed");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!((server.rate().await - 2.0).abs() < f64::EPSILON);
+
+    // Rewind
+    client.rewind().await.expect("Rewind failed");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!((server.rate().await - -2.0).abs() < f64::EPSILON);
+
     // Pause
     client.pause().await.expect("Pause failed");
     tokio::time::sleep(Duration::from_millis(50)).await;
     assert!(!server.is_streaming().await);
+    assert!((server.rate().await - 0.0).abs() < f64::EPSILON);
     assert!(!client.playback_state().await.is_playing);
 
     // 6. Disconnect


### PR DESCRIPTION
Implemented proper playback rate control for AirPlay 2 by filling out the TODOs in `src/control/playback.rs`. Instead of performing relative time seeks, `fast_forward` and `rewind` now correctly construct an Apple Binary Plist with the target rate parameter and send it via the RTSP `SetRateAnchorTime` command. The changes include adding unit tests for playback progress, exposing the methods on `AirPlayClient`, and writing end-to-end integration tests using `MockServer`.

---
*PR created automatically by Jules for task [2559796829566174391](https://jules.google.com/task/2559796829566174391) started by @jburnhams*