### PR TITLE
Refactor and combine multiple #[allow(clippy::...)] attributes

### DIFF
--- a/src/connection/manager.rs
+++ b/src/connection/manager.rs
@@ -2340,15 +2340,16 @@ impl ConnectionManager {
                         } else {
                             micros = micros.saturating_sub(offset_micros.unsigned_abs());
                         }
-                        ntp_time = crate::protocol::rtp::NtpTimestamp {
-                            #[allow(clippy::cast_possible_truncation, reason = "NTP seconds")]
-                            seconds: (micros / 1_000_000) as u32,
-                            #[allow(
-                                clippy::cast_possible_truncation,
-                                reason = "Fraction fits in 32 bits"
-                            )]
-                            fraction: (((micros % 1_000_000) << 32) / 1_000_000) as u32,
-                        };
+                        #[allow(
+                            clippy::cast_possible_truncation,
+                            reason = "NTP seconds and fraction fit in 32 bits"
+                        )]
+                        {
+                            ntp_time = crate::protocol::rtp::NtpTimestamp {
+                                seconds: (micros / 1_000_000) as u32,
+                                fraction: (((micros % 1_000_000) << 32) / 1_000_000) as u32,
+                            };
+                        }
                     }
                     let ntp_timestamp_64 =
                         (u64::from(ntp_time.seconds) << 32) | u64::from(ntp_time.fraction);

--- a/src/protocol/ptp/tests/node.rs
+++ b/src/protocol/ptp/tests/node.rs
@@ -1590,7 +1590,10 @@ async fn test_delay_resp_correction_field_t4_extraction() {
     // ── Simulate HomePod sending Sync + Follow_Up ────────────────────────────
     // We use a HomePod-style epoch: T1 = 1000 s from HomePod reference.
     // Unix epoch offset would be ~56 years; we pick something computable.
-    #[allow(clippy::no_effect_underscore_binding)]
+    #[allow(
+        clippy::no_effect_underscore_binding,
+        reason = "Variables are named for clarity in test documentation even if unused"
+    )]
     let _t1_homepod_ns: i128 = 1_000_000_000_000; // 1000 s in HomePod ns (kept for documentation)
 
     // Build a Sync message (transport_specific=1, messageType=0x00).

--- a/src/protocol/rtp/ntp_client.rs
+++ b/src/protocol/rtp/ntp_client.rs
@@ -111,13 +111,12 @@ impl NtpClient {
         let t3 = NtpTimestamp::decode(&buf[40..48]);
 
         #[allow(clippy::cast_possible_wrap, reason = "NTP micros fit in i64")]
-        let t1_micros = t1.to_micros() as i64;
-        #[allow(clippy::cast_possible_wrap, reason = "NTP micros fit in i64")]
-        let t2_micros = t2.to_micros() as i64;
-        #[allow(clippy::cast_possible_wrap, reason = "NTP micros fit in i64")]
-        let t3_micros = t3.to_micros() as i64;
-        #[allow(clippy::cast_possible_wrap, reason = "NTP micros fit in i64")]
-        let t4_micros = t4.to_micros() as i64;
+        let (t1_micros, t2_micros, t3_micros, t4_micros) = (
+            t1.to_micros() as i64,
+            t2.to_micros() as i64,
+            t3.to_micros() as i64,
+            t4.to_micros() as i64,
+        );
 
         let offset = ((t2_micros - t1_micros) + (t3_micros - t4_micros)) / 2;
         Ok(offset)

--- a/src/protocol/rtp/raop_timing.rs
+++ b/src/protocol/rtp/raop_timing.rs
@@ -100,25 +100,12 @@ impl RaopTimingResponse {
             reason = "Timestamp values converted to microseconds fit within i64 for typical \
                       operation"
         )]
-        let t1 = self.reference_time.to_micros() as i64;
-        #[allow(
-            clippy::cast_possible_wrap,
-            reason = "Timestamp values converted to microseconds fit within i64 for typical \
-                      operation"
-        )]
-        let t2 = self.receive_time.to_micros() as i64;
-        #[allow(
-            clippy::cast_possible_wrap,
-            reason = "Timestamp values converted to microseconds fit within i64 for typical \
-                      operation"
-        )]
-        let t3 = self.send_time.to_micros() as i64;
-        #[allow(
-            clippy::cast_possible_wrap,
-            reason = "Timestamp values converted to microseconds fit within i64 for typical \
-                      operation"
-        )]
-        let t4 = client_receive.to_micros() as i64;
+        let (t1, t2, t3, t4) = (
+            self.reference_time.to_micros() as i64,
+            self.receive_time.to_micros() as i64,
+            self.send_time.to_micros() as i64,
+            client_receive.to_micros() as i64,
+        );
 
         ((t2 - t1) + (t3 - t4)) / 2
     }

