### PR TITLE
test: fix silently swallowed test errors and timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.6.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
 dependencies = [
- "crypto-common 0.2.0",
+ "crypto-common 0.2.1",
  "inout 0.2.2",
 ]
 
@@ -29,7 +29,7 @@ version = "0.9.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04097e08a47d9ad181c2e1f4a5fabc9ae06ce8839a333ba9a949bcb0d31fd2a3"
 dependencies = [
- "cipher 0.5.0",
+ "cipher 0.5.1",
  "cpubits",
  "cpufeatures 0.2.17",
 ]
@@ -42,8 +42,8 @@ checksum = "e22c0c90bbe8d4f77c3ca9ddabe41a1f8382d6fc1f7cea89459d0f320371f972"
 dependencies = [
  "aead",
  "aes 0.9.0-rc.4",
- "cipher 0.5.0",
- "ctr 0.10.0-rc.3",
+ "cipher 0.5.1",
+ "ctr 0.10.0",
  "ghash",
  "subtle",
 ]
@@ -89,7 +89,7 @@ dependencies = [
  "num-traits",
  "portpicker",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.10.0",
  "rsa",
  "serde",
@@ -273,6 +273,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,7 +357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cipher 0.5.0",
+ "cipher 0.5.1",
  "cpufeatures 0.3.0",
 ]
 
@@ -360,7 +369,7 @@ checksum = "1c9ed179664f12fd6f155f6dd632edf5f3806d48c228c67ff78366f2a0eb6b5e"
 dependencies = [
  "aead",
  "chacha20",
- "cipher 0.5.0",
+ "cipher 0.5.1",
  "poly1305",
 ]
 
@@ -416,12 +425,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64727038c8c5e2bb503a15b9f5b9df50a1da9a33e83e1f93067d914f2c6604a5"
+checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
 dependencies = [
- "block-buffer 0.11.0",
- "crypto-common 0.2.0",
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
  "inout 0.2.2",
 ]
 
@@ -672,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "211f05e03c7d03754740fd9e585de910a095d6b99f8bcfffdef8319fa02a8331"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "getrandom 0.4.1",
  "hybrid-array",
@@ -703,11 +712,11 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ea71550d18331d179854662ab330bb54306b9b56020d0466aae2a58f4e17c1"
+checksum = "17469f8eb9bdbfad10f71f4cfddfd38b01143520c0e717d8796ccb4d44d44e42"
 dependencies = [
- "cipher 0.5.0",
+ "cipher 0.5.1",
 ]
 
 [[package]]
@@ -791,7 +800,7 @@ checksum = "d4b37eb2004a3548553a44cc1e688aac70f0345b896c9d822b4a0e520bc9183b"
 dependencies = [
  "block-buffer 0.11.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.0",
+ "crypto-common 0.2.1",
  "subtle",
 ]
 
@@ -1237,7 +1246,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "nix",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1503,7 +1512,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1793,7 +1802,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1875,9 +1884,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2299,7 +2308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0b7d0b0d27b2475e779315c09af698ac9f6d40016bc011bf3fa0f0054ce38ed"
 dependencies = [
  "crypto-bigint",
- "crypto-common 0.2.0",
+ "crypto-common 0.2.1",
  "digest 0.11.0-rc.12",
  "subtle",
 ]
@@ -2511,7 +2520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2756,12 +2765,12 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.10"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058482a494bb3c9c39447d8b40a3a0f38ebb3dccaf02c5a2d681e69035f8da11"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.2.0",
- "subtle",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]

--- a/src/protocol/rtp/ntp_client.rs
+++ b/src/protocol/rtp/ntp_client.rs
@@ -97,8 +97,8 @@ impl NtpClient {
                     valid_response = true;
                     break;
                 }
-                Ok(Err(_)) => {}                             // Ignore socket errors
-                Err(_) => return Err(AirPlayError::Timeout), // Timeout
+                Ok(Err(e)) => tracing::debug!("NTP socket error: {}", e), // Log socket errors
+                Err(_) => return Err(AirPlayError::Timeout),              // Timeout
             }
         }
 

--- a/tests/client_integration.rs
+++ b/tests/client_integration.rs
@@ -158,14 +158,16 @@ async fn test_client_connect_failure() {
     // We expect the connection to either timeout (if OS drops) or return an error (Connection
     // refused)
     match result {
-        Ok(Err(_e)) => {
+        Ok(Err(e)) => {
             // Connection failed as expected
+            println!("Connection failed as expected: {}", e);
         }
         Ok(Ok(_)) => {
             panic!("Connection succeeded when it should have failed");
         }
-        Err(_) => {
+        Err(e) => {
             // Timeout is also an acceptable failure mode depending on OS
+            println!("Connection timed out as expected: {}", e);
         }
     }
 

--- a/tests/raop_compliance.rs
+++ b/tests/raop_compliance.rs
@@ -113,12 +113,15 @@ async fn test_raop_handshake_compliance() {
     // The client might fail if we stopped early, but we verified the handshake start.
     // If handshake completed, client.connect() should return Ok.
 
-    let result = tokio::time::timeout(Duration::from_secs(1), connect_handle).await;
+    // Await client result (with timeout)
+    // The client might fail if we stopped early, but we verified the handshake start.
+    // brute_force_pairing can take up to 4 seconds to fail completely. Default connect timeout is 10s.
+    let result = tokio::time::timeout(Duration::from_secs(12), connect_handle).await;
 
     match result {
         Ok(Ok(Ok(_))) => println!("Client connected successfully"),
-        Ok(Ok(Err(e))) => println!("Client failed: {}", e),
-        Ok(Err(_)) => println!("Client panic"),
-        Err(_) => println!("Timeout waiting for client"),
+        Ok(Ok(Err(e))) => println!("Client failed as expected: {}", e),
+        Ok(Err(e)) => std::panic::resume_unwind(e.into_panic()),
+        Err(_) => panic!("Timeout waiting for client"),
     }
 }

--- a/tests/raop_compliance.rs
+++ b/tests/raop_compliance.rs
@@ -115,7 +115,8 @@ async fn test_raop_handshake_compliance() {
 
     // Await client result (with timeout)
     // The client might fail if we stopped early, but we verified the handshake start.
-    // brute_force_pairing can take up to 4 seconds to fail completely. Default connect timeout is 10s.
+    // brute_force_pairing can take up to 4 seconds to fail completely. Default connect timeout is
+    // 10s.
     let result = tokio::time::timeout(Duration::from_secs(12), connect_handle).await;
 
     match result {

--- a/tests/receiver/protocol_tests.rs
+++ b/tests/receiver/protocol_tests.rs
@@ -92,7 +92,7 @@ async fn test_volume_control() {
                     }
                 }
                 Ok(_) => continue,
-                Err(_) => return false,
+                Err(e) => panic!("Timeout/error waiting for VolumeChanged event: {:?}", e),
             }
         }
     })


### PR DESCRIPTION
This PR addresses a testing issue where certain failures and exceptions were being silently swallowed, causing tests to falsely "pass". It removes empty `Err(_)` match arms and silent `return false` branches in test verification blocks, replacing them with explicit `panic!` or panic propagation. It also adds logging to the NTP client instead of swallowing network errors.

---
*PR created automatically by Jules for task [3545998924987351969](https://jules.google.com/task/3545998924987351969) started by @jburnhams*