### PR TITLE
Implement Playback Rate Control for Fast-Forward and Rewind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
  "num-traits",
  "portpicker",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.10.0",
  "rsa",
  "serde",
@@ -1237,7 +1237,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "nix",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1503,7 +1503,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1793,7 +1793,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1875,9 +1875,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -418,6 +418,26 @@ impl AirPlayClient {
         self.playback.seek(position).await
     }
 
+    /// Fast forward
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
+        self.ensure_connected().await?;
+        self.playback.fast_forward().await
+    }
+
+    /// Rewind
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn rewind(&self) -> Result<(), AirPlayError> {
+        self.ensure_connected().await?;
+        self.playback.rewind().await
+    }
+
     /// Get current playback state
     pub async fn playback_state(&self) -> PlaybackState {
         self.state.get().await.playback

--- a/src/control/playback.rs
+++ b/src/control/playback.rs
@@ -242,24 +242,61 @@ impl PlaybackController {
 
     /// Fast forward
     ///
+    /// Sends `SetRateAnchorTime` with `rate=2.0`
+    ///
     /// # Errors
     ///
     /// Returns error if network fails
     pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip forward 10s
-        self.seek_relative(Duration::from_secs(10), true).await
+        self.set_rate(2.0).await
     }
 
     /// Rewind
+    ///
+    /// Sends `SetRateAnchorTime` with `rate=-2.0`
     ///
     /// # Errors
     ///
     /// Returns error if network fails
     pub async fn rewind(&self) -> Result<(), AirPlayError> {
-        // TODO: Implement rate control properly
-        // For now just skip backward 10s
-        self.seek_relative(Duration::from_secs(10), false).await
+        self.set_rate(-2.0).await
+    }
+
+    /// Set playback rate
+    ///
+    /// Sends `SetRateAnchorTime` with the specified rate.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if state is invalid or network fails
+    async fn set_rate(&self, rate: f64) -> Result<(), AirPlayError> {
+        let mut builder = DictBuilder::new()
+            .insert("rate", rate)
+            .insert("rtpTime", 0u64);
+
+        if let Some((secs, frac, timeline_id)) = self.connection.get_ptp_network_time().await {
+            builder = builder
+                .insert("networkTimeSecs", secs)
+                .insert("networkTimeFrac", frac)
+                .insert("networkTimeTimelineID", timeline_id);
+        }
+
+        let body = builder.build();
+        let encoded =
+            crate::protocol::plist::encode(&body).map_err(|e| AirPlayError::RtspError {
+                message: format!("Failed to encode plist: {e}"),
+                status_code: None,
+            })?;
+
+        self.connection
+            .send_command(
+                Method::SetRateAnchorTime,
+                Some(encoded),
+                Some("application/x-apple-binary-plist".to_string()),
+            )
+            .await?;
+
+        Ok(())
     }
 
     /// Set repeat mode

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -369,6 +369,24 @@ impl AirPlayPlayer {
         self.client.seek(Duration::from_secs_f64(seconds)).await
     }
 
+    /// Fast forward
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn fast_forward(&self) -> Result<(), AirPlayError> {
+        self.client.fast_forward().await
+    }
+
+    /// Rewind
+    ///
+    /// # Errors
+    ///
+    /// Returns error if playback command fails.
+    pub async fn rewind(&self) -> Result<(), AirPlayError> {
+        self.client.rewind().await
+    }
+
     // === Volume ===
 
     /// Set volume (0.0 - 1.0)

--- a/src/testing/mock_server.rs
+++ b/src/testing/mock_server.rs
@@ -69,6 +69,8 @@ struct ServerState {
     paired: bool,
     /// Pairing server instance
     pairing_server: PairingServer,
+    /// Playback rate
+    rate: f64,
 }
 
 /// A Mock `AirPlay` server.
@@ -103,6 +105,7 @@ impl MockServer {
                 volume: 0.0,
                 paired: false,
                 pairing_server,
+                rate: 0.0,
             })),
             shutdown: None,
             address: None,
@@ -185,6 +188,11 @@ impl MockServer {
     /// Returns the current volume level.
     pub async fn volume(&self) -> f32 {
         self.state.read().await.volume
+    }
+
+    /// Returns the current playback rate.
+    pub async fn rate(&self) -> f64 {
+        self.state.read().await.rate
     }
 
     /// Checks if the server is currently streaming.
@@ -422,24 +430,25 @@ impl MockServer {
             }
             Method::SetRateAnchorTime => {
                 // Parse body to check rate
-                let streaming = if let Ok(plist) = crate::protocol::plist::decode(&request.body) {
+                let mut streaming = true;
+                let mut parsed_rate = 1.0;
+                if let Ok(plist) = crate::protocol::plist::decode(&request.body) {
                     if let Some(dict) = plist.as_dict() {
                         if let Some(rate) = dict
                             .get("rate")
                             .and_then(crate::protocol::plist::PlistValue::as_f64)
                         {
-                            rate.abs() > f64::EPSILON
-                        } else {
-                            true
+                            parsed_rate = rate;
+                            streaming = rate.abs() > f64::EPSILON;
                         }
-                    } else {
-                        true
                     }
-                } else {
-                    true
-                };
+                }
 
-                state.write().await.streaming = streaming;
+                let mut state_guard = state.write().await;
+                state_guard.streaming = streaming;
+                state_guard.rate = parsed_rate;
+                drop(state_guard);
+
                 Self::response(StatusCode::OK, cseq, None, None)
             }
             Method::Pause => {

--- a/tests/player_integration.rs
+++ b/tests/player_integration.rs
@@ -179,6 +179,30 @@ async fn test_player_advanced_controls() {
 
     player.seek(15.0).await.expect("Seek failed");
 
+    // Fast Forward
+    player.fast_forward().await.expect("Fast forward failed");
+    let rate = server.rate().await;
+    assert!(
+        (rate - 2.0).abs() < f64::EPSILON,
+        "Rate should be 2.0 for fast forward"
+    );
+
+    // Rewind
+    player.rewind().await.expect("Rewind failed");
+    let rate = server.rate().await;
+    assert!(
+        (rate - -2.0).abs() < f64::EPSILON,
+        "Rate should be -2.0 for rewind"
+    );
+
+    // Play again to restore rate to 1.0
+    player.play().await.expect("Play failed");
+    let rate = server.rate().await;
+    assert!(
+        (rate - 1.0).abs() < f64::EPSILON,
+        "Rate should be 1.0 for play"
+    );
+
     player.disconnect().await.expect("Disconnect failed");
     server.stop().await;
 }


### PR DESCRIPTION
Implemented proper fast forward and rewind playback rate control via `SetRateAnchorTime` in the AirPlay player, completing an outstanding TODO in `playback.rs`. Extended test coverage to verify correct rate parameter parsing.

---
*PR created automatically by Jules for task [16523178405004108020](https://jules.google.com/task/16523178405004108020) started by @jburnhams*