--- a/src/protocol/rtp/timing.rs
+++ b/src/protocol/rtp/timing.rs
@@ -23,16 +23,13 @@ impl NtpTimestamp {
         let ntp_secs = duration.as_secs() + Self::NTP_UNIX_OFFSET;
         let fraction = (u64::from(duration.subsec_nanos()) << 32) / 1_000_000_000;
 
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "NTP timestamp seconds wrap around in 2036 (Year 2038 problem), and \
+                      fractional part fits within u32"
+        )]
         Self {
-            #[allow(
-                clippy::cast_possible_truncation,
-                reason = "NTP timestamp seconds wrap around in 2036 (Year 2038 problem)"
-            )]
             seconds: ntp_secs as u32,
-            #[allow(
-                clippy::cast_possible_truncation,
-                reason = "Fractional part calculation fits within u32"
-            )]
             fraction: fraction as u32,
         }
     }

--- a/src/receiver/ap2/jitter_buffer.rs
+++ b/src/receiver/ap2/jitter_buffer.rs
@@ -293,18 +293,14 @@ impl JitterBuffer {
         let channels = self.config.channels as usize;
 
         // Determine the "end" timestamp (timestamp of the last sample + 1)
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "Frame duration fits in u32"
+        )]
         let end_ts = if let Some((_, last_frame)) = self.frames.iter().next_back() {
-            #[allow(
-                clippy::cast_possible_truncation,
-                reason = "Frame duration fits in u32"
-            )]
             let duration = (last_frame.samples.len() / channels) as u32;
             last_frame.timestamp.wrapping_add(duration)
         } else if let Some(ref frame) = self.current_frame {
-            #[allow(
-                clippy::cast_possible_truncation,
-                reason = "Frame duration fits in u32"
-            )]
             let duration = (frame.samples.len() / channels) as u32;
             frame.timestamp.wrapping_add(duration)
         } else {

--- a/src/receiver/ap2/metadata_handler.rs
+++ b/src/receiver/ap2/metadata_handler.rs
@@ -66,6 +66,11 @@ impl MetadataController {
     }
 
     /// Recursively extract metadata fields from DMAP value
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "DMAP numeric values (time, track, disc) are non-negative and fit in u32"
+    )]
     fn extract_metadata(value: &DmapValue, metadata: &mut TrackMetadata) {
         if let DmapValue::Container(items) = value {
             for (tag, val) in items {
@@ -92,38 +97,17 @@ impl MetadataController {
                     }
                     DmapTag::SongTime => {
                         if let DmapValue::Int(i) = val {
-                            #[allow(
-                                clippy::cast_possible_truncation,
-                                clippy::cast_sign_loss,
-                                reason = "DMAP song time values are non-negative and fit in u32"
-                            )]
-                            {
-                                metadata.duration_ms = Some(*i as u32);
-                            }
+                            metadata.duration_ms = Some(*i as u32);
                         }
                     }
                     DmapTag::SongTrackNumber => {
                         if let DmapValue::Int(i) = val {
-                            #[allow(
-                                clippy::cast_possible_truncation,
-                                clippy::cast_sign_loss,
-                                reason = "DMAP track numbers are non-negative and fit in u32"
-                            )]
-                            {
-                                metadata.track_number = Some(*i as u32);
-                            }
+                            metadata.track_number = Some(*i as u32);
                         }
                     }
                     DmapTag::SongDiscNumber => {
                         if let DmapValue::Int(i) = val {
-                            #[allow(
-                                clippy::cast_possible_truncation,
-                                clippy::cast_sign_loss,
-                                reason = "DMAP disc numbers are non-negative and fit in u32"
-                            )]
-                            {
-                                metadata.disc_number = Some(*i as u32);
-                            }
+                            metadata.disc_number = Some(*i as u32);
                         }
                     }
                     _ => {

--- a/src/streaming/tests/resampler.rs
+++ b/src/streaming/tests/resampler.rs
@@ -143,12 +143,10 @@ fn test_resampling_48k_to_44k_sine() {
         clippy::cast_precision_loss,
         reason = "Precision loss in frequency estimation is acceptable for test verification"
     )]
-    let duration = samples.len() as f32 / 44100.0;
-    #[allow(
-        clippy::cast_precision_loss,
-        reason = "Precision loss in frequency estimation is acceptable for test verification"
-    )]
-    let frequency = (zero_crossings as f32 / duration) / 2.0;
+    let frequency = {
+        let d = samples.len() as f32 / 44100.0;
+        (zero_crossings as f32 / d) / 2.0
+    };
 
     println!("Estimated frequency: {frequency:.1} Hz");
     // Tolerance increased to 30Hz due to FFT resampling artifacts/phase shifts in block processing


### PR DESCRIPTION
Addresses an issue where the codebase had multiple bare `#[allow(clippy::...)]` exclusions without the required `reason` fields. Adds professional reasoning. Also, combines several consecutive `#[allow(...)]` attributes placed right next to each other on the same code paths into single blocks or function declarations to remove boilerplate.

---
*PR created automatically by Jules for task [15220146721966884758](https://jules.google.com/task/15220146721966884758) started by @jburnhams*