### PR TITLE
Fix swallowed errors

### DIFF
--- a/src/protocol/rtp/ntp_client.rs
+++ b/src/protocol/rtp/ntp_client.rs
@@ -97,7 +97,9 @@ impl NtpClient {
                     valid_response = true;
                     break;
                 }
-                Ok(Err(_)) => {}                             // Ignore socket errors
+                Ok(Err(e)) => {
+                    tracing::debug!("NTP socket error: {:?}", e);
+                }
                 Err(_) => return Err(AirPlayError::Timeout), // Timeout
             }
         }

--- a/src/protocol/rtsp/tests/server_codec.rs
+++ b/src/protocol/rtsp/tests/server_codec.rs
@@ -175,7 +175,10 @@ fn test_invalid_content_length() {
     let result = codec.decode();
     assert!(result.is_err());
     match result {
-        Err(ParseError::InvalidContentLength(_)) => {}
+        Err(ParseError::InvalidContentLength(e)) => {
+            // The error from ParseIntError is mapped differently or is custom
+            assert_eq!(e.as_str(), "Not a number");
+        }
         _ => panic!("Expected InvalidContentLength error"),
     }
 }

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -182,7 +182,10 @@ impl EventFilter {
         loop {
             match self.rx.recv().await {
                 Ok(event) if (self.filter)(&event) => return Some(event),
-                Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {}
+                Ok(_) => {} // Filter didn't match
+                Err(broadcast::error::RecvError::Lagged(count)) => {
+                    tracing::warn!("Event filter lagged and missed {} events", count);
+                }
                 Err(broadcast::error::RecvError::Closed) => return None,
             }
         }


### PR DESCRIPTION
Fixes #1 by properly handling swallowed errors in `NtpClient` and `EventFilter` using tracing, and fixes a test (`test_invalid_content_length`) in `RtspServerCodec` that was wrongly passing by verifying the `ParseIntError` string correctly.

---
*PR created automatically by Jules for task [7820381235249017758](https://jules.google.com/task/7820381235249017758) started by @jburnhams*