### PR TITLE
Fix tests with silent early returns and invalid ignores

### DIFF
--- a/src/protocol/ptp/tests/handler.rs
+++ b/src/protocol/ptp/tests/handler.rs
@@ -215,10 +215,7 @@ async fn test_airplay_format_exchange() {
 
 #[tokio::test]
 async fn test_master_handler_responds_to_delay_req() {
-    let Ok(sock) = UdpSocket::bind("127.0.0.1:0").await else {
-        // Can't bind privileged port in this environment — skip test.
-        return;
-    };
+    let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let master_sock = Arc::new(sock);
 
     let client_sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -455,13 +452,11 @@ async fn test_master_handler_clock_accessor() {
 /// We simulate this by having a client bind to port 320 on loopback and checking
 /// the `Delay_Resp` arrives there.
 #[tokio::test]
+#[ignore = "Requires root permissions to bind privileged PTP port (320)"]
 async fn test_master_sends_delay_resp_on_general_port() {
     // Bind the client "general" socket to the expected PTP general port (320).
     // This simulates how a real PTP slave would listen.
-    let Ok(client_general) = UdpSocket::bind(("127.0.0.1", PTP_GENERAL_PORT)).await else {
-        // Can't bind privileged port in this environment — skip test.
-        return;
-    };
+    let client_general = UdpSocket::bind(("127.0.0.1", PTP_GENERAL_PORT)).await.unwrap();
 
     let master_event = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
     let master_general = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());

--- a/src/protocol/ptp/tests/handler.rs
+++ b/src/protocol/ptp/tests/handler.rs
@@ -456,7 +456,9 @@ async fn test_master_handler_clock_accessor() {
 async fn test_master_sends_delay_resp_on_general_port() {
     // Bind the client "general" socket to the expected PTP general port (320).
     // This simulates how a real PTP slave would listen.
-    let client_general = UdpSocket::bind(("127.0.0.1", PTP_GENERAL_PORT)).await.unwrap();
+    let client_general = UdpSocket::bind(("127.0.0.1", PTP_GENERAL_PORT))
+        .await
+        .unwrap();
 
     let master_event = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
     let master_general = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());

--- a/test_captures.sh
+++ b/test_captures.sh
@@ -1,0 +1,1 @@
+cargo test --test capture_replay_tests

--- a/tests/receiver/capture_replay_tests.rs
+++ b/tests/receiver/capture_replay_tests.rs
@@ -11,10 +11,11 @@ use airplay2::testing::packet_capture::{CaptureLoader, CaptureProtocol, CaptureR
 fn test_captured_info_request() {
     let capture_path = Path::new("tests/captures/info_request.hex");
 
-    if !capture_path.exists() {
-        eprintln!("Skipping: capture file not found");
-        return;
-    }
+    assert!(
+        capture_path.exists(),
+        "Capture file not found: {:?}",
+        capture_path
+    );
 
     let packets = CaptureLoader::load_hex_dump(capture_path).unwrap();
     let mut replay = CaptureReplay::new(packets);
@@ -42,10 +43,11 @@ fn test_captured_info_request() {
 fn test_captured_pairing() {
     let capture_path = Path::new("tests/captures/pairing_exchange.hex");
 
-    if !capture_path.exists() {
-        eprintln!("Skipping: capture file not found");
-        return;
-    }
+    assert!(
+        capture_path.exists(),
+        "Capture file not found: {:?}",
+        capture_path
+    );
 
     let packets = CaptureLoader::load_hex_dump(capture_path).unwrap();
 


### PR DESCRIPTION
Fixed testing anti-patterns where several tests were silently passing despite failures or missing prerequisites. Specifically:
- `capture_replay_tests.rs`: Capture files are verified with `assert!` to prevent silently skipping if files are missing.
- `handler.rs`: Ensured tests strictly `unwrap()` UDP socket binds, failing properly when ephemeral port binding fails.
- Added appropriate `#[ignore]` descriptions for tests requiring root privileges for PTP testing.

---
*PR created automatically by Jules for task [14380871224729499579](https://jules.google.com/task/14380871224729499579) started by @jburnhams*