### PR TITLE
Implement playback rate control for fast-forward and rewind

### DIFF
--- a/src/control/playback.rs
+++ b/src/control/playback.rs
@@ -75,46 +75,7 @@ impl PlaybackController {
         let mut state = self.state.write().await;
 
         if !state.is_playing {
-            let mut builder = DictBuilder::new()
-                .insert("rate", 1i64)
-                .insert("rtpTime", 0u64);
-
-            // Include PTP anchor timestamps so the device knows when to render
-            if let Some((secs, frac, timeline_id)) = self.connection.get_ptp_network_time().await {
-                tracing::info!(
-                    "SetRateAnchorTime: anchoring rtpTime=0 to PTP time {}.{:09} \
-                     (timeline=0x{:016X})",
-                    secs,
-                    // Convert frac back to nanos for display: nanos = frac * 10^9 / 2^64
-                    u32::try_from((u128::from(frac) * 1_000_000_000u128) >> 64)
-                        .expect("PTP time fraction conversion should fit in u32"),
-                    timeline_id,
-                );
-                builder = builder
-                    .insert("networkTimeSecs", secs)
-                    .insert("networkTimeFrac", frac)
-                    .insert("networkTimeTimelineID", timeline_id);
-            } else {
-                tracing::warn!(
-                    "SetRateAnchorTime: PTP clock not available or not synchronized — sending \
-                     without networkTime fields (device may not render audio)"
-                );
-            }
-
-            let body = builder.build();
-            let encoded =
-                crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
-                    message: format!("Failed to encode plist: {e}"),
-                    status_code: None,
-                })?;
-
-            self.connection
-                .send_command(
-                    Method::SetRateAnchorTime,
-                    Some(encoded),
-                    Some("application/x-apple-binary-plist".to_string()),
-                )
-                .await?;
+            self.send_rate(1.0).await?;
             state.is_playing = true;
         }
 
@@ -131,23 +92,7 @@ impl PlaybackController {
 
         // Send pause unconditionally. We might have started a stream in another task
         // and the state might not be synchronized, but it's safe to send a pause command.
-        let body = DictBuilder::new()
-            .insert("rate", 0i64)
-            .insert("rtpTime", 0u64)
-            .build();
-        let encoded =
-            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
-                message: format!("Failed to encode plist: {e}"),
-                status_code: None,
-            })?;
-
-        self.connection
-            .send_command(
-                Method::SetRateAnchorTime,
-                Some(encoded),
-                Some("application/x-apple-binary-plist".to_string()),
-            )
-            .await?;
+        self.send_rate(0.0).await?;
         state.is_playing = false;
 
         Ok(())
@@ -246,9 +191,7 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip forward 10s
-        self.seek_relative(Duration::from_secs(10), true).await
+        self.send_rate(2.0).await
     }
 
     /// Rewind
@@ -257,9 +200,7 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn rewind(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip backward 10s
-        self.seek_relative(Duration::from_secs(10), false).await
+        self.send_rate(-2.0).await
     }
 
     /// Set repeat mode
@@ -362,6 +303,55 @@ impl PlaybackController {
                 Some(mime_type.to_string()),
             )
             .await?;
+        Ok(())
+    }
+
+    /// Internal: send rate command
+    async fn send_rate(&self, rate: f64) -> Result<(), AirPlayError> {
+        let mut builder = DictBuilder::new()
+            .insert("rate", rate)
+            .insert("rtpTime", 0u64);
+
+        // For non-zero rate, include PTP anchor timestamps so the device knows when to render
+        if rate.abs() > f64::EPSILON {
+            if let Some((secs, frac, timeline_id)) = self.connection.get_ptp_network_time().await {
+                tracing::info!(
+                    "SetRateAnchorTime: anchoring rtpTime=0 to PTP time {}.{:09} \
+                     (timeline=0x{:016X}) with rate {}",
+                    secs,
+                    // Convert frac back to nanos for display: nanos = frac * 10^9 / 2^64
+                    u32::try_from((u128::from(frac) * 1_000_000_000u128) >> 64)
+                        .expect("PTP time fraction conversion should fit in u32"),
+                    timeline_id,
+                    rate
+                );
+                builder = builder
+                    .insert("networkTimeSecs", secs)
+                    .insert("networkTimeFrac", frac)
+                    .insert("networkTimeTimelineID", timeline_id);
+            } else {
+                tracing::warn!(
+                    "SetRateAnchorTime: PTP clock not available or not synchronized — sending \
+                     without networkTime fields (device may not render audio)"
+                );
+            }
+        }
+
+        let body = builder.build();
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
+
+        self.connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
+            )
+            .await?;
+
         Ok(())
     }
 

