### PR TITLE
Fix silently skipped tests

### DIFF
--- a/src/protocol/ptp/tests/handler.rs
+++ b/src/protocol/ptp/tests/handler.rs
@@ -215,11 +215,7 @@ async fn test_airplay_format_exchange() {
 
 #[tokio::test]
 async fn test_master_handler_responds_to_delay_req() {
-    let Ok(sock) = UdpSocket::bind("127.0.0.1:0").await else {
-        // Can't bind privileged port in this environment — skip test.
-        return;
-    };
-    let master_sock = Arc::new(sock);
+    let master_sock = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
 
     let client_sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
 

--- a/tests/receiver/capture_replay_tests.rs
+++ b/tests/receiver/capture_replay_tests.rs
@@ -9,14 +9,9 @@ use airplay2::testing::packet_capture::{CaptureLoader, CaptureProtocol, CaptureR
 /// Test parsing real /info response capture
 #[test]
 fn test_captured_info_request() {
-    let capture_path = Path::new("tests/captures/info_request.hex");
+    let capture_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/captures/info_request.hex");
 
-    if !capture_path.exists() {
-        eprintln!("Skipping: capture file not found");
-        return;
-    }
-
-    let packets = CaptureLoader::load_hex_dump(capture_path).unwrap();
+    let packets = CaptureLoader::load_hex_dump(&capture_path).unwrap();
     let mut replay = CaptureReplay::new(packets);
 
     // Get first inbound packet (should be GET /info)
@@ -40,14 +35,9 @@ fn test_captured_info_request() {
 /// Test parsing real pairing exchange capture
 #[test]
 fn test_captured_pairing() {
-    let capture_path = Path::new("tests/captures/pairing_exchange.hex");
+    let capture_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/captures/pairing_exchange.hex");
 
-    if !capture_path.exists() {
-        eprintln!("Skipping: capture file not found");
-        return;
-    }
-
-    let packets = CaptureLoader::load_hex_dump(capture_path).unwrap();
+    let packets = CaptureLoader::load_hex_dump(&capture_path).unwrap();
 
     // Process entire exchange
     for packet in &packets {

--- a/tests/receiver/capture_replay_tests.rs
+++ b/tests/receiver/capture_replay_tests.rs
@@ -9,7 +9,8 @@ use airplay2::testing::packet_capture::{CaptureLoader, CaptureProtocol, CaptureR
 /// Test parsing real /info response capture
 #[test]
 fn test_captured_info_request() {
-    let capture_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/captures/info_request.hex");
+    let capture_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/captures/info_request.hex");
 
     let packets = CaptureLoader::load_hex_dump(&capture_path).unwrap();
     let mut replay = CaptureReplay::new(packets);
@@ -35,7 +36,8 @@ fn test_captured_info_request() {
 /// Test parsing real pairing exchange capture
 #[test]
 fn test_captured_pairing() {
-    let capture_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/captures/pairing_exchange.hex");
+    let capture_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/captures/pairing_exchange.hex");
 
     let packets = CaptureLoader::load_hex_dump(&capture_path).unwrap();
 


### PR DESCRIPTION
This commit addresses an issue where some tests were silently skipping by returning early instead of failing or using explicit `#[ignore]` attributes. In capture replay tests, the path resolution was corrected to ensure test execution in any directory, and in the PTP handler test, a false-positive privileged port skip check on port 0 was removed to allow the test to run and assert properly.

---
*PR created automatically by Jules for task [16902089849266691137](https://jules.google.com/task/16902089849266691137) started by @jburnhams*