### PR TITLE
feat: implement fast-forward and rewind rate controls

### DIFF
--- a/src/control/playback.rs
+++ b/src/control/playback.rs
@@ -246,9 +246,24 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip forward 10s
-        self.seek_relative(Duration::from_secs(10), true).await
+        let body = DictBuilder::new()
+            .insert("rate", 2.0f64)
+            .insert("rtpTime", 0u64)
+            .build();
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
+
+        self.connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
+            )
+            .await?;
+        Ok(())
     }
 
     /// Rewind
@@ -257,9 +272,24 @@ impl PlaybackController {
     ///
     /// Returns error if network fails
     pub async fn rewind(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip backward 10s
-        self.seek_relative(Duration::from_secs(10), false).await
+        let body = DictBuilder::new()
+            .insert("rate", -2.0f64)
+            .insert("rtpTime", 0u64)
+            .build();
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
+
+        self.connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
+            )
+            .await?;
+        Ok(())
     }
 
     /// Set repeat mode

--- a/src/control/tests/playback.rs
+++ b/src/control/tests/playback.rs
@@ -96,6 +96,24 @@ async fn test_playback_controller_next_prev_not_connected() {
 }
 
 #[tokio::test]
+async fn test_playback_controller_fast_forward_rewind_not_connected() {
+    use std::sync::Arc;
+
+    use crate::connection::ConnectionManager;
+    use crate::types::AirPlayConfig;
+
+    let config = AirPlayConfig::default();
+    let manager = Arc::new(ConnectionManager::new(config));
+    let controller = crate::control::playback::PlaybackController::new(manager);
+
+    let res = controller.fast_forward().await;
+    assert!(res.is_err(), "fast_forward() should fail when disconnected");
+
+    let res = controller.rewind().await;
+    assert!(res.is_err(), "rewind() should fail when disconnected");
+}
+
+#[tokio::test]
 async fn test_playback_controller_play_pause_stop_not_connected() {
     use std::sync::Arc;
 


### PR DESCRIPTION
Implement rate controls for Airplay 2 fast forward and rewind. Added tests for disconnected states.

---
*PR created automatically by Jules for task [2725715794135689267](https://jules.google.com/task/2725715794135689267) started by @jburnhams*