--- a/src/control/playback.rs
+++ b/src/control/playback.rs
@@ -75,7 +75,7 @@ impl PlaybackController {
         let mut state = self.state.write().await;
 
         if !state.is_playing {
-            self.send_rate(1.0).await?;
+            self.send_rate_i64(1).await?;
             state.is_playing = true;
         }
 
@@ -92,7 +92,7 @@ impl PlaybackController {
 
         // Send pause unconditionally. We might have started a stream in another task
         // and the state might not be synchronized, but it's safe to send a pause command.
-        self.send_rate(0.0).await?;
+        self.send_rate_i64(0).await?;
         state.is_playing = false;
 
         Ok(())
@@ -306,6 +306,54 @@ impl PlaybackController {
         Ok(())
     }
 
+    /// Internal: send rate command with an integer
+    async fn send_rate_i64(&self, rate: i64) -> Result<(), AirPlayError> {
+        let mut builder = DictBuilder::new()
+            .insert("rate", rate)
+            .insert("rtpTime", 0u64);
+
+        // Include PTP anchor timestamps so the device knows when to render
+        if rate != 0 {
+            if let Some((secs, frac, timeline_id)) = self.connection.get_ptp_network_time().await {
+                tracing::info!(
+                    "SetRateAnchorTime: anchoring rtpTime=0 to PTP time {}.{:09} \
+                     (timeline=0x{:016X})",
+                    secs,
+                    // Convert frac back to nanos for display: nanos = frac * 10^9 / 2^64
+                    u32::try_from((u128::from(frac) * 1_000_000_000u128) >> 64)
+                        .expect("PTP time fraction conversion should fit in u32"),
+                    timeline_id,
+                );
+                builder = builder
+                    .insert("networkTimeSecs", secs)
+                    .insert("networkTimeFrac", frac)
+                    .insert("networkTimeTimelineID", timeline_id);
+            } else {
+                tracing::warn!(
+                    "SetRateAnchorTime: PTP clock not available or not synchronized — sending \
+                     without networkTime fields (device may not render audio)"
+                );
+            }
+        }
+
+        let body = builder.build();
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
+
+        self.connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
+            )
+            .await?;
+
+        Ok(())
+    }
+
     /// Internal: send rate command
     async fn send_rate(&self, rate: f64) -> Result<(), AirPlayError> {
         let mut builder = DictBuilder::new()
@@ -317,13 +365,12 @@ impl PlaybackController {
             if let Some((secs, frac, timeline_id)) = self.connection.get_ptp_network_time().await {
                 tracing::info!(
                     "SetRateAnchorTime: anchoring rtpTime=0 to PTP time {}.{:09} \
-                     (timeline=0x{:016X}) with rate {}",
+                     (timeline=0x{:016X}) with rate {rate}",
                     secs,
                     // Convert frac back to nanos for display: nanos = frac * 10^9 / 2^64
                     u32::try_from((u128::from(frac) * 1_000_000_000u128) >> 64)
                         .expect("PTP time fraction conversion should fit in u32"),
                     timeline_id,
-                    rate
                 );
                 builder = builder
                     .insert("networkTimeSecs", secs)

--- a/src/control/tests/playback.rs
+++ b/src/control/tests/playback.rs
@@ -131,3 +131,64 @@ async fn test_playback_controller_set_shuffle_and_repeat() {
     // it returns an error, state might remain unchanged.
     assert!(res.is_err());
 }
+
+#[tokio::test]
+async fn test_playback_controller_fast_forward_rewind() {
+    use std::sync::Arc;
+
+    use crate::connection::ConnectionManager;
+    use crate::testing::mock_server::MockServer;
+    use crate::types::{AirPlayConfig, AirPlayDevice};
+
+    let mut server = MockServer::default_server();
+    let addr = server.start().await.expect("Failed to start mock server");
+
+    let config = AirPlayConfig::default();
+
+    let manager = Arc::new(ConnectionManager::new(config));
+    let controller = crate::control::playback::PlaybackController::new(manager.clone());
+
+    let device = AirPlayDevice {
+        id: "mock_device_playback".to_string(),
+        name: "Mock Device".to_string(),
+        model: Some("MockModel".to_string()),
+        addresses: vec![addr.ip()],
+        port: addr.port(),
+        capabilities: crate::types::DeviceCapabilities::default(),
+        raop_port: None,
+        raop_capabilities: None,
+        txt_records: std::collections::HashMap::new(),
+        last_seen: None,
+    };
+
+    manager.connect(&device).await.expect("Failed to connect");
+
+    // Give it a moment to connect
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // Test fast_forward
+    controller
+        .fast_forward()
+        .await
+        .expect("Failed to fast forward");
+    // Wait for the server to process the request
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let rate = server.rate().await.expect("Server did not receive rate");
+    assert!(
+        (rate - 2.0).abs() < f64::EPSILON,
+        "Expected rate 2.0, got {rate}"
+    );
+
+    // Test rewind
+    controller.rewind().await.expect("Failed to rewind");
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let rate = server.rate().await.expect("Server did not receive rate");
+    assert!(
+        (rate - (-2.0)).abs() < f64::EPSILON,
+        "Expected rate -2.0, got {rate}"
+    );
+
+    // Clean up
+    manager.disconnect().await.unwrap_or(());
+    server.stop().await;
+}

--- a/src/testing/mock_server.rs
+++ b/src/testing/mock_server.rs
@@ -69,6 +69,8 @@ struct ServerState {
     paired: bool,
     /// Pairing server instance
     pairing_server: PairingServer,
+    /// The last received rate value
+    rate: Option<f64>,
 }
 
 /// A Mock `AirPlay` server.
@@ -103,6 +105,7 @@ impl MockServer {
                 volume: 0.0,
                 paired: false,
                 pairing_server,
+                rate: None,
             })),
             shutdown: None,
             address: None,
@@ -190,6 +193,11 @@ impl MockServer {
     /// Checks if the server is currently streaming.
     pub async fn is_streaming(&self) -> bool {
         self.state.read().await.streaming
+    }
+
+    /// Get the last received rate value.
+    pub async fn rate(&self) -> Option<f64> {
+        self.state.read().await.rate
     }
 
     /// Handles a single client connection.
@@ -422,12 +430,14 @@ impl MockServer {
             }
             Method::SetRateAnchorTime => {
                 // Parse body to check rate
+                let mut parsed_rate = None;
                 let streaming = if let Ok(plist) = crate::protocol::plist::decode(&request.body) {
                     if let Some(dict) = plist.as_dict() {
                         if let Some(rate) = dict
                             .get("rate")
                             .and_then(crate::protocol::plist::PlistValue::as_f64)
                         {
+                            parsed_rate = Some(rate);
                             rate.abs() > f64::EPSILON
                         } else {
                             true
@@ -439,7 +449,12 @@ impl MockServer {
                     true
                 };
 
-                state.write().await.streaming = streaming;
+                let mut state_guard = state.write().await;
+                state_guard.streaming = streaming;
+                if let Some(r) = parsed_rate {
+                    state_guard.rate = Some(r);
+                }
+
                 Self::response(StatusCode::OK, cseq, None, None)
             }
             Method::Pause => {


### PR DESCRIPTION
Implemented actual rate control for the `fast_forward` and `rewind` methods in `PlaybackController` using the `SetRateAnchorTime` command, replacing the previous temporary seek logic. Added an internal helper function to reduce code duplication and verified the functionality with a new unit test against a local `MockServer`.

---
*PR created automatically by Jules for task [17399940117905104055](https://jules.google.com/task/17399940117905104055) started by @jburnhams*