### PR TITLE
Fix silently swallowed errors in networking and testing components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,7 +2511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/src/protocol/rtp/ntp_client.rs
+++ b/src/protocol/rtp/ntp_client.rs
@@ -97,7 +97,9 @@ impl NtpClient {
                     valid_response = true;
                     break;
                 }
-                Ok(Err(_)) => {}                             // Ignore socket errors
+                Ok(Err(e)) => {
+                    tracing::debug!("NTP client socket error: {}", e);
+                } // Ignore socket errors
                 Err(_) => return Err(AirPlayError::Timeout), // Timeout
             }
         }

--- a/src/testing/mock_raop_server.rs
+++ b/src/testing/mock_raop_server.rs
@@ -327,7 +327,11 @@ impl MockRaopServer {
 
         loop {
             let n = match stream.read(&mut temp_buf).await {
-                Ok(0) | Err(_) => break,
+                Ok(0) => break,
+                Err(e) => {
+                    tracing::debug!("MockRAOPServer stream read error: {}", e);
+                    break;
+                }
                 Ok(n) => n,
             };
             buffer.extend_from_slice(&temp_buf[..n]);

--- a/src/testing/mock_server.rs
+++ b/src/testing/mock_server.rs
@@ -227,7 +227,11 @@ impl MockServer {
 
             // Read data from the stream
             let n = match stream.read(&mut temp_buf).await {
-                Ok(0) | Err(_) => break, // Connection closed or Error
+                Ok(0) => break, // Connection closed
+                Err(e) => {
+                    tracing::debug!("MockServer stream read error: {}", e);
+                    break;
+                }
                 Ok(n) => n,
             };
 

--- a/tests/client_integration.rs
+++ b/tests/client_integration.rs
@@ -158,8 +158,9 @@ async fn test_client_connect_failure() {
     // We expect the connection to either timeout (if OS drops) or return an error (Connection
     // refused)
     match result {
-        Ok(Err(_e)) => {
-            // Connection failed as expected
+        Ok(Err(e)) => {
+            // Log the expected connection failure instead of silently dropping the error.
+            tracing::debug!("Expected connection failure: {:?}", e);
         }
         Ok(Ok(_)) => {
             panic!("Connection succeeded when it should have failed");

--- a/tests/raop_compliance.rs
+++ b/tests/raop_compliance.rs
@@ -118,7 +118,7 @@ async fn test_raop_handshake_compliance() {
     match result {
         Ok(Ok(Ok(_))) => println!("Client connected successfully"),
         Ok(Ok(Err(e))) => println!("Client failed: {}", e),
-        Ok(Err(_)) => println!("Client panic"),
+        Ok(Err(e)) => std::panic::resume_unwind(e.into_panic()),
         Err(_) => println!("Timeout waiting for client"),
     }
 }

--- a/tests/receiver/protocol_tests.rs
+++ b/tests/receiver/protocol_tests.rs
@@ -93,7 +93,9 @@ async fn test_volume_control() {
                 }
                 Ok(_) => continue,
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => panic!("Events channel closed"),
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    panic!("Events channel closed")
+                }
             }
         }
     })

--- a/tests/receiver/protocol_tests.rs
+++ b/tests/receiver/protocol_tests.rs
@@ -92,7 +92,8 @@ async fn test_volume_control() {
                     }
                 }
                 Ok(_) => continue,
-                Err(_) => return false,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => panic!("Events channel closed"),
             }
         }
     })


### PR DESCRIPTION
Fixes an issue where stream read and socket errors, as well as test panics, were being silently ignored with empty `Err(_)` match arms, leading to potential false positives in test runs and silent failures in the mock networking stack. Logs are added in production/mock code, and panic propagation is added to tests.

---
*PR created automatically by Jules for task [6867160015497573274](https://jules.google.com/task/6867160015497573274) started by @jburnhams*