### PR TITLE
Implement proper rate control for fast forward and rewind

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -344,6 +344,26 @@ impl AirPlayClient {
         Ok(())
     }
 
+    /// Fast forward
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
+        self.ensure_connected().await?;
+        self.playback.fast_forward().await
+    }
+
+    /// Rewind
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn rewind(&self) -> Result<(), AirPlayError> {
+        self.ensure_connected().await?;
+        self.playback.rewind().await
+    }
+
     /// Toggle play/pause
     ///
     /// # Errors

--- a/src/control/playback.rs
+++ b/src/control/playback.rs
@@ -397,10 +397,11 @@ impl PlaybackController {
         }
 
         let body = builder.build();
-        let encoded = crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
-            message: format!("Failed to encode plist: {e}"),
-            status_code: None,
-        })?;
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
 
         self.connection
             .send_command(

--- a/src/control/playback.rs
+++ b/src/control/playback.rs
@@ -246,9 +246,7 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip forward 10s
-        self.seek_relative(Duration::from_secs(10), true).await
+        self.send_rate(2.0).await
     }
 
     /// Rewind
@@ -257,9 +255,7 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn rewind(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip backward 10s
-        self.seek_relative(Duration::from_secs(10), false).await
+        self.send_rate(-2.0).await
     }
 
     /// Set repeat mode
@@ -385,6 +381,36 @@ impl PlaybackController {
         );
 
         self.set_progress(progress).await
+    }
+
+    /// Internal: send rate command
+    async fn send_rate(&self, rate: f64) -> Result<(), AirPlayError> {
+        let mut builder = DictBuilder::new()
+            .insert("rate", rate)
+            .insert("rtpTime", 0u64);
+
+        if let Some((secs, frac, timeline_id)) = self.connection.get_ptp_network_time().await {
+            builder = builder
+                .insert("networkTimeSecs", secs)
+                .insert("networkTimeFrac", frac)
+                .insert("networkTimeTimelineID", timeline_id);
+        }
+
+        let body = builder.build();
+        let encoded = crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+            message: format!("Failed to encode plist: {e}"),
+            status_code: None,
+        })?;
+
+        self.connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
+            )
+            .await?;
+
+        Ok(())
     }
 
     /// Internal: send metadata command

--- a/src/control/tests/playback.rs
+++ b/src/control/tests/playback.rs
@@ -131,3 +131,18 @@ async fn test_playback_controller_set_shuffle_and_repeat() {
     // it returns an error, state might remain unchanged.
     assert!(res.is_err());
 }
+
+#[tokio::test]
+async fn test_playback_controller_fast_forward_rewind_not_connected() {
+    use std::sync::Arc;
+
+    use crate::connection::ConnectionManager;
+    use crate::types::AirPlayConfig;
+
+    let config = AirPlayConfig::default();
+    let manager = Arc::new(ConnectionManager::new(config));
+    let controller = crate::control::playback::PlaybackController::new(manager);
+
+    assert!(controller.fast_forward().await.is_err());
+    assert!(controller.rewind().await.is_err());
+}

--- a/src/testing/mock_server.rs
+++ b/src/testing/mock_server.rs
@@ -69,6 +69,8 @@ struct ServerState {
     paired: bool,
     /// Pairing server instance
     pairing_server: PairingServer,
+    /// The current rate.
+    rate: f64,
 }
 
 /// A Mock `AirPlay` server.
@@ -103,6 +105,7 @@ impl MockServer {
                 volume: 0.0,
                 paired: false,
                 pairing_server,
+                rate: 1.0,
             })),
             shutdown: None,
             address: None,
@@ -185,6 +188,11 @@ impl MockServer {
     /// Returns the current volume level.
     pub async fn volume(&self) -> f32 {
         self.state.read().await.volume
+    }
+
+    /// Returns the current rate.
+    pub async fn rate(&self) -> f64 {
+        self.state.read().await.rate
     }
 
     /// Checks if the server is currently streaming.
@@ -422,24 +430,24 @@ impl MockServer {
             }
             Method::SetRateAnchorTime => {
                 // Parse body to check rate
-                let streaming = if let Ok(plist) = crate::protocol::plist::decode(&request.body) {
+                let mut is_streaming = true;
+                let mut rate_val = 1.0;
+                if let Ok(plist) = crate::protocol::plist::decode(&request.body) {
                     if let Some(dict) = plist.as_dict() {
                         if let Some(rate) = dict
                             .get("rate")
                             .and_then(crate::protocol::plist::PlistValue::as_f64)
                         {
-                            rate.abs() > f64::EPSILON
-                        } else {
-                            true
+                            is_streaming = rate.abs() > f64::EPSILON;
+                            rate_val = rate;
                         }
-                    } else {
-                        true
                     }
-                } else {
-                    true
-                };
+                }
 
-                state.write().await.streaming = streaming;
+                let mut state_write = state.write().await;
+                state_write.streaming = is_streaming;
+                state_write.rate = rate_val;
+
                 Self::response(StatusCode::OK, cseq, None, None)
             }
             Method::Pause => {

--- a/tests/client_integration.rs
+++ b/tests/client_integration.rs
@@ -118,13 +118,21 @@ async fn test_client_integration_flow() {
     client.fast_forward().await.expect("Fast forward failed");
     tokio::time::sleep(Duration::from_millis(50)).await;
     let rate = server.rate().await;
-    assert!((rate - 2.0).abs() < f64::EPSILON, "Server received rate {}, expected 2.0", rate);
+    assert!(
+        (rate - 2.0).abs() < f64::EPSILON,
+        "Server received rate {}, expected 2.0",
+        rate
+    );
 
     // Rewind
     client.rewind().await.expect("Rewind failed");
     tokio::time::sleep(Duration::from_millis(50)).await;
     let rate = server.rate().await;
-    assert!((rate - (-2.0)).abs() < f64::EPSILON, "Server received rate {}, expected -2.0", rate);
+    assert!(
+        (rate - (-2.0)).abs() < f64::EPSILON,
+        "Server received rate {}, expected -2.0",
+        rate
+    );
 
     // 6. Disconnect
     println!("Disconnecting...");

--- a/tests/client_integration.rs
+++ b/tests/client_integration.rs
@@ -114,6 +114,18 @@ async fn test_client_integration_flow() {
     assert!(!server.is_streaming().await);
     assert!(!client.playback_state().await.is_playing);
 
+    // Fast Forward
+    client.fast_forward().await.expect("Fast forward failed");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let rate = server.rate().await;
+    assert!((rate - 2.0).abs() < f64::EPSILON, "Server received rate {}, expected 2.0", rate);
+
+    // Rewind
+    client.rewind().await.expect("Rewind failed");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let rate = server.rate().await;
+    assert!((rate - (-2.0)).abs() < f64::EPSILON, "Server received rate {}, expected -2.0", rate);
+
     // 6. Disconnect
     println!("Disconnecting...");
     client.disconnect().await.expect("Disconnect failed");


### PR DESCRIPTION
Implement playback rate control (fast forward and rewind).
The `TODO` marks in `PlaybackController` indicated that skipping forward or backward 10 seconds was a placeholder for proper rate adjustment. Added `send_rate` using `SetRateAnchorTime` to send rates `2.0` and `-2.0`, added `fast_forward` and `rewind` methods in `UnifiedAirPlayClient`, and added unit / integration tests to confirm the mock server appropriately captures the correct rate values.

---
*PR created automatically by Jules for task [17140786942676239197](https://jules.google.com/task/17140786942676239197) started by @jburnhams*